### PR TITLE
SRFI 87 already supported - document it

### DIFF
--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -537,6 +537,14 @@ you need to insert the following expression])
 (p [in your code or uses the ,(code "cond-expand") special form.]))
 
 ;; ----------------------------------------------------------------------
+;; SRFI 87 -- => in case clauses
+;; ----------------------------------------------------------------------
+(srfi-section 87
+
+(p [,(quick-link-srfi 87), ehich became part of the R7RS standard,
+is fully supported.]))
+
+;; ----------------------------------------------------------------------
 ;; SRFI 88 -- Keyword objects
 ;; ----------------------------------------------------------------------
 (srfi-section 88

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -66,6 +66,7 @@
      (69 . "Basic Hash Tables")
      (70 . "Numbers")
      (74 . "Octet-Addressed Binary Blocks")
+     (87 . "=> in case clauses")
      (88 . "Keyword Objects")
      (89 . "Optional Positional and Named Parameters")
      (96 . "SLIB Prerequisites ")

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -141,7 +141,7 @@
     ;; srfi-84                          ; ....... withdrawn
     ;; srfi-85                          ; ....... withdrawn
     ;; srfi-86                          ; MU and NU simulating VALUES & CALL-WITH-VALUES
-    ;; srfi-87                          ; => in case clauses
+    srfi-87                             ; => in case clauses
     srfi-88                             ; Keyword objects
     (srfi-89 "srfi-89")                 ; Optional Positional and Named Parameters
     ;; srfi-90                          ; Extensible hash table constructor

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -483,6 +483,24 @@
       '(0 0 0 14640 -1 -1 -1 -513)
       (blob->sint-list 2 (endianness little) b4))
 
+
+;; ----------------------------------------------------------------------
+;;  SRFI 87 and R7RS ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 87 - => in case clauses")
+
+(test "=> else symbol" 'none (case 20 ((5) 'five) ((10) => 'ten) ((15) 'fifteen) (else => (lambda (x) 'none))))
+(test "=> choose non-procedure" *test-failed* (case 10 ((5) 'five) ((10) => 'ten) ((15) 'fifteen) (else 'none)))
+(test "=> don't choose non-procedure" 'none (case 20 ((5) 'five) ((10) => 'ten) ((15) 'fifteen) (else 'none)))
+(test "=> don't choose non-procedure, II"  -20 (case 20 ((5) 'five) ((10) => 'ten) ((15) 'fifteen) (else => (lambda (x) (- x)))))
+(test "=> else number" 60 (case 20 ((5) 'five) ((10) 'ten) ((15) 'fifteen) (else =>  (lambda (x) (* x 3)))))
+(test "=> else -" -20 (case 20 ((5) 'five) ((10) 'ten) ((15) 'fifteen) (else =>  -)))
+(test "=> only"  #\z (case #\Z ((#\a) => char-upcase)
+                               ((#\c) => (lambda (x) (string x #\d)))
+                               ((#\z) => char->integer)
+                               ((#\Z) => char-downcase)
+                               (else => #f)))
+
 ;; ----------------------------------------------------------------------
 ;;  SRFI 117 ...
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
STklos already supports SRFI-87 out of the box, as part of
R7RS support. This commit only documents it, and adds a
couple of tests to test-srfi.stk (besides the tests already
in test-r7rs.stk).