### PR TITLE
Adds SRFI-143 - Fixnums

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -78,6 +78,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-135: Immutable Texts
     - SRFI-137: Minimal Unique Types
     - SRFI-141: Integer Division
+    - SRFI-143: Fixnums
     - SRFI-145: Assumptions
     - SRFI-151: Bitwise Operations
     - SRFI-156: Syntactic combiners for binary predicates

--- a/lib/boot.stk
+++ b/lib/boot.stk
@@ -69,6 +69,15 @@
 (autoload        "srfi-48"        srfi48:help srfi48:format-fixed)
 
 ;==============================================================================
+;; give new names to some primitives and define some constants so as to comply
+;; with SRFI-143 (fixnums):
+(define fxquotient fxdiv)
+(define fxremainder fxrem)
+(define fx-width (fixnum-width))
+(define fx-greatest (greatest-fixnum))
+(define fx-least (least-fixnum))
+
+;==============================================================================
 ;; Execute the REPL only if a file was not given on the command line
 (define %before-exit-hook void)
 

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -181,7 +181,7 @@
     ;; 140  Immutable Strings
     (141 "Integer Division" (integer-division) "srfi-141")
     ;; 142  ....... withdrawn
-    ;; 143  Fixnums
+    (143  "Fixnums")
     ;; 144  Flonums
     (145 "Assumptions")
     ;; 146  Mappings

--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -25,6 +25,9 @@
  */
 
 #include "stklos.h"
+#include <stdlib.h>  /* for ldiv */
+#include <math.h>    /* for sqrt & pow */
+
 
 static void error_bad_fixnum(SCM obj)
 {
@@ -34,6 +37,33 @@ static void error_bad_fixnum(SCM obj)
 static void error_division_by_0(void)
 {
   STk_error("division by 0");
+}
+
+static void error_fx_at_least_1(void)
+{
+  STk_error("expects at least one fixnum argument");
+}
+
+static void error_negative_fixnum(SCM obj)
+{
+    STk_error("expected non-negative fixnum, found ~S", obj);
+}
+
+static void error_bad_fxlength(SCM obj)
+{
+    STk_error("bad fixnum length ~S (should be < ~S)", obj, INT_LENGTH);
+}
+
+static void error_bad_boolean(SCM obj)
+{
+  STk_error("bad boolean ~S", obj);
+}
+
+/* used internally by the fx../carry primitives */
+inline static
+long exp_2_fxwidth() {
+    return ( 1L << (INT_LENGTH/2-1) ) << (INT_LENGTH/2-1);
+/*    return (long) pow (2, sizeof(long)* 8 - 2);  */
 }
 
 
@@ -59,7 +89,7 @@ doc>
 */
 DEFINE_PRIMITIVE("fixnum-width", fixnum_width, subr0, (void))
 {
-  return MAKE_INT(sizeof(long)* 8 - 2);
+  return MAKE_INT(INT_LENGTH);
 }
 
 /*
@@ -81,42 +111,150 @@ DEFINE_PRIMITIVE("greatest-fixnum", greatest_fixnum, subr0, (void))
   return MAKE_INT(INT_MAX_VAL);
 }
 
+/*
+<doc  fxzero?
+ * (fxzero? obj)
+ *
+ * |fxzero?| returns |#t| if |obj| is the fixnum zero and returns
+ * |#f| if it is a non-zero fixnum.
+ * @lisp
+ *   (fxzero? #f)            =>  error
+ *   (fxzero? (expt 100 100) =>  error
+ *   (fxzero? 0)             =>  #t
+ *   (fxzero? 1)             =>  #f
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxzero?", fxzerop, subr1, (SCM o1))
+{
+    /* if (!INTP(o1)) error_bad_fixnum(o1); */
+    return MAKE_BOOLEAN (INT_VAL(o1)==0);
+}
 
 /*
-<doc EXT fx+ fx- fx* fxdiv fxrem fxmod
+<doc  fxpositive?
+ * (fxpositive? obj)
+ *
+ * |fxpositive?| returns |#t| if |obj| is a positive fixnum and returns
+ * |#f| if it is a non-positive fixnum.
+ * @lisp
+ *   (fxpositive? #f)            =>  error
+ *   (fxpositive? (expt 100 100) =>  error
+ *   (fxpositive? 0)             =>  #f
+ *   (fxpositive? 1)             =>  #t
+ *   (fxpositive? -1)            =>  #f
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxpositive?", fxpositivep, subr1, (SCM o1))
+{
+    /* if (!INTP(o1)) error_bad_fixnum(o1); */
+    return MAKE_BOOLEAN (INT_VAL(o1)>0);
+}
+
+/*
+<doc  fxnegative?
+ * (fxnegative? obj)
+ *
+ * |fxnegative?| returns |#t| if |obj| is a negative fixnum and returns
+ * |#f| if it is a non-negative fixnum.
+ * @lisp
+ *   (fxnegative? #f)            =>  error
+ *   (fxnegative? (expt 100 100) =>  error
+ *   (fxnegative? 0)             =>  #f
+ *   (fxnegative? 1)             =>  #f
+ *   (fxnegative? -1)            =>  #t
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxnegative?", fxnegativep, subr1, (SCM o1))
+{
+    /* if (!INTP(o1)) error_bad_fixnum(o1); */
+    return MAKE_BOOLEAN (INT_VAL(o1)<0);
+}
+
+/*
+<doc  fxodd?
+ * (fxodd? obj)
+ *
+ * |fxodd?| returns |#t| if |obj| is a odd fixnum and returns
+ * |#f| if it is an even fixnum.
+ * @lisp
+ *   (fxodd? #f)            =>  error
+ *   (fxodd? (expt 100 100) =>  error
+ *   (fxodd? 0)             =>  #f
+ *   (fxodd? 1)             =>  #t
+ *   (fxodd? 4)             =>  #f
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxodd?", fxoddp, subr1, (SCM o1))
+{
+    /*if (!INTP(o1)) error_bad_fixnum(o1);*/
+    return MAKE_BOOLEAN (INT_VAL(o1)&1);
+}
+
+/*
+<doc  fxeven?
+ * (fxeven? obj)
+ *
+ * |fxeven?| returns |#t| if |obj| is a even fixnum and returns
+ * |#f| if it is an odd fixnum.
+ * @lisp
+ *   (fxeven? #f)            =>  error
+ *   (fxeven? (expt 100 100) =>  error
+ *   (fxeven? 0)             =>  #t
+ *   (fxeven? 1)             =>  #f
+ *   (fxeven? 4)             =>  #t
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxeven?", fxevenp, subr1, (SCM o1))
+{
+    /*if (!INTP(o1)) error_bad_fixnum(o1);*/
+    return MAKE_BOOLEAN (!(INT_VAL(o1)&1));
+}
+
+/*
+<doc EXT fx+ fx- fx* fxdiv fxrem fxmod fxabs
  * (fx+ fx1 fx2)
  * (fx- fx1 fx2)
  * (fx* fx1 fx2)
  * (fxdiv fx1 fx2)
  * (fxrem fx1 fx2)
  * (fxmod fx1 fx2)
+ * (fxabs fx)
  * (fx- fx)
  *
  * These procedures compute (respectively) the sum, the difference, the product,
  * the quotient and the remainder and modulp of the fixnums |fx1| and |fx2|.
- * The call of  |fx-| with one parameter |fx| computes the opposite of |fx|.
+ * The call of  |fx-| with one parameter |fx| computes the opposite of |fx|,
+ * and |fxabs| compute the absolute value of |fx|.
 doc>
  */
 DEFINE_PRIMITIVE("fx+", fxplus, subr2, (SCM o1, SCM o2))
 {
-  if (!INTP(o1)) error_bad_fixnum(o1);
-  if (!INTP(o2)) error_bad_fixnum(o2);
+    /* removing original STklos check:
+      if (!INTP(o1)) error_bad_fixnum(o1);
+      if (!INTP(o2)) error_bad_fixnum(o2); */
   return MAKE_INT(INT_VAL(o1) + INT_VAL(o2));
 }
 
 DEFINE_PRIMITIVE("fx-", fxminus, subr12, (SCM o1, SCM o2))
 {
-  if (!INTP(o1)) error_bad_fixnum(o1);
+    /* removing original STklos test:
+       if (!INTP(o1)) error_bad_fixnum(o1); */
   if (!o2)
     return MAKE_INT(-INT_VAL(o1));
-  if (!INTP(o2)) error_bad_fixnum(o2);
+  /* if (!INTP(o2)) error_bad_fixnum(o2); */
   return MAKE_INT(INT_VAL(o1) - INT_VAL(o2));
 }
 
 DEFINE_PRIMITIVE("fx*", fxtime, subr2, (SCM o1, SCM o2))
 {
-  if (!INTP(o1)) error_bad_fixnum(o1);
-  if (!INTP(o2)) error_bad_fixnum(o2);
+    /* removing original STklos test:
+       if (!INTP(o1)) error_bad_fixnum(o1);
+       if (!INTP(o2)) error_bad_fixnum(o2); */
   return MAKE_INT(INT_VAL(o1) * INT_VAL(o2));
 }
 
@@ -124,8 +262,9 @@ DEFINE_PRIMITIVE("fxdiv", fxdiv, subr2, (SCM o1, SCM o2))
 {
   int n;
 
-  if (!INTP(o1)) error_bad_fixnum(o1);
-  if (!INTP(o2)) error_bad_fixnum(o2);
+    /* removing original STklos test:
+       if (!INTP(o1)) error_bad_fixnum(o1);
+       if (!INTP(o2)) error_bad_fixnum(o2); */
 
   n = INT_VAL(o2);
 
@@ -137,8 +276,9 @@ DEFINE_PRIMITIVE("fxrem", fxrem, subr2, (SCM o1, SCM o2))
 {
   int n;
 
-  if (!INTP(o1)) error_bad_fixnum(o1);
-  if (!INTP(o2)) error_bad_fixnum(o2);
+     /* removing original STklos test:
+        if (!INTP(o1)) error_bad_fixnum(o1);
+        if (!INTP(o2)) error_bad_fixnum(o2); */
 
   n = INT_VAL(o2);
 
@@ -149,8 +289,9 @@ DEFINE_PRIMITIVE("fxrem", fxrem, subr2, (SCM o1, SCM o2))
 
 DEFINE_PRIMITIVE("fxmod", fxmod, subr2, (SCM o1, SCM o2))
 {
-  if (!INTP(o1)) error_bad_fixnum(o1);
-  if (!INTP(o2)) error_bad_fixnum(o2);
+      /* removing original STklos test:
+         if (!INTP(o1)) error_bad_fixnum(o1);
+         if (!INTP(o2)) error_bad_fixnum(o2); */
   {
     int n1 = INT_VAL(o1);
     int n2 = INT_VAL(o2);
@@ -168,6 +309,101 @@ DEFINE_PRIMITIVE("fxmod", fxmod, subr2, (SCM o1, SCM o2))
   }
 }
 
+DEFINE_PRIMITIVE("fxabs", fxabs, subr1, (SCM o1))
+{
+    /* removing original STklos test:
+       if (!INTP(o1)) error_bad_fixnum(o1); */
+  return MAKE_INT(abs(INT_VAL(o1)));
+}
+
+/*
+<doc EXT fxsquare fxsqrt
+ * (fxsquare fx1)
+ * (fxsqrt fx1)
+ *
+ * These procedures compute (respectively) the square and the square root
+ * of the fixnum |fx1|.
+ * |fxsqrt| id semantically equivalent to exact-integer-sqrt (not sqrt), so
+ * that |(fxsqrt n)| returns two values |a|, |b|, such that |a*a+b|=|n|.
+  * @lisp
+ *   (fxsqrt? #f)            =>  error
+ *   (fxdqrt? (expt 100 100) =>  error
+ *   (fxsqrt? -1)            =>  error
+ *   (fxsqrt? 0)             =>  0, 0
+ *   (fxsqrt? 1)             =>  1, 0
+ *   (fxsqrt? 6)             =>  2, 2
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxsquare", fxsquare, subr1, (SCM o1))
+{
+  return MAKE_INT(INT_VAL(o1) * INT_VAL(o1));
+}
+
+DEFINE_PRIMITIVE("fxsqrt", fxsqrt, subr1, (SCM o1))
+{
+  long no = INT_VAL(o1);
+  if (no < 0)   STk_error("non negative fixnum expected. It was: ~S", o1);
+  long n1 = (long) sqrt((float)no);
+  long n2 = no - (n1*n1);
+  return STk_n_values(2,
+                      MAKE_INT(n1),
+                      MAKE_INT(n2));
+}
+
+
+/*
+<doc  fxmax fxmin
+ * (fxmax fx1 fx2 ...)
+ * (fxmin fx1 fx2 ...)
+ *
+ * These procedures return the maximum or minimum of their fixnum arguments.
+ *
+ * @lisp
+ * (fxmax 3 4)              =>  4    
+ * (fxmax 3.9 4)            =>  error
+ * (fxmax)                  =>  error
+ * (fxmax 2 -1 3)           =>  3
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxmax", fxmax, vsubr, (int argc, SCM *argv))
+{
+    SCM res;
+    
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1)  return *argv;
+    
+    for (res = *argv--; --argc; argv--) {
+        /* Do not check that the argument is a correct number 
+           if (!INTP(*argv)) error_bad_fixnum(*argv); */
+
+        /* compute max */
+        if (INT_VAL(res) < INT_VAL(*argv)) res = *argv;
+    }
+    return res;
+}
+
+DEFINE_PRIMITIVE("fxmin", fxmin, vsubr, (int argc, SCM *argv))
+{
+    SCM res;
+    
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1) return *argv;
+    
+    for (res = *argv--; --argc; argv--) {
+        /* Do not check that the argument is a correct number 
+           if (!INTP(*argv)) error_bad_fixnum(*argv); */
+
+        /* compute max */
+        if (INT_VAL(res) > INT_VAL(*argv)) res = *argv;
+    }
+    return res;
+}
+
+
 /*
 <doc EXT fx< fx<= fx> fx>= fx=
  * (fx< fx1 fx2)
@@ -183,10 +419,9 @@ doc>
 #define SIMPLE_COMP(name, func, op) \
 DEFINE_PRIMITIVE(name, func, subr2, (SCM o1, SCM o2))           \
 {                                                               \
-  if (!INTP(o1)) error_bad_fixnum(o1);                          \
-  if (!INTP(o2)) error_bad_fixnum(o2);                          \
-  return MAKE_BOOLEAN(INT_VAL(o1) op INT_VAL(o2));              \
+    return MAKE_BOOLEAN(INT_VAL(o1) op INT_VAL(o2));            \
 }
+/* above: removed original STklos test */
 
 SIMPLE_COMP("fx<",  fxlt, <)
 SIMPLE_COMP("fx<=", fxle, <=)
@@ -195,6 +430,577 @@ SIMPLE_COMP("fx>=", fxge, >=)
 SIMPLE_COMP("fx=",  fxeq, ==)
 
 
+/*
+<doc EXT fx<? fx<=? fx>? fx>=? fx=?
+ * (fx<? fx1 fx2 ...)
+ * (fx<=? fx1 fx2 ...)
+ * (fx>? fx1 fx2 ...)
+ * (fx>=? fx1 fx2 ...)
+ * (fx=? fx1 fx2 ...)
+ *
+ * These are SRFI-143 procedures that compare the fixnums |fx1|, |fx2|, and so on.
+ * |fx<?| and |fx>?| return |#t| if the arguments are in strictly increasing/decreasing
+ * order;
+ * |fx<=?| and |fx>=?| do the same, but admit equal neighbors;
+ * |fx=?| returns |#t| if the arguments are all equal.
+doc>
+ */
+DEFINE_PRIMITIVE("fx<?", fxlt_, vsubr, (int argc, SCM *argv))
+{
+    SCM p;
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1) return *argv;
+        
+    for (p = *argv--; --argc; p=*argv,argv--) {
+        /* Do NOT check that the argument is a correct number
+           if (!INTP(*argv)) error_bad_fixnum(*argv);*/
+        
+        /* compute  */
+        if (INT_VAL(p) >= INT_VAL(*argv)) return STk_false;
+    }
+    return STk_true;
+}
+
+DEFINE_PRIMITIVE("fx<=?", fxle_, vsubr, (int argc, SCM *argv))
+{
+    SCM p;
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1) return *argv;
+    
+    
+    for (p = *argv--; --argc; p=*argv,argv--) {
+        /* Do NOT check that the argument is a correct number
+           if (!INTP(*argv)) error_bad_fixnum(*argv);*/
+
+        /* compute  */
+        if (INT_VAL(p) > INT_VAL(*argv)) return STk_false;
+    }
+    return STk_true;
+}
+
+
+DEFINE_PRIMITIVE("fx>?", fxgt_, vsubr, (int argc, SCM *argv))
+{
+    SCM p;
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1)  return *argv;
+    
+    for (p = *argv--; --argc; p=*argv,argv--) {
+        /* Do NOT check that the argument is a correct number
+           if (!INTP(*argv)) error_bad_fixnum(*argv);*/
+
+        /* compute  */
+        if (INT_VAL(p) <= INT_VAL(*argv)) return STk_false;
+    }
+    return STk_true;
+}
+
+DEFINE_PRIMITIVE("fx>=?", fxge_, vsubr, (int argc, SCM *argv))
+{
+    SCM p;
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1) {
+        if (!INTP(*argv)) error_bad_fixnum(*argv);
+        return *argv;
+    }
+    
+    for (p = *argv--; --argc; p=*argv,argv--) {
+        /* Do NOT check that the argument is a correct number
+           if (!INTP(*argv)) error_bad_fixnum(*argv);*/
+
+        /* compute  */
+        if (INT_VAL(p) < INT_VAL(*argv)) return STk_false;
+    }
+    return STk_true;
+}
+
+DEFINE_PRIMITIVE("fx=?", fxeq_, vsubr, (int argc, SCM *argv))
+{
+    SCM p;
+    if (argc == 0) error_fx_at_least_1();
+    
+    if (argc == 1) return *argv;
+    
+    for (p = *argv--; --argc; p=*argv,argv--) {
+        /* Do NOT check that the argument is a correct number
+           if (!INTP(*argv)) error_bad_fixnum(*argv);*/
+
+        /* compute  */
+        if (INT_VAL(p) != INT_VAL(*argv)) return STk_false;
+    }
+    return STk_true;
+}
+
+DEFINE_PRIMITIVE("fxneg", fxneg, subr1, (SCM o1))
+{
+   return MAKE_INT(-INT_VAL(o1));
+}
+
+
+
+/*
+<doc EXT fxnot fxand fxior fxxor
+ * (fxnot fx1)
+ * (fxand fx1 fx2)
+ * (fxior fx1 fx2)
+ * (fxxor fx1 fx2)
+ *
+ * These procedures are specified in SRFI-143, and they return
+ * (respectively) the bitwise not, and, inclusive or and exclusive
+ * or of their arguments, which must be fixnums.
+ * @lisp
+ * (fxnot 1)              => -2
+ * (fxnot 0)              => -1
+ * (fxand #x1010 #x1011)  => 4112  ; = #x1010
+ * (fxior #x1010 #x1011)  => 4113  ; = #x1011
+ * (fxxor #x1010 #x1011)  => 1     ; = #x0001
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxnot", fxnot, subr1, (SCM o1))
+{
+  return MAKE_INT(~INT_VAL(o1));
+}
+
+DEFINE_PRIMITIVE("fxand", fxand, subr2, (SCM o1, SCM o2))
+{
+  return MAKE_INT(INT_VAL(o1) & INT_VAL(o2));
+}
+
+DEFINE_PRIMITIVE("fxior", fxior, subr2, (SCM o1, SCM o2))
+{
+  return MAKE_INT(INT_VAL(o1) | INT_VAL(o2));
+}
+
+DEFINE_PRIMITIVE("fxxor", fxxor, subr2, (SCM o1, SCM o2))
+{
+  return MAKE_INT(INT_VAL(o1) ^ INT_VAL(o2));
+}
+
+/*
+<doc EXT fxarithmetic-shift-right fxarithmetic-shift-left fxarithmetic-shift
+ * (fxarithmetic-shift-right fx count)
+ * (fxarithmetic-shift-left fx count)
+ * (fxarithmetic-shift fx count)
+ *
+ * These procedures are specified in SRFI-143, and they perform
+ * bitwise right-shift, left-shft and shift with arbitrary direction
+ * on fixnums. The strictly left and right shifts are more efficient.
+ * @lisp
+ * (fxarithmetic-shift-right #b100110 3) =>   4 ; = #b100
+ * (fxarithmetic-shift-left  #b100110 3) => 304 ; = #b100110000
+ * (fxarithmetic-shift #b101 2)          => 20  ; = #b10100
+ * (fxarithmetic-shift #b101 -2)         =>  1  ; =#b1
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxarithmetic-shift-right", fxarithmetic_shiftr, subr2, (SCM o1, SCM o2))
+{
+  if (!INTP(o2)) error_bad_fixnum(o2);
+  long k = INT_VAL(o2);
+  if (k>=0)
+      return MAKE_INT( INT_VAL(o1) >> k );
+  error_negative_fixnum(o2);
+  return STk_false; /* should never get here */
+}
+
+DEFINE_PRIMITIVE("fxarithmetic-shift-left", fxarithmetic_shiftl, subr2, (SCM o1, SCM o2))
+{
+  if (!INTP(o2)) error_bad_fixnum(o2);
+  long k = INT_VAL(o2);
+  if (k>=0)
+      return MAKE_INT( INT_VAL(o1) << k );
+  error_negative_fixnum(o2);
+  return STk_false; /* should never get here */
+}
+
+DEFINE_PRIMITIVE("fxarithmetic-shift", fxarithmetic_shift, subr2, (SCM o1, SCM o2))
+{
+  if (!INTP(o2)) error_bad_fixnum(o2);
+  long k = INT_VAL(o2);
+/*  if (abs(k) > INT_LENGTH) error_bad_fxlength(o2); */
+  if (k<0) return MAKE_INT( INT_VAL(o1) >> -k );
+  else     return MAKE_INT( INT_VAL(o1) << k );
+}
+
+/*
+<doc EXT fxlength
+ * (fxlength fx)
+ *
+ * This is a SRFI-143 procedure that returns the length of the fixnum in
+ * bits (that is, the number of bits necessary to represent the number).
+ * @lisp
+ * (fxlength #b101)          =>  3
+ * (fxlength #b1101)         =>  4
+ * (fxlength #b0101)         =>  3
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxlength", fxlength, subr1, (SCM o1))
+{
+  long n = INT_VAL(o1);
+  if (n == -1 || n == 0) return MAKE_INT(0);
+  if (n>0)  return MAKE_INT( (long) log2( (float) n) + 1 );
+  return MAKE_INT( (long) log2( (float) abs(n+1) ) + 1 ); /* n<-1 */
+}
+
+/*
+<doc EXT fxif
+ * (fxif mask fx1 fx2)
+ *
+ * This is a SRFI-143 procedure that merge the fixnum bitstrings |fx1| and |fx2|, with bitstring
+ * mask determining from which string to take each bit. That is, if the kth bit of mask
+ * is 1, then the kth bit of the result is the kth bit of |fx1|, otherwise the kth bit of
+ * |fx2|.
+ * @lisp
+ * (fxif 3 1 8)                            => 9
+ * (fxif 3 8 1)                            => 0
+ * (fxif 1 1 2)                            => 3
+ * (fxif #b00111100 #b11110000 #b00001111) => #b00110011
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxif", fxif, subr3, (SCM m, SCM o1, SCM o2))
+{
+  unsigned long mask = INT_VAL(m);
+  return MAKE_INT(  (  mask  & INT_VAL(o1))  |
+                    ((~mask) & INT_VAL(o2)));
+}
+
+/*
+<doc EXT fxbit-set?
+ * (fxbit-set? index fx)
+ *
+ * This is a SRFI-143 procedure that returns |#t| if the |index|-th bit of
+ * |fx|.
+ * @lisp
+ * (fxbit-set? 1 3)          => #t
+ * (fxbit-set? 2 7)          => #t
+ * (fxbit-set? 3 6)          => #f
+ * (fxbit-set? 5 #b00111100) => #t
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxbit-set?", fxbit_setp, subr2, (SCM o1, SCM o2))
+{
+/* don't check arguments
+   if (!INTP(o1)) error_bad_fixnum(o1);
+   if (!INTP(o2)) error_bad_fixnum(o2); 
+   if (INT_VAL(o1) > INT_LENGTH-1) error_bad_fixnum(o1);
+   if (INT_VAL(o1) < 0) error_negative_fixnum(); */
+  return MAKE_BOOLEAN(  (1 << INT_VAL(o1)) & INT_VAL(o2) );
+}
+
+/*
+<doc EXT fxcopy-bit
+ * (fxcopy-bit index fx value)
+ *
+ * This is a SRFI-143 procedure that sets the |index|-th bit if |fx|
+ * to one if |value| is |#t|, and to zero if |value| is |#f|.
+ * @lisp
+ * (fxcopy-bit 2 3 #t)          =>  7
+ * (fxcopy-bit 2 7 #f)          =>  3
+ * (fxcopy-bit 5 #b00111100 #f) => 28 ; = #b00011100
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxcopy-bit", fxcopy_bit, subr3, (SCM o1, SCM o2, SCM o3))
+{
+/* don't check arguments
+   if (!INTP(o1)) error_bad_fixnum(o1);
+   if (!INTP(o2)) error_bad_fixnum(o2); 
+   if (!BOOLEANP(o3)) error_bad_boolean(o3); */
+/*  if (INT_VAL(o1)>INT_LENGTH -1) error_bad_fixnum(o1); */
+  unsigned long mask = 1 << INT_VAL(o1);
+  if (o3==STk_true) return MAKE_INT( INT_VAL(o2) | mask);
+  else              return MAKE_INT( INT_VAL(o2) & (~mask) );
+}
+
+
+/*
+<doc EXT fxbit-count
+ * (fxbit-count fx1)
+ *
+ * This is a SRFI-143 procedure that returns the quantity of bits equal to one in
+ * the fixnum |fx| (that is, computes its Hamming weight).
+ * @lisp
+ * (fxbit-count 8)                         => 1
+ * (fxbit-count 3)                         => 2
+ * (fxbit-count 7)                         => 3
+ * (fxbit-count #b00111010)                => 4
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxbit-count", fxbit_count, subr1, (SCM o1))
+/* TODO: Someewhat efficient, but there is a better way, described
+   in "Hacker's Delight", but it needs to be adapted to the
+   variable length datum. */
+{
+  long n = INT_VAL(o1);
+  int total=0;
+  for (int i=0; i< INT_LENGTH; i++, n=n>> 1)
+      if ( n & 1 )
+          total++;
+  return MAKE_INT(total);
+}
+
+/*
+<doc EXT fxfirst-set-bit
+ * (fxfirst-set-bit fx1)
+ *
+ * This is a SRFI-143 procedure that returns the index of the first (smallest index)
+ * 1 bit in bitstring |fx|. Returns -1 if |fx| contains no 1 bits (i.e., if |fx|
+ * is zero). 
+ * @lisp
+ * (fxfirst-set-bit  8)                         => 3
+ * (fxfirst-set-bit  3)                         => 0
+ * (fxfirst-set-bit  7)                         => 0
+ * (fxfirst-set-bit  #b10110000)                => 4
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxfirst-set-bit", fxfirst_set_bit, subr1, (SCM o1))
+{
+  unsigned long n = INT_VAL(o1);
+  for (int i=0; i< INT_LENGTH; i++, n=n>> 1)
+      if ( n & 1 )
+          return MAKE_INT(i);
+  return MAKE_INT(-1);
+}
+
+/*
+<doc EXT fxbit-field
+ * (fxbit-field fx1 start end)
+ *
+ * This is a SRFI-143 procedure that extracts a bit field from the fixnum |fx1|.
+ * The bit field is the sequence of bits between |start| (including) and |end|
+ * (excluding)
+ * @lisp
+ * (fxbit-field  #b10110000 3 5)  => 6 ; = #b110
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxbit-field", fxbit_field, subr3, (SCM o1, SCM o2, SCM o3))
+{
+    int start = INT_VAL(o2);
+    int end = INT_VAL(o3);
+    unsigned long n = INT_VAL(o1);
+    int leftshift = INT_LENGTH +2 -end;
+    n = (n << leftshift) >> (leftshift+start);
+    return MAKE_INT(n);
+}
+
+
+/*
+<doc EXT fxbit-field-rotate
+ * (fxbit-field-rotate fx)
+ *
+ * This is a SRFI-143 procedure that returns fx with the field cyclically permuted by count bits towards high-order. 
+ * @lisp
+ * (fxbit-field-rotate #b101011100 -2 1 5)     => 342  = #b101010110
+ * (fxbit-field-rotate #b101011011110 -3 2 10) => 3034 = #b101111011010
+ * (fxbit-field-rotate #b101011011110 3 2 10)  => 2806 = #b101011110110
+ * 
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxbit-field-rotate", fxbit_field_rotate, subr4, (SCM o1, SCM o2, SCM o3, SCM o4))
+{
+    int count = INT_VAL(o2);
+    int start = INT_VAL(o3);
+    int end = INT_VAL(o4);
+    unsigned long n = INT_VAL(o1);
+
+    unsigned long start_mask = (1 << start);
+    unsigned long last_mask  = (1 << (end-1));
+
+    if (count < 0) {
+        for (int j=0; j<-count; j++) {
+            
+            /* single rotation to RIGHT: */
+            unsigned long start_bit = n & start_mask; /* save start-th bit of n */
+            for (int i=start; i<end-1; i++)
+                n = (n & (~(1 << i))) /* set ith-bit to zero */
+                    | ( (n & (1 << (i+1)) ) >> 1); /* now OR it with i+1-th bit, shifted down */
+            
+            n = (n & ~last_mask)
+                | (start_bit << (end-start-1));
+        }
+    } else if (count > 0) {
+        for (int j=0; j < count; j++) {
+            
+            /* single rotation to LEFT: */
+            unsigned long end_bit = n & last_mask; /* save start-th bit of n */
+            for (int i=end-1; i>start; i--)
+                n = (n & (~(1 << i))) /* set ith-bit to zero */
+                    | ( (n & (1 << (i-1)) ) << 1); /* now OR it with i-1-th bit, shifted up */
+
+            n = (n & ~start_mask)
+                | (end_bit >> (end-start-1));
+        }
+    } else return o1;
+        
+    return MAKE_INT((long)n);
+}
+
+
+/*
+  This is a helper function for the fx../carry functions. It is
+  similar to balanced/ from SRFI-141, but works on long integers.
+ */
+inline static
+void fxbalanced_div (long *qq, long *rr, long x, long y)
+{
+    if (y==0) error_division_by_0();
+    ldiv_t qr = ldiv(x,y);
+    long q = qr.quot;
+    long r = qr.rem;
+    
+    if (x >= 0) {
+        if (y > 0) {
+            if (2*r >= y) {
+                *qq = (q+1);
+                *rr = r-y;
+            }
+            else {
+                *qq = q;
+                *rr = r;
+            }
+        } else { /* y <= 0 */
+            if (2*r >= -y) {
+                *qq = q-1;
+                *rr = r+y;
+            } else {
+                *qq = q;
+                *rr = r;
+            }
+        }
+    } else { /* x < 0 */
+        if (y > 0) {
+            if (2*r < -y) {
+                *qq = q-1;
+                *rr = r+y;
+            } else {
+                *qq = q;
+                *rr = r;
+            }
+        } else { /* y <= 0 */
+            if (2*r < y) {
+                *qq = q+1;
+                *rr = r-y;
+            } else {
+                *qq = q;
+                *rr = r;
+            }
+        }
+    }
+}
+
+
+
+/*
+<doc EXT fx+/carry
+ * (fx+/carry i j k)
+ *
+ * Returns two values: |i|+|j|+|k|, and carry: it is the value of the computation
+ * (let*-values (((s) (+ i j k))
+ *        ((q r) (balanced/ s (expt 2 fx-width))))
+ *   (values r q))
+doc>
+*/
+DEFINE_PRIMITIVE("fx+/carry", fxsum_carry, subr3, (SCM o1, SCM o2, SCM o3))
+{
+    long s = INT_VAL(o1) + INT_VAL(o2) + INT_VAL(o3);
+    long e = exp_2_fxwidth();
+    long q;
+    long r;
+    fxbalanced_div (&q,&r,s,e);
+    STk_n_values(2, MAKE_INT(r), MAKE_INT(q));
+}
+
+/*
+<doc EXT fx-/carry
+ * (fx-/carry i j k)
+ *
+ * Returns two values: |i|-|j|-|k|, and carry: it is the value of the computation
+ * (let*-values (((s) (- i j k))
+ *        ((q r) (balanced/ s (expt 2 fx-width))))
+ *   (values r q))
+doc>
+*/
+DEFINE_PRIMITIVE("fx-/carry", fxminus_carry, subr3, (SCM o1, SCM o2, SCM o3)) 
+{ 
+    long d = INT_VAL(o1) - INT_VAL(o2) - INT_VAL(o3); 
+    long e = exp_2_fxwidth();
+    long q;
+    long r;
+    fxbalanced_div (&q,&r,d,e);
+    STk_n_values(2, MAKE_INT(r), MAKE_INT(q));
+}
+
+/*
+<doc EXT fx{*}/carry
+ * (fx{*}/carry i j k)
+ *
+ * Returns two values: |i|-|j|-|k|, and carry: it is the value of the computation
+ * (let*-values (((s) (+ (* i j) k))
+ *        ((q r) (balanced/ s (expt 2 fx-width))))
+ *   (values r q))
+doc>
+*/
+DEFINE_PRIMITIVE("fx*/carry", fxmul_carry, subr3, (SCM o1, SCM o2, SCM o3))
+{
+    long s = INT_VAL(o1) * INT_VAL(o2) + INT_VAL(o3);
+    long e = exp_2_fxwidth();
+    long q;
+    long r;
+    fxbalanced_div (&q,&r,s,e);
+    STk_n_values(2, MAKE_INT(r), MAKE_INT(q));
+}
+
+
+/*
+<doc EXT fxbit-field-reverse
+ * (fxbit-field-reverse fx)
+ *
+ * This is a SRFI-143 procedure that returns fx with the order of the bits in the field reversed.
+ * @lisp
+ * (fxbit-field-reverse #b101011100 1 5)     => #b101001110
+ * (fxbit-field-reverse #b101011011110 2 10) => #b101110110110
+ * 
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("fxbit-field-reverse", fxbit_field_reverse, subr3, (SCM o1, SCM o2, SCM o3))
+{
+    int start = INT_VAL(o2);
+    int end = INT_VAL(o3);
+    unsigned long n = INT_VAL(o1);
+    int size = end-start;
+
+    for (int i=0; i < size/2; i++) {
+        long mask_left  = 1<<(start+i);
+        long mask_right = 1<<(start+size-i-1);
+        long left = n & mask_left;
+        long right= n & mask_right;
+        
+        if (left)
+            n = n | mask_right;
+        else
+            n = n & (~mask_right);
+        
+        if (right)
+            n = n | mask_left;
+        else
+            n = n & (~mask_left);
+    }
+    return MAKE_INT(n);
+}
+
 int STk_init_fixnum(void)
 {
   ADD_PRIMITIVE(fixnump);
@@ -202,19 +1008,58 @@ int STk_init_fixnum(void)
   ADD_PRIMITIVE(least_fixnum);
   ADD_PRIMITIVE(greatest_fixnum);
 
+  ADD_PRIMITIVE(fxzerop);
+  ADD_PRIMITIVE(fxpositivep);
+  ADD_PRIMITIVE(fxnegativep);
+  ADD_PRIMITIVE(fxoddp);
+  ADD_PRIMITIVE(fxevenp);
 
   ADD_PRIMITIVE(fxplus);
   ADD_PRIMITIVE(fxminus);
   ADD_PRIMITIVE(fxtime);
   ADD_PRIMITIVE(fxdiv);
+  ADD_PRIMITIVE(fxneg);
   ADD_PRIMITIVE(fxmod);
   ADD_PRIMITIVE(fxrem);
+  ADD_PRIMITIVE(fxabs);
+  ADD_PRIMITIVE(fxsquare);
+  ADD_PRIMITIVE(fxsqrt);
+  
+  ADD_PRIMITIVE(fxmax);
+  ADD_PRIMITIVE(fxmin);
 
   ADD_PRIMITIVE(fxlt);
   ADD_PRIMITIVE(fxle);
   ADD_PRIMITIVE(fxgt);
   ADD_PRIMITIVE(fxge);
   ADD_PRIMITIVE(fxeq);
+
+  ADD_PRIMITIVE(fxlt_);
+  ADD_PRIMITIVE(fxle_);
+  ADD_PRIMITIVE(fxgt_);
+  ADD_PRIMITIVE(fxge_);
+  ADD_PRIMITIVE(fxeq_);
+
+  ADD_PRIMITIVE(fxnot);
+  ADD_PRIMITIVE(fxand);
+  ADD_PRIMITIVE(fxior);
+  ADD_PRIMITIVE(fxxor);
+  ADD_PRIMITIVE(fxarithmetic_shift);
+  ADD_PRIMITIVE(fxarithmetic_shiftr);
+  ADD_PRIMITIVE(fxarithmetic_shiftl);
+  ADD_PRIMITIVE(fxbit_count);
+  ADD_PRIMITIVE(fxlength);
+  ADD_PRIMITIVE(fxif);
+  ADD_PRIMITIVE(fxbit_setp);
+  ADD_PRIMITIVE(fxcopy_bit);
+  ADD_PRIMITIVE(fxfirst_set_bit);
+  ADD_PRIMITIVE(fxbit_field);
+  ADD_PRIMITIVE(fxbit_field_rotate);
+  ADD_PRIMITIVE(fxbit_field_reverse);
+
+  ADD_PRIMITIVE(fxsum_carry);
+  ADD_PRIMITIVE(fxminus_carry);
+  ADD_PRIMITIVE(fxmul_carry);
 
   return TRUE;
 }

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -720,7 +720,8 @@ int STk_init_misc(void);
 #define MAKE_INT(n)     (AS_SCM(SCM_LONG(n)))
 #define INT_MIN_VAL     ((LONG_MIN & ~3) >> 2)
 #define INT_MAX_VAL     ((LONG_MAX & ~3) >> 2)
-
+#define INT_LENGTH      (sizeof(long) * 8 - 2)
+    
 long STk_integer_value(SCM x); /* Returns LONG_MIN if not representable as long */
 unsigned long STk_uinteger_value(SCM x); /* Returns ULONG_MAX if not an ulong */
 

--- a/tests/srfis/143.stk
+++ b/tests/srfis/143.stk
@@ -1,0 +1,226 @@
+;; ----------------------------------------------------------------------
+;;  SRFI 143...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 143 - fixnums")
+
+(test "fixnum? 1" #t (fixnum? 32767))
+(test "fixnum? 2" #f (fixnum? 1.1))
+
+(test "fx=? 1" #t (fx=? 1 1 1))
+(test "fx=? 2" #f (fx=? 1 2 2))
+(test "fx=? 3" #f (fx=? 1 1 2))
+(test "fx=? 4" #f (fx=? 1 2 3))
+
+(test "fx<? 1" #t (fx<? 1 2 3))
+(test "fx<? 2" #f (fx<? 1 1 2))
+(test "fx>? 1" #t (fx>? 3 2 1))
+(test "fx>? 2" #f (fx>? 2 1 1))
+(test "fx<=? 1" #t (fx<=? 1 1 2))
+(test "fx<=? 2" #f (fx<=? 1 2 1))
+(test "fx>=? 1" #t (fx>=? 2 1 1))
+(test "fx>=? 2" #f (fx>=? 1 2 1))
+(test "fx<=? 3" '(#t #f) (list (fx<=? 1 1 2) (fx<=? 2 1 3)))
+
+(test "fxzero? 1" #t (fxzero? 0))
+(test "fxzero? 2" #f (fxzero? 1))
+
+(test "fxpositive? 1" #f (fxpositive? 0))
+(test "fxpositive? 2" #t (fxpositive? 1))
+(test "fxpositive? 3" #f (fxpositive? -1))
+
+(test "fxnegative? 1" #f (fxnegative? 0))
+(test "fxnegative? 2" #f (fxnegative? 1))
+(test "fxnegative? 3" #t (fxnegative? -1))
+
+(test "fxodd? 1" #f (fxodd? 0))
+(test "fxodd? 2" #t (fxodd? 1))
+(test "fxodd? 3" #t (fxodd? -1))
+(test "fxodd? 4" #f (fxodd? 102))
+
+(test "fxeven? 1" #t (fxeven? 0))
+(test "fxeven? 2" #f (fxeven? 1))
+(test "fxeven? 3" #t (fxeven? -2))
+(test "fxeven? 4" #t (fxeven? 102))
+
+(test "fxmax 1" 4 (fxmax 3 4))
+(test "fxmax 2" 5 (fxmax 3 5 4))
+(test "fxmin 1" 3 (fxmin 3 4))
+(test "fxmin 2" 3 (fxmin 3 5 4))
+
+(test "fx+" 7 (fx+ 3 4))
+(test "fx*" 12 (fx* 4 3))
+
+(test "fx-" -1 (fx- 3 4))
+(test "fxneg" -3 (fxneg 3))
+
+(test "fxabs" 7 (fxabs -7))
+(test "fxabs" 7 (fxabs 7))
+
+(test "fxsquare 1" 1764 (fxsquare 42))
+(test "fxsquare 2"    4 (fxsquare 2))
+
+(test "fxquotient 1"  2 (fxquotient 5 2))
+(test "fxquotient 2" -2 (fxquotient -5 2))
+(test "fxquotient 3" -2 (fxquotient 5 -2))
+(test "fxquotient 4"  2 (fxquotient -5 -2))
+
+(test "fxremainder 1"  1 (fxremainder 13 4))
+(test "fxremainder 2" -1 (fxremainder -13 4))
+(test "fxremainder 3"  1 (fxremainder 13 -4))
+(test "fxremainder 4" -1 (fxremainder -13 -4))
+
+(let*-values (((root rem) (fxsqrt 32)))
+  (test "fxsqrt" 35 (* root rem)))
+
+(test "test-1" -1 (fxnot 0))
+(test "test-2" 0 (fxand #b0 #b1))
+(test "test-115" 6 (fxand 14 6))
+(test "test-117" 14 (fxior 10 12))
+(test "test-119" 6 (fxxor 10 12))
+(test "test-122" 0 (fxnot -1))
+(test "test-125" 9 (fxif 3 1 8))
+(test "test-126" 0 (fxif 3 8 1))
+(test "test-135" 2 (fxbit-count 12))
+(test "test-137" 0 (fxlength 0))
+(test "test-138" 8 (fxlength 128))
+(test "test-139" 8 (fxlength 255))
+(test "test-140" 9 (fxlength 256))
+(test "test-141" -1 (fxfirst-set-bit 0))
+(test "test-142" 0 (fxfirst-set-bit 1))
+(test "test-143" 0 (fxfirst-set-bit 3))
+(test "test-144" 2 (fxfirst-set-bit 4))
+(test "test-145" 1 (fxfirst-set-bit 6))
+(test "test-146" 0 (fxfirst-set-bit -1))
+(test "test-147" 1 (fxfirst-set-bit -2))
+(test "test-148" 0 (fxfirst-set-bit -3))
+(test "test-149" 2 (fxfirst-set-bit -4))
+(test "test-160" #t (fxbit-set? 0 1))
+(test "test-161" #f (fxbit-set? 1 1))
+(test "test-162" #f (fxbit-set? 1 8))
+
+;;
+;; The following do not seem to be correct:
+;; (test "test-163" #t (fxbit-set? 10000 -1))
+;; (test "test-167" #t (fxbit-set? 1000 -1))
+;;
+;; Theoretically, they'd be correct, considering negative numbers
+;; reprsented as 2's complement, but in practice we can't do
+;; x << HUGE_VALUE -- compilers do not like that, so we'd need to
+;; do a somewhat slow operation to break the shift in smaller
+;; shifts, etc... But:
+;; SRFI-143 specifically says the index should not be larger than
+;; the fixnum width, so one cannot expect any specific value
+;; from the predicate when used like that.
+;;
+;; The tests pass on x86_64, but fails on ARM 32 bits.
+;;
+
+(test "test-168" 0 (fxcopy-bit 0 0 #f))
+(test "test-174" -1 (fxcopy-bit 0 -1 #t))
+(test "test-180" 1 (fxcopy-bit 0 0 #t))
+(test "test-181" #x106 (fxcopy-bit 8 6 #t))
+(test "test-182" 6 (fxcopy-bit 8 6 #f))
+(test "test-183" -2 (fxcopy-bit 0 -1 #f))
+(test "test-189" 0 (fxbit-field 6 0 1))
+(test "test-190" 3 (fxbit-field 6 1 3))
+(test "test-196" 2 (fxarithmetic-shift 1 1))
+(test "test-197" 0 (fxarithmetic-shift 1 -1))
+(test "test-200" #b110  (fxbit-field-rotate #b110 1 1 2))
+(test "test-201" #b1010 (fxbit-field-rotate #b110 1 2 4))
+(test "test-202" #b1011 (fxbit-field-rotate #b0111 -1 1 4))
+(test "test-208" #b110 (fxbit-field-rotate #b110 0 0 10))
+(test "test-211" 6 (fxbit-field-reverse 6 1 3))
+(test "test-212" 12 (fxbit-field-reverse 6 1 4))
+(test "test-248" -11 (fxnot 10))
+(test "test-249" 36 (fxnot -37))
+(test "test-250" 11 (fxior 3  10))
+(test "test-251" 10 (fxand 11 26))
+(test "test-252" 9 (fxxor 3 10))
+(test "test-254" 4 (fxand 37 12))
+(test "test-255" 32 (fxarithmetic-shift 8 2))
+(test "test-256" 4 (fxarithmetic-shift 4 0))
+(test "test-257" 4 (fxarithmetic-shift 8 -1))
+(test "test-263" 0 (fxlength  0))
+(test "test-264" 1 (fxlength  1))
+(test "test-265" 0 (fxlength -1))
+(test "test-266" 3 (fxlength  7))
+(test "test-267" 3 (fxlength -7))
+(test "test-268" 4 (fxlength  8))
+(test "test-269" 3 (fxlength -8))
+(test "test-272" #t (fxbit-set? 3 10))
+(test "test-273" #t (fxbit-set? 2 6))
+(test "test-274" #f (fxbit-set? 0 6))
+(test "test-276" #b100 (fxcopy-bit 2 0 #t))
+(test "test-277" #b1011 (fxcopy-bit 2 #b1111 #f))
+(test "test-280" 1 (fxfirst-set-bit 2))
+(test "test-282" 3 (fxfirst-set-bit 40))
+(test "test-283" 2 (fxfirst-set-bit -28))
+(test "test-288" 1 (fxand #b1 #b1))
+(test "test-289" 0 (fxand #b1 #b10))
+(test "test-290" #b10 (fxand #b11 #b10))
+(test "test-291" #b101 (fxand #b101 #b111))
+(test "test-292" #b111 (fxand -1 #b111))
+(test "test-293" #b110 (fxand -2 #b111))
+(test "test-331" 1 (fxarithmetic-shift 1 0))
+(test "test-333" 4 (fxarithmetic-shift 1 2))
+(test "test-334" 8 (fxarithmetic-shift 1 3))
+(test "test-335" 16 (fxarithmetic-shift 1 4))
+(test "test-346" -1 (fxarithmetic-shift -1 0))
+(test "test-347" -2 (fxarithmetic-shift -1 1))
+(test "test-348" -4 (fxarithmetic-shift -1 2))
+(test "test-349" -8 (fxarithmetic-shift -1 3))
+(test "test-350" -16 (fxarithmetic-shift -1 4))
+(test "test-363" #b1010 (fxbit-field #b1101101010 0 4))
+(test "test-364" #b101101 (fxbit-field #b1101101010 3 9))
+(test "test-365" #b10110 (fxbit-field #b1101101010 4 9))
+(test "test-366" #b110110 (fxbit-field #b1101101010 4 10))
+(test "test-373" 3 (fxif 1 1 2))
+(test "test-378" #b00110011 (fxif #b00111100 #b11110000 #b00001111))
+(test "test-379" #b1 (fxcopy-bit 0 0 #t))
+
+;; Extra tests for the tricky bit-field juggling functions:
+
+(test "rotate 1"
+      #b101010110
+      (fxbit-field-rotate #b101011100 -2 1 5))
+(test "rotate 2"
+      #b101111011010
+      (fxbit-field-rotate #b101011011110 -3 2 10))
+(test "rotate 3"
+      #b101011110110
+      (fxbit-field-rotate #b101011011110 3 2 10))
+
+(test "reverse 1"
+      #b101001110
+      (fxbit-field-reverse #b101011100 1 5))
+(test "reverse 2"
+      #b101110110110
+      (fxbit-field-reverse #b101011011110 2 10))
+
+
+;; simple test:
+
+(test "fixnum width"
+      #t
+      (= fx-width (fixnum-width)))
+
+(test "width and greatest fixnum"
+      #t
+      (= fx-greatest (- (expt 2 (- fx-width 1))  1)))
+
+(test "is greatest-fixnum a fixnum?"
+      #t
+      (fixnum? fx-greatest))
+
+(test "is greatest-fixnum +1 a fixnum?"
+      #f
+      (fixnum? (+ fx-greatest 1)))
+
+(test "is greatest-fixnum a fixnum?"
+      #t
+      (fixnum? fx-least))
+
+(test "is least-fixnum -1 a fixnum?"
+      #f
+      (fixnum? (- fx-least 1)))
+


### PR DESCRIPTION
Hello @egallesio !

This is a pull request, but consider it also a question: how do you feel about unsafe optimizations for fixnums (and possibly flonums later)?
I have implemnted SRFI-143 (fixnums), fully -- including the "/carry" procedures.
Now, the SRFI mentions that implementations can -- if they want -- skip type checks for these procedures, in order to run faster. 

So, I have ran one simple loop in three different ways:

1. using standard Scheme procedures
2. using fx... procedures as they are currently implemented in STklos
3. using fx... procedures without type checks

The loop is this:
```
(define n 100_000_000)  ;; look, there are underscores in the numbers ! :)

(define (sum n)
  (let ((s 0))
    (dotimes (i n)
      (set! s (- (+ (- s) (* 2 i)) 5)))
    s))

(define (fxsum n)
  (let ((s 0))
    (dotimes (i n)
      (set! s (fx- (fx+ (fxneg s) (fx* 2 i)) 5)))
    s))

(begin (print "SUM")
       (time (sum n))
       (print "FXSUM")
       (time (fxsum n)))
```

In the interpreter,
```
generic int ==> 16s
fx, type checked ==> 12s
fx, not type checked ==> 11s
```

Compiled with `stklos-compile`:
```
generic int ==> 14s
fx, type checked ==> 11s
fx, not type checked ==> 10s
```

It's not a real benchmark, I know... It only hints at the relevance of those type checks.

What do you think? Right now this pull request removes the type checks on `fx` procedures, but I can quickly rework it so the procedures are all type checked. Or, if you don't think it's ok to change the current fixnum code, I'm fine if you don't accept it.

About the pull request:

* it introduces `INT_LENGTH` in `stklos.h`, since the length of fixnums is used a few times in the code;
* includes `stdlib.h` and `math.h` in `fixnum.c`, because these are needed in a few places for SRFI-143
* introduces the inline, static `exp_2_fxwidth` function, which returns the highest power of 2 representable as fixnum (also used a couple of times)
* includes an inline, static helper function for division with carry
* includes a couple of new error functions for fixnums
* passes all tests for the reference implementation (although no code is shared with it)
*I'm not sure how to work the documentation in this case -- there's no Scheme file like `srfi-143.stk`; it's all in `fixnum.c`, `stklos.h` and `boot.stk`...
The rest is probably what you'd expect for fixnum code, I suppose.