### PR TITLE
Adds SRFI-171

### DIFF
--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -632,6 +632,16 @@ you need to insert the following expression])
 (p [in your code or uses the ,(code "cond-expand") special form.]))
 
 ;; ----------------------------------------------------------------------
+;; SRFI 171 -- Transducers
+;; ----------------------------------------------------------------------
+(srfi-section 171
+
+(p [,(quick-link-srfi 171) is fully supported.  To use SRFI-171,
+you need to insert the following expression])
+(fontified-code [(require "srfi-171")])
+(p [in your code or uses the ,(code "cond-expand") special form.]))
+
+;; ----------------------------------------------------------------------
 ;; SRFI 173 -- Hooks
 ;; ----------------------------------------------------------------------
 (srfi-section 173

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -74,6 +74,7 @@
      (111 . "Boxes")
      (112 . "Environment Inquiry")
      (158 . "Generators and Accumulators")
+     (171 . "Trnsducers")
      (173 . "Hooks")
      (190 . "Coroutines Generators")
    ))

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -89,6 +89,7 @@ scheme_SRCS = STklos.init     \
           srfi-96.stk         \
           srfi-100.stk        \
           srfi-158.stk        \
+          srfi-171.stk        \
           srfi-173.stk        \
           srfi-190.stk        \
           tar.stk             \
@@ -136,6 +137,7 @@ scheme_OBJS = compfile.ostk    \
           srfi-96.ostk         \
           srfi-100.ostk        \
           srfi-158.ostk        \
+          srfi-171.ostk        \
           srfi-173.ostk        \
           srfi-190.ostk        \
           tar.ostk             \

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -225,7 +225,7 @@
     ;; srfi-168                         ; Generic Tuple Store Database
     ;; srfi-169                         ; Underscores in numbers
     ;; srfi-170                         ; POSIX API (draft)
-    ;; srfi-171                         ; Transducers
+    ((srfi-171 transducers) "srfi-171") ; Transducers
     ;; srfi-172                         ; Two Safer Subsets of R7RS
     ((srfi-173 hooks) "srfi-173")       ; Hooks
     ;; srfi-174                         ; POSIX Timespecs

--- a/lib/srfi-171.stk
+++ b/lib/srfi-171.stk
@@ -1,0 +1,625 @@
+;;;;
+;;;; srfi-171.stk		-- Implementation of SRFI-171
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Linus Björnstam, it is copyrighted as:
+;;;;
+;;;;;;  Copyright (c) 2019 Linus Björnstam
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 25-Jun-2020 06:21 (jpellegrini)
+;;;; Last file update: 25-May-2020 07:00 (jpellegrini)
+;;;;
+
+(require "srfi-9")
+(require "srfi-69")
+
+(define-module SRFI-171
+  (export rcons
+          reverse-rcons
+          rcount
+          rany
+          revery
+          list-transduce
+          vector-transduce
+          string-transduce
+          bytevector-u8-transduce
+          port-transduce
+          generator-transduce
+          
+          tmap
+          tfilter
+          tremove
+          treplace
+          tfilter-map
+          tdrop
+          tdrop-while
+          ttake
+          ttake-while
+          tconcatenate
+          tappend-map
+          tdelete-neighbor-duplicates
+          tdelete-duplicates
+          tflatten
+          tsegment
+          tpartition
+          tadd-between
+          tenumerate
+          tlog)
+
+
+  ;; auxiliary compose procedure
+  (define (compose . functions)
+    (define (make-chain thunk chain)
+      (lambda args
+        (call-with-values (lambda () (apply thunk args)) chain)))
+    (if (null? functions)
+        values
+        (fold make-chain (car functions) (cdr functions))))
+
+;;; helpers:
+
+  (define-record-type <reduced>
+  (reduced val)
+  reduced?
+  (val unreduce))
+
+
+;; helper function which ensures x is reduced.
+(define (ensure-reduced x)
+  (if (reduced? x)
+      x
+      (reduced x)))
+
+
+;; helper function that wraps a reduced value twice since reducing functions (like list-reduce)
+;; unwraps them. tconcatenate is a good example: it re-uses it's reducer on it's input using list-reduce.
+;; If that reduction finishes early and returns a reduced value, list-reduce would "unreduce"
+;; that value and try to continue the transducing process.
+(define (preserving-reduced reducer)
+  (lambda (a b)
+    (let ((return (reducer a b)))
+      (if (reduced? return)
+          (reduced return)
+          return))))
+
+
+;; This is where the magic tofu is cooked
+(define (list-reduce f identity lst)
+  (if (null? lst)
+      identity
+      (let ((v (f identity (car lst))))
+        (if (reduced? v)
+            (unreduce v)
+            (list-reduce f v (cdr lst))))))
+
+(define (vector-reduce f identity vec)
+  (let ((len (vector-length vec)))
+    (let loop ((i 0) (acc identity))
+      (if (= i len)
+          acc
+          (let ((acc (f acc (vector-ref vec i))))
+            (if (reduced? acc)
+                (unreduce acc)
+                (loop (+ i 1) acc)))))))
+
+(define (string-reduce f identity str)
+  (let ((len (string-length str)))
+    (let loop ((i 0) (acc identity))
+      (if (= i len)
+          acc
+          (let ((acc (f acc (string-ref str i))))
+            (if (reduced? acc)
+                (unreduce acc)
+                (loop (+ i 1) acc)))))))
+
+(define (bytevector-u8-reduce f identity vec)
+  (let ((len (bytevector-length vec)))
+    (let loop ((i 0) (acc identity))
+      (if (= i len)
+          acc
+          (let ((acc (f acc (bytevector-u8-ref vec i))))
+            (if (reduced? acc)
+                (unreduce acc)
+                (loop (+ i 1) acc)))))))
+
+(define (port-reduce f identity reader port)
+  (let loop ((val (reader port)) (acc identity))
+    (if (eof-object? val)
+        acc
+        (let ((acc (f acc val)))
+          (if (reduced? acc)
+              (unreduce acc)
+              (loop (reader port) acc))))))
+
+(define (generator-reduce f identity gen)
+  (let loop ((val (gen)) (acc identity))
+    (if (eof-object? val)
+        acc
+        (let ((acc (f acc val)))
+          (if (reduced? acc)
+              (unreduce acc)
+              (loop (gen) acc))))))
+
+;;; SRFI code:
+  
+;; A special value to be used as a placeholder where no value has been set and #f
+;; doesn't cut it. Not exported, and not really needed.
+(define-record-type <nothing>
+  (make-nothing)
+  nothing?)
+(define nothing (make-nothing))
+
+
+;; helper function which ensures x is reduced.
+(define (ensure-reduced x)
+  (if (reduced? x)
+      x
+      (reduced x)))
+
+
+;; helper function that wraps a reduced value twice since reducing functions (like list-reduce)
+;; unwraps them. tconcatenate is a good example: it re-uses it's reducer on it's input using list-reduce.
+;; If that reduction finishes early and returns a reduced value, list-reduce would "unreduce"
+;; that value and try to continue the transducing process.
+(define (preserving-reduced f)
+  (lambda (a b)
+    (let ((return (f a b)))
+      (if (reduced? return)
+          (reduced return)
+          return))))
+
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Reducing functions meant to be used at the end at the transducing
+;; process.    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; a transducer-friendly cons with the empty list as identity
+(define rcons
+  (case-lambda
+    (() '())
+    ((lst) (reverse! lst))
+    ((lst x) (cons x lst))))
+
+
+(define reverse-rcons
+  (case-lambda
+    (() '())
+    ((lst) lst)
+    ((lst x) (cons x lst))))
+
+
+;; Use this as the f in transduce to count the amount of elements passed through.
+;; (transduce (tfilter odd?) tcount (list 1 2 3)) => 2
+(define rcount
+  (case-lambda
+    (() 0)
+    ((result) result)
+    ((result input)
+     (+ 1  result))))
+
+
+;; These two take a predicate and returns reducing functions that behave
+;; like any and every from srfi-1
+(define (rany pred)
+  (case-lambda
+    (() #f)
+    ((result) result)
+    ((result input)
+     (let ((test (pred input)))
+       (if test
+           (reduced test)
+           #f)))))
+
+
+(define (revery pred)
+  (case-lambda
+    (() #t)
+    ((result) result)
+    ((result input)
+     (let ((test (pred input)))
+       (if (and result test)
+           test
+           (reduced #f))))))
+
+
+(define list-transduce
+  (case-lambda
+    ((xform f coll)
+     (list-transduce xform f (f) coll))
+    ((xform f init coll)
+     (let* ((xf (xform f))
+            (result (list-reduce xf init coll)))
+       (xf result)))))
+
+(define vector-transduce
+  (case-lambda
+    ((xform f coll)
+     (vector-transduce xform f (f) coll))
+    ((xform f init coll)
+     (let* ((xf (xform f))
+            (result (vector-reduce xf init coll)))
+       (xf result)))))
+
+(define string-transduce
+  (case-lambda
+    ((xform f coll)
+     (string-transduce xform f (f) coll))
+    ((xform f init coll)
+     (let* ((xf (xform f))
+            (result (string-reduce xf init coll)))
+       (xf result)))))
+
+(define bytevector-u8-transduce
+  (case-lambda
+    ((xform f coll)
+     (bytevector-u8-transduce xform f (f) coll))
+    ((xform f init coll)
+     (let* ((xf (xform f))
+            (result (bytevector-u8-reduce xf init coll)))
+       (xf result)))))
+
+(define port-transduce
+  (case-lambda
+    ((xform f by)
+     (generator-transduce xform f by))
+    ((xform f by port)
+     (port-transduce xform f (f) by port))
+    ((xform f init by port)
+     (let* ((xf (xform f))
+            (result (port-reduce xf init by port)))
+       (xf result)))))
+
+(define generator-transduce
+  (case-lambda
+    ((xform f gen)
+     (generator-transduce xform f (f) gen))
+    ((xform f init gen)
+     (let* ((xf (xform f))
+            (result (generator-reduce xf init gen)))
+       (xf result)))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Transducers!    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (tmap f)
+  (lambda (reducer)
+    (case-lambda
+      (() (reducer))
+      ((result) (reducer result)) 
+      ((result input)
+       (reducer result (f input))))))
+
+
+(define (tfilter pred)
+  (lambda (reducer)
+    (case-lambda
+      (() (reducer))
+      ((result) (reducer result))
+      ((result input)
+       (if (pred input)
+           (reducer result input)
+           result)))))
+
+
+(define (tremove pred)
+  (lambda (reducer)
+    (case-lambda
+      (() (reducer))
+      ((result) (reducer result))
+      ((result input)
+       (if (not (pred input))
+           (reducer result input)
+           result)))))
+
+
+(define (tfilter-map f) 
+  (compose (tmap f) (tfilter values)))
+
+
+(define (make-replacer map)
+  (cond
+   ((list? map)
+    (lambda (x)
+      (let ((replacer? (assoc x map)))
+        (if replacer?
+            (cdr replacer?)
+            x))))
+   ((hash-table? map)
+    (lambda (x)
+      (hash-table-ref/default map x x)))
+   ((procedure? map) map)
+   (else
+    (error "Unsupported mapping in treplace" map))))
+
+
+(define (treplace map)
+  (tmap (make-replacer map)))
+
+
+(define (tdrop n)
+  (lambda (reducer)
+    (let ((new-n (+ 1 n)))
+      (case-lambda
+        (() (reducer))
+        ((result) (reducer result))
+        ((result input)
+         (set! new-n (- new-n 1))
+         (if (positive? new-n)
+             result
+             (reducer result input)))))))
+
+
+(define (tdrop-while pred)
+  (lambda (reducer)
+    (let ((drop? #t))
+      (case-lambda
+        (() (reducer))
+        ((result) (reducer result))
+        ((result input)
+         (if (and (pred input) drop?)
+             result
+             (begin
+               (set! drop? #f)
+               (reducer result input))))))))
+
+
+(define (ttake n)
+  (lambda (reducer)
+    ;; we need to reset new-n for every new transduction
+    (let ((new-n n))
+      (case-lambda
+        (() (reducer))
+        ((result) (reducer result))
+        ((result input)
+         (let ((result (if (positive? new-n)
+                           (reducer result input)
+                           result)))
+           (set! new-n (- new-n 1))
+           (if (not (positive? new-n))
+               (ensure-reduced result)
+               result)))))))
+
+
+
+(define ttake-while
+  (case-lambda
+    ((pred) (ttake-while pred (lambda (result input) result)))
+    ((pred retf)
+     (lambda (reducer)
+       (let ((take? #t))
+         (case-lambda
+           (() (reducer))
+           ((result) (reducer result))
+           ((result input)
+            (if (and take? (pred input))
+                (reducer result input)
+                (begin
+                  (set! take? #f)
+                  (ensure-reduced (retf result input)))))))))))
+
+
+
+(define (tconcatenate reducer)
+  (let ((preserving-reducer (preserving-reduced reducer)))
+    (case-lambda
+      (() (reducer))
+      ((result) (reducer result))
+      ((result input)
+       (list-reduce preserving-reducer result input)))))
+
+
+(define (tappend-map f)
+  (compose (tmap f) tconcatenate))
+
+
+
+;; Flattens everything and passes each value through the reducer
+;; (list-transduce tflatten conj (list 1 2 (list 3 4 '(5 6) 7 8))) => (1 2 3 4 5 6 7 8)
+(define tflatten
+  (lambda (reducer)
+    (case-lambda
+      (() '())
+      ((result) (reducer result))
+      ((result input)
+       (if (list? input)
+           (list-reduce (preserving-reduced (tflatten reducer)) result input)
+           (reducer result input))))))
+
+
+
+;; removes duplicate consecutive elements
+(define tdelete-neighbor-duplicates
+  (case-lambda
+    (() (tdelete-neighbor-duplicates equal?))
+    ((equality-pred?) 
+     (lambda (reducer)
+       (let ((prev nothing))
+         (case-lambda
+           (() (reducer))
+           ((result) (reducer result))
+           ((result input)
+            (if (equality-pred? prev input)
+                result
+                (begin
+                  (set! prev input)
+                  (reducer result input))))))))))
+
+;; Deletes all duplicates that passes through.
+(define tdelete-duplicates
+  (case-lambda
+    (() (tdelete-duplicates equal?))
+    ((equality-pred?)
+     ;; changed by jpellegrini:
+     ;; STklos will optimize eq? and string=?, but other predicates
+     ;; will not work with hash-table-hash, so we use the identity
+     ;; function for them.
+     (let ((hash-function (if (member equality-pred? `(,eq? ,string=?))
+                              hash-table-hash
+                              (lambda (x) x))))
+       (lambda (reducer)
+         (let ((already-seen (make-hash-table equality-pred? hash-function)))
+           (case-lambda
+             (() (reducer))
+             ((result) (reducer result))
+             ((result input)
+              (if (hash-table-exists? already-seen input)
+                  result
+                  (begin
+                    (hash-table-set! already-seen input #t)
+                    (reducer result input)))))))))))
+
+;; Partitions the input into lists of N items. If the input stops it flushes whatever
+;; it has collected, which may be shorter than n.
+;; I am not sure about the correctness about this. It seems to work.
+(define (tsegment n)
+  (if (not (and (integer? n) (positive? n)))
+      (error "argument to tsegment must be a positive integer")
+      (lambda (reducer)
+        (let ((i 0)
+              (collect (make-vector n)))
+          (case-lambda
+            (() (reducer))
+            ((result)
+             ;; if there is anything collected when we are asked to quit
+             ;; we flush it to the remaining transducers
+             (let ((result
+                    (if (zero? i)
+                        result
+                        (reducer result (vector->list collect 0 i)))))
+               (set! i 0)
+               ;; now finally, pass it downstreams
+               (reducer result)))
+            ((result input)
+             (vector-set! collect i input)
+             (set! i (+ i 1))
+             ;; If we have collected enough input we can pass it on downstream
+             (if (< i n)
+                 result
+                 (let ((next-input (vector->list collect 0 i)))
+                   (set! i 0)
+                   (reducer result next-input)))))))))
+
+
+;; I am not sure about the correctness of this. It seems to work.
+;; we could maybe make it faster?
+(define (tpartition f)
+  (lambda (reducer)
+    (let* ((prev nothing)
+           (collect '()))
+      (case-lambda
+        (() (reducer))
+        ((result)
+         (let ((result
+                (if (null? collect)
+                    result
+                    (reducer result (reverse! collect)))))
+           (set! collect '())
+           (reducer result)))
+        ((result input)
+         (let ((fout (f input)))
+           (cond
+            ((or (equal? fout prev) (nothing? prev)) ; collect
+             (set! prev fout)
+             (set! collect (cons input collect))
+             result)
+            (else ; flush what we collected already to the reducer
+             (let ((next-input  (reverse! collect)))
+               (set! prev fout)
+               (set! collect (list input))
+               (reducer result next-input))))))))))
+
+
+;; Interposes element between each value pushed through the transduction.
+(define (tadd-between elem)
+  (lambda (reducer)
+    (let ((send-elem? #f))
+      (case-lambda
+        (() (reducer))
+        ((result)
+         (reducer result))
+        ((result input)
+         (if send-elem?
+             (let ((result (reducer result elem)))
+               (if (reduced? result)
+                   result
+                   (reducer result input)))
+             (begin
+               (set! send-elem? #t)
+               (reducer result input))))))))
+
+
+;; indexes every value passed through in a cons pair as in (index . value). By default starts at 0
+(define tenumerate
+  (case-lambda
+    (() (tenumerate 0))
+    ((n)
+     (lambda (reducer)
+       (let ((n n))
+         (case-lambda
+           (() (reducer))
+           ((result) (reducer result))
+           ((result input)
+            (let ((input (cons n input)))
+              (set! n (+ n 1))
+              (reducer result input)))))))))
+
+
+(define tlog
+  (case-lambda
+    (() (tlog (lambda (result input) (write input) (newline))))
+    ((log-function)
+     (lambda (reducer)
+       (case-lambda
+         (() (reducer))
+         ((result) (reducer result))
+         ((result input)
+          (log-function result input)
+          (reducer result input)))))))
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import SRFI-171)
+(provide "srfi-171")

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -538,6 +538,277 @@
       '(a d e))
 
 ;; ----------------------------------------------------------------------
+;;  SRFI 171 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 171 - Transducers")
+
+(require "srfi-1")
+(require "srfi-66")
+(require "srfi-69")
+(require "srfi-171")
+
+(define (add1 x) (+ x 1))
+
+(define numeric-list (iota 5))
+(define numeric-vec (list->vector numeric-list))
+(define bv (list->u8vector numeric-list))
+(define test-string "0123456789abcdef")
+(define list-of-chars (string->list test-string))
+
+;; for testing all treplace variations
+(define replace-alist '((1 . s) (2 . c) (3 . h) (4 . e) (5 . m)))
+(define stklos-hashtable (%old-alist->hash-table replace-alist eq? md5sum))
+(define srfi69-hashtable (alist->hash-table replace-alist))
+;;(define rnrs-hashtable (rnrs:make-eq-hashtable))
+
+;; No rnrs hashtables
+;; (rnrs:hashtable-set! rnrs-hashtable 1 's)
+;; (rnrs:hashtable-set! rnrs-hashtable 2 'c)
+;; (rnrs:hashtable-set! rnrs-hashtable 3 'h)
+;; (rnrs:hashtable-set! rnrs-hashtable 4 'e)
+;; (rnrs:hashtable-set! rnrs-hashtable 5 'm)
+
+(define (replace-function val)
+  (case val
+    ((1) 's)
+    ((2) 'c)
+    ((3) 'h)
+    ((4) 'e)
+    ((5) 'm)
+    (else val)))
+
+;; Test procedures for port-transduce
+;; broken out to properly close port
+(define (port-transduce-test)
+  (let* ((port (open-input-string "0 1 2 3 4"))
+        (res (equal? 15 (port-transduce (tmap add1) + read
+                                        (open-input-string "0 1 2 3 4")))))
+    (close-port port)
+    res))
+(define (port-transduce-with-identity-test)
+  (let* ((port (open-input-string "0 1 2 3 4"))
+         (res (equal? 15 (port-transduce (tmap add1)
+                                         +
+                                         0
+                                         read
+                                         (open-input-string "0 1 2 3 4")))))
+    (close-port port)
+    res))
+
+
+;;; helpers:
+
+
+  (define (compose . functions)
+    (define (make-chain thunk chain)
+      (lambda args
+        (call-with-values (lambda () (apply thunk args)) chain)))
+    (if (null? functions)
+        values
+        (fold make-chain (car functions) (cdr functions))))
+
+
+;; "transducers"
+
+
+(test "tmap"
+      '(1 2 3 4 5)
+      (list-transduce (tmap add1)
+                      rcons
+                      numeric-list))
+
+(test "tfilter"
+      '(0 2 4)
+      (list-transduce (tfilter even?)
+                      rcons
+                      numeric-list))
+
+(test "tfilter+tmap"
+      '(1 3 5)
+      (list-transduce (compose (tfilter even?) (tmap add1))
+                      rcons
+                      numeric-list))
+
+(test "tfilter-map"
+      '(1 3 5)
+      (list-transduce (tfilter-map
+                       (lambda (x)
+                         (if (even? x)
+                             (+ x 1)
+                             #f)))
+                      rcons numeric-list))
+
+(test "tremove"
+      (list-transduce (tremove char-alphabetic?)
+                      rcount
+                      list-of-chars)
+      (string-transduce (tremove char-alphabetic?)
+                        rcount
+                        test-string))
+
+(test "treplace with alist"
+      '(s c h e m e  r o c k s)
+      (list-transduce (treplace replace-alist)
+                      rcons
+                      '(1 2 3 4 5 4 r o c k s) ))
+
+(test "treplace with replace-function"
+      '(s c h e m e  r o c k s)
+      (list-transduce (treplace replace-function)
+                      rcons
+                      '(1 2 3 4 5 4 r o c k s)))
+
+(test "treplace with STklos hash-table"
+      '(s c h e m e  r o c k s)
+      (list-transduce (treplace stklos-hashtable)
+                      rcons
+                      '(1 2 3 4 5 4 r o c k s)))
+
+(test "treplace with srfi-69 hash-table"
+      '(s c h e m e  r o c k s)
+      (list-transduce (treplace srfi69-hashtable)
+                      rcons
+                      '(1 2 3 4 5 4 r o c k s)))
+
+;; STklos has no RNRS hashtables, so we comment this out.
+;;
+;; (test "treplace with rnrs hash-table"
+;;       '(s c h e m e  r o c k s)
+;;       (list-transduce (treplace rnrs-hashtable)
+;;                       rcons
+;;                       '(1 2 3 4 5 4 r o c k s)))
+
+(test "ttake"
+      6 (list-transduce (ttake 4) + numeric-list))
+
+(test "tdrop"
+      7 (list-transduce (tdrop 3) + numeric-list))
+
+(test "tdrop-while"
+      '(3 4)
+      (list-transduce (tdrop-while (lambda (x) (< x 3)))
+                      rcons
+                      numeric-list))
+
+(test "ttake-while"
+      '(0 1 2)
+      (list-transduce (ttake-while (lambda (x) (< x 3)))
+                      rcons
+                      numeric-list))
+
+(test "tconcatenate"
+      '(0 1 2 3 4) (list-transduce tconcatenate
+                                   rcons
+                                   '((0 1) (2 3) (4))))
+
+(test "tappend-map"
+      '(1 2 2 4 3 6)
+      (list-transduce (tappend-map (lambda (x) (list x (* x 2))))
+                      rcons
+                      '(1 2 3)))
+
+(test "tdelete-neighbor-duplicates"
+      '(1 2 1 2 3)
+      (list-transduce (tdelete-neighbor-duplicates)
+                      rcons
+                      '(1 1 1 2 2 1 2 3 3)))
+
+(test "tdelete-neighbor-duplicates with equality predicate"
+      '(a b c "hej" "hej")
+      (list-transduce (tdelete-neighbor-duplicates eq?)
+                      rcons
+                      (list 'a 'a 'b 'c 'c "hej" (string #\h #\e #\j))))
+
+(test "tdelete-duplicates"
+      '(1 2 3 4)
+      (list-transduce (tdelete-duplicates)
+                      rcons
+                      '(1 1 2 1 2 3 3 1 2 3 4)))
+
+(test "tdelete-duplicates with predicate"
+      '("hej" "hopp")
+      (list-transduce (tdelete-duplicates string-ci=?)
+                      rcons
+                      (list "hej" "HEJ" "hopp" "HOPP" "heJ")))
+
+;; added by jpellegrini:
+(test "tdelete-duplicates with string=?"
+      '("hej" "HEJ" "hopp" "HOPP")
+      (list-transduce (tdelete-duplicates string=?)
+                      rcons
+                      (list "hej" "HEJ" "hopp" "HOPP" "hej")))
+
+(test "tflatten"
+      '(1 2 3 4 5 6 7 8 9)
+      (list-transduce tflatten rcons '((1 2) 3 (4 (5 6) 7) 8 (9))))
+
+(test "tpartition"
+      '((1 1 1 1) (2 2 2 2) (3 3 3) (4 4 4 4))
+      (list-transduce (tpartition even?)
+                      rcons
+                      '(1 1 1 1 2 2 2 2 3 3 3 4 4 4 4)))
+
+(test "tsegment"
+      '((0 1) (2 3) (4))
+      (vector-transduce (tsegment 2) rcons numeric-vec))
+
+(test "tadd-between"
+      '(0 and 1 and 2 and 3 and 4)
+      (list-transduce (tadd-between 'and) rcons numeric-list))
+
+(test "tenumerate"
+      '((-1 . 0) (0 . 1) (1 . 2) (2 . 3) (3 . 4))
+      (list-transduce (tenumerate (- 1)) rcons numeric-list))
+
+
+;; "x-transduce"
+
+(test "list-transduce"
+      15 (list-transduce (tmap add1) + numeric-list))
+
+(test "list-transduce with identity"
+      15 (list-transduce (tmap add1) + 0 numeric-list))
+
+(test "vector-transduce"
+      15 (vector-transduce (tmap add1) + numeric-vec))
+
+(test "vector-transduce with identity"
+      15
+      (vector-transduce (tmap add1) + 0 numeric-vec))
+
+(test "port-transduce" #t (port-transduce-test))
+(test "port-transduce with identity" #t (port-transduce-with-identity-test))
+
+;; Converts each numeric char to it's corresponding integer  and sums them.
+(test "string-transduce"
+      15
+      (string-transduce (tmap (lambda (x) (- (char->integer x) 47))) + "01234"))
+
+(test "string-transduce with identity"
+      15
+      (string-transduce  (tmap (lambda (x) (- (char->integer x) 47)))
+                         +
+                         0
+                         "01234"))
+
+(test "generator-transduce"
+      '(1 2 3)
+      (with-input-from-string "1 2 3"
+        (lambda () (generator-transduce (tmap (lambda (x) x)) rcons read))))
+
+(test "generator-transduce with identity"
+      '(1 2 3)
+      (with-input-from-string "1 2 3"
+        (lambda () (generator-transduce (tmap (lambda (x) x)) rcons '() read))))
+
+(test "bytevector-u8-transduce"
+      15 (bytevector-u8-transduce (tmap add1) + bv))
+
+(test "bytevector-u8-transduce with identity"
+      15 (bytevector-u8-transduce (tmap add1) + 0 bv))
+
+
+;; ----------------------------------------------------------------------
 ;;  SRFI 173 ...
 ;; ----------------------------------------------------------------------
 (test-subsection "SRFI 173 - Hooks")


### PR DESCRIPTION
This is SRFI-171, Transducers.

The reference implementation has one single procedure (`tremove-duplicates`) which uses hash tables, allowing the user to pass an arbitrary equality predicate. Tests wouldn't pass in STklos, so I adpted it: if the predicate is `eq?` or `string=?`, then pass `hash-table-hash` to `make-hash-table`, otherwise, use the identity `(lambda (x) x)`.

I have included one more test, for `tremove-duplicates` with `string=?`.