### PR TITLE
Redefine alist->hash-table in SRFI-69

### DIFF
--- a/lib/srfi-69.stk
+++ b/lib/srfi-69.stk
@@ -60,6 +60,9 @@
 (define (make-hash-table :optional (comp equal?) (hash hash))
   (%old-make-hash-table comp hash))
 
+(define (alist->hash-table lst :optional (comp equal?) (hash hash-table-hash))
+  (%old-alist->hash-table lst comp hash))
+
 ;; hash-table-for-each is called hash-table-walk in SRFI-69
 (define hash-table-walk hash-table-for-each) ;; Name used in srfi69
 


### PR DESCRIPTION
In `srfi-69.stk`  there is this:

```
;; ======================================================================
;; Redefine make-hash-table and alist->hash-table to use equal? instead of
;; eq? as default comparison function

(define %old-make-hash-table make-hash-table)
(define %old-alist->hash-table alist->hash-table)

(define (make-hash-table :optional (comp equal?) (hash hash))
  (%old-make-hash-table comp hash))
```

But that code redefines `make-hash-table` only, not `alist->hash-table`. I confirmed on the REPL:

```
stklos> (require "srfi-69")
"srfi-69"
stklos> (eq? %old-make-hash-table make-hash-table)
#f
stklos> (eq? %old-alist->hash-table alist->hash-table)
#t
```

And the `alist->hash-table` defined in `bonus.stk` uses `eq?` as default comparison predicate.

By the way, this affects the tests for SRFI-171, which I am porting (the tests are adapted from Guile).