### PR TITLE
Add SRFI-176 - Version flag

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -74,5 +74,6 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-171: Transducers
     - SRFI-173: Hooks
     - SRFI-174: POSIX Timespecs
+    - SRFI-176: Version flag
     - SRFI-180: JSON
     - SRFI-190: Coroutines Generators

--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -662,6 +662,15 @@ described in this document (procedures
 ;; SRFI 174 -- POSIX Timespecs
 (gen-loaded-srfi 174)
 
+;; ----------------------------------------------------------------------
+;; SRFI 176 -- Version flag
+;; ----------------------------------------------------------------------
+(srfi-section 176
+
+(p [,(quick-link-srfi 176) is fully supported.  To use SRFI-176,
+pass (tt "-V") as option when calling STklos, or use the (tt version-alist)
+procedure.]))
+
 ;; SRFI 180 -- JSON
 (gen-loaded-srfi 180)
 

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -86,6 +86,7 @@
      (171 . "Transducers")
      (173 . "Hooks")
      (174 . "POSIX Timespecs")
+     (176 . "Version flag")
      (180 . "JSON")
      (190 . "Coroutines Generators")
    ))

--- a/lib/boot.stk
+++ b/lib/boot.stk
@@ -204,12 +204,45 @@
   (%redefine-module-exports STklos Scheme)
   (%module-exports-set! Scheme (module-exports STklos)))
 
+;; ----------------------------------------------------------------------
+;;      SRFI-176
+;; ----------------------------------------------------------------------
+
+          
+(define (version-alist)
+  (define (%feature->srfi feature)
+    (let* ((srfi- "srfi-")
+           (srfi-len 5)
+           (feat (symbol->string feature))
+           (feat-len (string-length feat)))
+      (and (> feat-len srfi-len)
+           (string=? srfi- (substring feat 0 srfi-len))
+           (string->number (substring feat srfi-len feat-len)))))
+  (let ((u (%uname)) (utf8? (key-get *%system-state-plist* :use-utf8 #f)))
+    `((version ,(version))
+      (command "stklos")
+      (scheme.id stklos)
+      (languages scheme r5rs)
+      (encodings ,@(if utf8? '(utf-8) '()))
+      (install-dir ,(%library-prefix))
+      (website "https://stklos.net")
+      (scheme.features ,@(features))
+      (scheme.srfi ,@(filter-map %feature->srfi (features)))
+      (scheme.path ,@(load-path))
+      (build.configure ,@(key-get (%stklos-configure) :configure))
+      (stklos.threads ,(%thread-system))
+      (stklos.system-libs ,@(key-get (%stklos-configure)  :system))
+      (stklos.compiled-libs ,@(key-get (%stklos-configure)  :compiled))
+      (os.uname ,(vector-ref u 0) ,(vector-ref u 2) ,(vector-ref u 4))
+      (os.env.LANG ,(or (getenv "LANG") ""))
+      (os.env.TERM ,(or (getenv "TERM") "")))))
 
 ;; ----------------------------------------------------------------------
 ;;      option analysis and REPL launching
 ;; ----------------------------------------------------------------------
 (let ((no-init (key-get *%program-args* :no-init-file #f))
       (ld      (key-get *%program-args* :load  #f))
+      (s176    (key-get *%program-args* :srfi-176 #f))
       (file    (key-get *%program-args* :file #f))
       (expr    (key-get *%program-args* :sexpr #f))
       (confdir (key-get *%program-args* :conf-dir #f))
@@ -235,6 +268,16 @@
          (eprintf "Warning: cannot create configuration directory ~S\n" dir))
        (make-directories dir))))
 
+  (when s176
+    (display (string-append "stklos (version " (version) ")"))
+    (newline)
+    (for-each (lambda (line)
+                (write line)
+                (newline))
+              (version-alist))
+    (flush-output-port (current-output-port))
+    (emergency-exit 0))
+  
   ;; Try to load the user initialization file except if "--no-init-file"
   (unless no-init
     (try-load (%stklos-conf-file "stklosrc")))

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -234,7 +234,7 @@
     ((srfi-174 posix-timespecs) "srfi-174")
                                         ; POSIX Timespecs
     ;; srfi-175                         ; ASCII character library
-    ;; srfi-176                         ; Version flag
+    srfi-176                            ; Version flag
     ;; srfi-177                         ; Portable keyword arguments (draft)
     ;; srfi-178                         ; Bitvector library (draft)
     ;; srfi-179                         ; Nonempty Intervals and Generalized Arrays (Updated) (draft)

--- a/src/stklos.c
+++ b/src/stklos.c
@@ -28,7 +28,6 @@
 #include <langinfo.h>
 #include "gnu-getopt.h"
 
-
 #define ADD_OPTION(o, k)                                        \
   if (*o) options = STk_key_set(options,                        \
                                 STk_makekey(k),                 \
@@ -61,6 +60,7 @@ static int  vanilla       = 0;
 static int  stack_size    = DEFAULT_STACK_SIZE;
 static int  debug_mode    = 0;
 static int  line_editor   = 1;
+static int  srfi_176      = 0;
 
 static struct option long_options [] =
 {
@@ -103,6 +103,7 @@ static void Usage(char *progname, int only_version)
 "       --case-insensitive      be case incensitive by default\n"
 "   -u, --utf8-encoding=yes|no  use/don't use UTF-8 encoding (instead of default)\n"
 "   -v, --version               print program version and exit\n"
+"   -V, (SRFI-176)              print version and program information, as per SRFI-176"
 "   -h, --help                  print this help and exit\n"
 "All the arguments given after options are passed to the Scheme program.\n",
 DEFAULT_STACK_SIZE);
@@ -116,11 +117,12 @@ static int process_program_arguments(int argc, char *argv[])
   int c;
 
   for ( ; ; ) {
-    c = getopt_long(argc, argv, "qidnvhcf:l:e:b:s:D:u:", long_options, NULL);
+    c = getopt_long(argc, argv, "qidnvVhcf:l:e:b:s:D:u:", long_options, NULL);
     if (c == -1) break;
 
     switch (c) {
       case 'v': Usage(*argv, 1); exit(0);
+      case 'V': srfi_176        = 1;                            break;
       case 'f': program_file    = optarg;                       break;
       case 'l': load_file       = optarg;                       break;
       case 'e': sexpr           = optarg;                       break;
@@ -157,6 +159,7 @@ static void  build_scheme_args(int argc, char *argv[], char *argv0)
   ADD_OPTION(load_file,            ":load");
   ADD_OPTION(sexpr,                ":sexpr");
   ADD_OPTION(conf_dir,             ":conf-dir");
+  ADD_BOOL_OPTION(srfi_176,        ":srfi-176");
   ADD_BOOL_OPTION(vanilla,         ":no-init-file");
   ADD_BOOL_OPTION(STk_interactive, ":interactive");
   ADD_BOOL_OPTION(line_editor,     ":line-editor");

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -2692,6 +2692,15 @@
               hook-sum-var
               hook-prod-var)))
 
+;;  SRFI 176 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 176 - Version flag")
+
+(test "version-alist is list" #t (list? (version-alist)))
+(test "scheme.id stklos" 'stklos (cadr (assoc 'scheme.id (version-alist))))
+(test "version" (version) (cadr (assoc 'version (version-alist))))
+(test "version" (features) (cdr (assoc 'scheme.features (version-alist))))
+
 ;; ----------------------------------------------------------------------
 ;;  SRFI 174 ...
 ;; ----------------------------------------------------------------------
@@ -2748,8 +2757,6 @@
       #t
       (with-handler (lambda (e) (json-error? e))
                     (call-with-input-string "{" json-read)))
-
-
 
 ;; ----------------------------------------------------------------------
 ;;  SRFI 190 ...


### PR DESCRIPTION
This adds SRFI 176, version flag.

I included the code in boot.stk -- so Scheme instead of C, because it would be easier.
I'm not sure what other information could be printed.

Please tell me if there is interest in this, and if it's implemented in a way you think is OK.

There are two SRFI PRs pending, and they both change `srfi-0.stk`, `doc/skb/srfi.stk` and	`doc/skb/srfi.skb` . If you accept one, the other will start conflicting, maybe -- I'll update then.