### PR TITLE
Fix read-bytevector! to return actual read count

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -464,7 +464,7 @@ DEFINE_PRIMITIVE("%read-bytevector!", d_read_bytevector, subr4,
 
   if (n && !count)
     return STk_eof;
-  return MAKE_INT(n);
+  return MAKE_INT(count);
 }
 
 


### PR DESCRIPTION
R7RS states `read-bytevector!` should return actual read count, instead of to-be read count.

https://small.r7rs.org/attachment/r7rs.pdf

> Returns the number of bytes read.

