### PR TITLE
make cross-compilation easier

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -9,8 +9,10 @@ schemedemo_SCRIPTS  = fork-test hello secho \
 
 SUFFIXES            = .stk
 
+COMP ?= ../utils/tmpcomp
+
 .stk:
-	../utils/tmpcomp $*.stk $*
+	$(COMP) $*.stk -o $*
 
 clean:
 	   /bin/rm -f $(schemedemo_SCRIPTS) *~

--- a/lib/Lalr.d/Makefile.am
+++ b/lib/Lalr.d/Makefile.am
@@ -7,10 +7,13 @@
 schemedir   = $(prefix)/share/@PACKAGE@/@VERSION@
 scheme_DATA = lalr.stk lalr.ostk
 
+COMP ?= ../utils/tmpcomp
+
 #======================================================================
 SUFFIXES = .stk .ostk .scm
 .stk.ostk:
-	(cd ..; ../utils/tmpcomp Lalr.d/$*.stk Lalr.d/$*.ostk)
+	echo "COMP = $(COMP)"
+	(cd ..; $(COMP) Lalr.d/$*.stk -o Lalr.d/$*.ostk)
 #======================================================================
 all: lalr.ostk calc
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,6 +8,9 @@ SUBDIRS = Match.d SILex.d Lalr.d ScmPkg.d
 
 SFLAGS=
 
+COMP ?= ../utils/tmpcomp
+STKLOS_BINARY ?= ../src/stklos
+
 scheme_BOOT = assembler.stk		\
 	      bb.stk 			\
 	      bonus.stk 		\
@@ -138,10 +141,10 @@ scheme_DATA = $(scheme_SRCS) $(scheme_OBJS) $(scheme_BOOT)
 
 SUFFIXES = .stk .ostk .scm
 .stk.ostk:
-	../utils/tmpcomp $*.stk $*.ostk
+	$(COMP) $*.stk -o $*.ostk
 
 .scm.ostk:
-	../utils/tmpcomp $*.scm $*.ostk
+	$(COMP) $*.scm -o $*.ostk
 
 #======================================================================
 
@@ -152,16 +155,16 @@ boot:	../src/boot.img
 ../src/boot.img: $(scheme_BOOT)
 	@echo "*** Boot 0"; \
 	(export STKLOS_BUILDING=1; \
-	../src/stklos -q -c -b ../src/boot.img -f bb.stk boot.img0 instr0)
+	$(STKLOS_BINARY) -q -c -b ../src/boot.img -f bb.stk boot.img0 instr0)
 	@echo "*** Boot 1"; \
 	(export STKLOS_BUILDING=1; \
-	../src/stklos $(SFLAGS) -q -c -b ./boot.img0     -f bb.stk boot.img1 instr1)
+	$(STKLOS_BINARY) $(SFLAGS) -q -c -b ./boot.img0     -f bb.stk boot.img1 instr1)
 	@echo "*** Boot 2"; \
 	(export STKLOS_BUILDING=1; \
-	 ../src/stklos $(SFLAGS) -q -c -b ./boot.img1    -f bb.stk boot.img2 instr2)
+	 $(STKLOS_BINARY) $(SFLAGS) -q -c -b ./boot.img1    -f bb.stk boot.img2 instr2)
 	@echo "*** Boot 3"; \
 	(export STKLOS_BUILDING=1; \
-	../src/stklos $(SFLAGS) -q -c -b ./boot.img2     -f bb.stk boot.img3 instr3)
+	$(STKLOS_BINARY) $(SFLAGS) -q -c -b ./boot.img2     -f bb.stk boot.img3 instr3)
 	@if cmp ./boot.img2 ./boot.img3 ;then 				\
 	   echo "*** New boot file created";  				\
 	   cp ../src/boot.img ../src/boot.ok; 				\
@@ -169,7 +172,7 @@ boot:	../src/boot.img
 	   cp ./instr3    ../src/vm-instr.h;  				\
 	   echo "*** Create new boot.c";				\
 	   (export STKLOS_BUILDING=1;					\
-	    ../src/stklos $(SFLAGS) -q -c -b ../src/boot.img  		\
+	    $(STKLOS_BINARY) $(SFLAGS) -q -c -b ../src/boot.img  		\
 		-f make-C-boot.stk -- boot.img3 ../src/boot.c);		\
 	   echo "*** Recompile STklos";					\
 	   (cd ../src; $(MAKE) stklos);					\
@@ -195,7 +198,7 @@ slib.ostk: slib.stk STklos.init
 doc: $(DOCDB)
 
 $(DOCDB): $(scheme_SRCS) $(scheme_BOOT)
-	../src/stklos -q -c -b ../src/boot.img -f ../doc/extract-doc \
+	$(STKLOS_BINARY) -q -c -b ../src/boot.img -f ../doc/extract-doc \
 	$(scheme_SRCS) $(scheme_BOOT) > $(DOCDB)
 
 clean:

--- a/lib/ScmPkg.d/Makefile.am
+++ b/lib/ScmPkg.d/Makefile.am
@@ -7,7 +7,7 @@
 SRCS =  scmpkg-interface.stk scmpkg-languages.stk
 OBJ  =  ../scmpkg-support.ostk
 
-
+COMP ?= ../utils/tmpcomp
 
 scheme_libdir      = $(prefix)/share/@PACKAGE@/@VERSION@
 scheme_lib_DATA    = scmpkg-support.stk $(OBJ)
@@ -18,7 +18,7 @@ scheme_scmpkg_DATA = $(SRCS)
 all: $(OBJ)
 
 $(OBJ): scmpkg-support.stk $(SRCS)
-	(cd ..; ../utils/tmpcomp ScmPkg.d/scmpkg-support.stk scmpkg-support.ostk)
+	(cd ..; $(COMP) ScmPkg.d/scmpkg-support.stk -o scmpkg-support.ostk)
 
 clean: 
 	/bin/rm -f $(OBJ) *~

--- a/pkgman/Makefile.am
+++ b/pkgman/Makefile.am
@@ -17,8 +17,8 @@ SRC     = ../lib/http.stk \
 	  repository.stk rewrite.stk misc.stk tune.stk types.stk
 SFLAGS  =
 RM      = /bin/rm
-COMP	= ../utils/tmpcomp
-GENLEX  = ../utils/tmpgenlex
+COMP	?= ../utils/tmpcomp
+GENLEX  ?= ../utils/tmpgenlex
 
 all: $(bin_SCRIPTS)
 
@@ -32,7 +32,7 @@ lang-mzscheme.inc: lang-mzscheme.l
 	$(GENLEX) lang-mzscheme.l lang-mzscheme.inc lang-mzscheme
 
 $(bin_SCRIPTS):  $(LEXOBJS) $(SRC)
-	$(COMP) main.stk $(bin_SCRIPTS)
+	$(COMP) main.stk -o $(bin_SCRIPTS)
 
 clean:
 	$(RM) -f $(bin_SCRIPTS) $(LEXOBJS) *~

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,8 @@
 CC	    = @CC@
 CFLAGS	    = @CFLAGS@ @STKCFLAGS@
 
+STKLOS_BINARY ?= ./stklos
+
 schemedir   = $(prefix)/share/@PACKAGE@/@VERSION@
 extraincdir = $(prefix)/include/@PACKAGE@
 
@@ -83,7 +85,7 @@ chars.c: utf8-tables.in
 doc:  $(DOCDB)
 
 $(DOCDB): $(stklos_SOURCES)
-	./stklos -b boot.img -c -q -f ../doc/extract-doc $(stklos_SOURCES) > $(DOCDB)
+	$(STKLOS_BINARY) -b boot.img -c -q -f ../doc/extract-doc $(stklos_SOURCES) > $(DOCDB)
 
 clean:
 	/bin/rm -f *.o $(DOCDB)

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -7,12 +7,13 @@
 scmbin      = stklos-compile stklos-genlex
 bin_SCRIPTS = stklos-config  stklos-script $(scmbin)
 
+COMP ?= ./tmpcomp
 
 stklos-compile: stklos-compile.stk
-	./tmpcomp stklos-compile.stk stklos-compile
+	$(COMP) stklos-compile.stk -o stklos-compile
 
 stklos-genlex: stklos-genlex.stk
-	./tmpcomp stklos-genlex.stk stklos-genlex
+	$(COMP) stklos-genlex.stk -o stklos-genlex
 
 clean:
 	rm -f $(scmbin)

--- a/utils/tmpcomp
+++ b/utils/tmpcomp
@@ -29,13 +29,19 @@
 # system which need compilation. It will not be installed since the
 # user version is the stklos-compile script.
 
-if [ $# != 2 ] ;then
+if [ $# = 2 ] ;then
+  in=$1
+  out=$2
+elif [ $# = 3 ] ;then
+  in=$1
+  out=$3
+else
   echo "Usage: $0 src bytecode-file "
   exit 1
 fi
 
-in=$1
-out=$2
+#in=$1
+#out=$2
 
 # Sep is now also ":"  on CYGWIN
 sep=":"


### PR DESCRIPTION
Hello!

This is to make it easier to cross-compile. I have used it to compile STklos for OpenWRT and run it on a wireless router (see here: https://gitlab.com/jpellegrini/openwrt-packages).

* Always use `COMP`, `STKLOS_BINARY`, `GENLEX` variables in
  Makefile.am files, and honor their previous values
  if they exist. This makes it easier to cross-compile:
  having STklos locally installed, we may just do

```
  COMP=/usr/local/bin/stklos-compile \
  GENLEX=/usr/local/bin/stklos-gelnex \
  STKLOS_BINARY=/usr/local/bin/stklos \
  ./configure && make
```

  For this to work, the utils/tmpcomp script had to be
  slightly modified, so it will accept the same arguments
  as stklos-compile, with the '-o' switch (but with this
  patch, it also works if called without it).