### PR TITLE
Adds SRFI-173

### DIFF
--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -444,6 +444,7 @@ figure ,(ref :figure "Feature identifiers") in a
          (tr (tdl "random")      (tdl "srfi-27"))
          (tr (tdl "conditions")  (tdl "srfi-34, srfi-35, srfi-36"))
          (tr (tdl "hash-tables") (tdl "srfi-69"))
+         (tr (tdl "hooks")       (tdl "srfi-173"))
          (tr (tdl "generators")  (tdl "srfi-158, srfi-190"))
          ))))
 
@@ -609,6 +610,16 @@ you need to insert the following expression])
 (p [,(quick-link-srfi 190) is fully supported.  To use SRFI-190,
 you need to insert the following expression])
 (fontified-code [(require "srfi-190")])
+(p [in your code or uses the ,(code "cond-expand") special form.]))
+
+;; ----------------------------------------------------------------------
+;; SRFI 173 -- Hooks
+;; ----------------------------------------------------------------------
+(srfi-section 173
+
+(p [,(quick-link-srfi 173) is fully supported.  To use SRFI-173,
+you need to insert the following expression])
+(fontified-code [(require "srfi-173")])
 (p [in your code or uses the ,(code "cond-expand") special form.]))
 
 ;; End of chapter

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -87,6 +87,7 @@ scheme_SRCS = STklos.init		\
 	      srfi-96.stk		\
 	      srfi-100.stk		\
 		  srfi-158.stk      \
+	      srfi-173.stk		\
 		  srfi-190.stk      \
 	      tar.stk			\
 	      trace.stk

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -227,7 +227,7 @@
     ;; srfi-170                         ; POSIX API (draft)
     ;; srfi-171                         ; Transducers
     ;; srfi-172                         ; Two Safer Subsets of R7RS
-    ;; srfi-173                         ; Hooks
+    (srfi-173 "srfi-173")               ; Hooks
     ;; srfi-174                         ; POSIX Timespecs
     ;; srfi-175                         ; ASCII character library
     ;; srfi-176                         ; Version flag

--- a/lib/srfi-1.stk
+++ b/lib/srfi-1.stk
@@ -312,7 +312,7 @@
 
 (define (make-list len . maybe-elt)
   (check-arg (lambda (n) (and (integer? n) (>= n 0))) len make-list)
-  (let ((elt (cond ((null? maybe-elt) #f) ; Default value
+  (let ((elt (cond ((null? maybe-elt) #void) ; Default value
 		   ((null? (cdr maybe-elt)) (car maybe-elt))
 		   (else (error 'make-list "too many arguments to make-list ~S"
 				(cons len maybe-elt))))))

--- a/lib/srfi-173.stk
+++ b/lib/srfi-173.stk
@@ -1,0 +1,110 @@
+;;;;
+;;;; srfi-173.stk		-- Implementation of SRFI-173
+;;;;
+;;;; Copyright © 2002-2007 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Amirouche Boubekki, it is copyrighted
+;;;; as:
+;;;;
+;;;;;; Copyright © Amirouche Boubekki (2019).
+;;;;;;
+;;;;;; Permission is hereby granted, free of charge, to any person obtaining
+;;;;;; a copy of this software and associated documentation files (the
+;;;;;; “Software”), to deal in the Software without restriction, including
+;;;;;; without limitation the rights to use, copy, modify, merge, publish,
+;;;;;; distribute, sublicense, and/or sell copies of the Software, and to
+;;;;;; permit persons to whom the Software is furnished to do so, subject to
+;;;;;; the following conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice (including the
+;;;;;; next paragraph) shall be included in all copies or substantial
+;;;;;; portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;;;;;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;;;;;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;;;;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 18-Jun-2020 15:21 (jpellegrini)
+;;;; Last file update: 18-May-2020 16:22 (jpellegrini)
+;;;;
+
+(require "srfi-9")
+
+(define-module SRFI-173
+  (export make-hook
+          hook?
+          list->hook
+          list->hook!
+          hook-add!
+          hook-delete!
+          hook-reset!
+          hook->list
+          hook-run)
+
+(define-record-type <hook>
+  (%make-hook procs arity)
+  hook?
+  (procs hook-procs hook-procs!)
+  (arity hook-arity hook-arity!))
+
+(define (make-hook arity)
+  (%make-hook '() arity))
+
+(define (list->hook arity lst)
+  (%make-hook lst arity))
+
+(define (list->hook! hook lst)
+  (hook-procs! hook lst))
+
+(define (hook-add! hook proc)
+  (let ((procs (hook-procs hook)))
+    (hook-procs! hook (cons proc procs))))
+
+(define (hook-delete! hook proc)
+  (let loop ((procs (hook-procs hook))
+             (out '()))
+    (unless (null? procs)
+      (if (eq? proc (car procs))
+          (hook-procs! hook (append (cdr procs) out))
+          (loop (cdr procs) (cons (car procs) out))))))
+
+(define (hook-reset! hook)
+  (hook-procs! hook '()))
+
+(define (hook->list hook)
+  (hook-procs hook))
+
+(define (hook-run hook . args)
+  (if (not (= (length args) (hook-arity hook)))
+      (error "wrong number of arguments to hook-run")
+      (for-each (lambda (proc) (apply proc args)) (hook-procs hook))))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import SRFI-173)
+(provide "srfi-173")
+

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -296,6 +296,69 @@
       '(a d e))
 
 ;; ----------------------------------------------------------------------
+;;  SRFI 173 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 173 - Hooks")
+
+(require "srfi-173")
+
+(test "make-hook type" (hook? (make-hook 2)) #t)
+
+(define hook (make-hook 2))
+(define hook-sum-var 0)
+(define hook-prod-var 1)
+(define (hook-prod x y)
+  (set! hook-prod-var (* x y)))
+
+(hook-add! hook (lambda (x y) (set! hook-sum-var (+ x y))))
+(hook-add! hook hook-prod)
+
+(test "add-hook!+run-hook" '(8 15)
+      (begin
+        (hook-run hook 3 5)
+        (list hook-sum-var hook-prod-var)))
+
+(define list-from-hook (hook->list hook))
+
+(test "hook->list" #t (list? list-from-hook))
+(test "hook->list length" 2 (length list-from-hook))
+(test "hook->list element types" #f (member #f (map procedure? list-from-hook)))
+
+(hook-delete! hook hook-prod)
+(set! list-from-hook (hook->list hook))
+(test "hook-delete!" #f (member hook-prod (hook->list hook)))
+(test "hook->list length after delete 1 proc" 1 (length list-from-hook))
+
+(hook-reset! hook)
+(set! list-from-hook (hook->list hook))
+(test "hook-reset!" 0 (length list-from-hook))
+
+;; these three will be changed by the hook:
+(define hook-arith-var 0)
+(define hook-geom-var 0)
+(define hook-harmo-var 0)
+;; define the following two as zero. the procs that changed their values
+;; were removed, so they should NOT be altered.
+(set! hook-sum-var 0)
+(set! hook-prod-var 1)
+
+;; three procedures:
+(define (arith-mean x y) (set! hook-arith-var (/ (+ x y) 2)))
+(define (geom-mean x y)  (set! hook-geom-var  (sqrt (* x y))))
+(define (harmo-mean x y) (set! hook-harmo-var (/ 1 (+ x y))))
+
+(list->hook! hook (list arith-mean geom-mean harmo-mean))
+(test "list->hook! - length of list" 3 (length (hook->list hook)))
+(test "add-hook!+run-hook after list->hook"  (list 4 (sqrt 15) 1/8 0 1)
+      (begin
+        (hook-run hook 3 5)
+        (list hook-arith-var
+              hook-geom-var
+              hook-harmo-var
+              hook-sum-var
+              hook-prod-var)))
+
+;; ----------------------------------------------------------------------
 ;;  SRFI 190 ...
 ;; ----------------------------------------------------------------------
 (test-subsection "SRFI 190 - Coroutine Generators")


### PR DESCRIPTION
This is the example implementation from the SRFI, adapted to STklos.

One procedure was changed: instead of "assume" in hook-run,
an if followed by a call to error is done. This is consistent
with what is done in other SRFI implementations in STklos.

The tests are simple, but all procedures are tested.