### PR TITLE
Add SRFI-128 - Comparators (reduced)

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -65,7 +65,8 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-111: Boxes
     - SRFI-112: Environment Inquiry
     - SRFI-117: Queues based on lists
-    - SRFI-118: Simple adjustable-size strings 
+    - SRFI-118: Simple adjustable-size strings
+    - SRFI-128: Comparators (reduced)
     - SRFI-129: Titlecase procedures
     - SRFI-141: Integer Division
     - SRFI-145: Assumptions

--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -631,6 +631,9 @@ described in this document (procedures
 ;; SRFI 118 -- Simple adjustable-size strings 
 (gen-embedded-srfi 118)
 
+;; SRFI 128 -- Comparators (reduced)
+(gen-loaded-srfi 128)
+
 ;; SRFI 129 -- Titlecase Procedures
 (gen-loaded-srfi 129)
 

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -77,6 +77,7 @@
      (112 . "Environment Inquiry")
      (117 . "Queues based on lists")
      (118 . "Simple adjustable-size strings ")
+     (128 . "Comparators (reduced)")
      (129 . "Titlecase procedures")
      (141 . "Integer Division")
      (145 . "Assumptions")

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -88,6 +88,7 @@ SRC_STK = STklos.init     \
           srfi-96.stk         \
           srfi-100.stk        \
           srfi-117.stk        \
+          srfi-128.stk        \
           srfi-129.stk        \
           srfi-141.stk        \
           srfi-151.stk        \
@@ -151,6 +152,7 @@ scheme_OBJS = compfile.ostk    \
           srfi-96.ostk         \
           srfi-100.ostk        \
           srfi-117.ostk        \
+          srfi-128.ostk        \
           srfi-129.ostk        \
           srfi-141.ostk        \
           srfi-151.ostk        \

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -185,7 +185,8 @@
     ;; srfi-125                         ; Intermediate hash tables
     ;; srfi-126                         ; R6RS-based hashtables
     ;; srfi-127                         ; Lazy Sequences
-    ;; srfi-128                         ; Comparators (reduced)
+    ((srfi-128 comparators-reduced) "srfi-128")
+                                        ; Comparators (reduced)
     ((srfi-129 titlecase) "srfi-129")   ; Titlecase procedures
     ;; srfi-130                         ; Cursor-based string library
     ;; srfi-131                         ; ERR5RS Record Syntax (reduced)

--- a/lib/srfi-128.stk
+++ b/lib/srfi-128.stk
@@ -1,0 +1,550 @@
+;;;;
+;;;; srfi-113.stk		-- Implementation of SRFI-113
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by John Cowan, it is copyrighted as:
+;;;;
+;;;;;;  Copyright (c) 2015 John Cowan
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 08-Jul-2020 13:21 (jpellegrini)
+;;;; Last file update: 25-May-2020 20:11 (jpellegrini)
+;;;;
+
+(require "srfi-9")
+
+(define-module SRFI-128
+  (export
+   comparator? comparator-ordered? comparator-hashable?
+   make-comparator
+   make-pair-comparator make-list-comparator make-vector-comparator
+   make-eq-comparator make-eqv-comparator make-equal-comparator
+   boolean-hash char-hash char-ci-hash
+   string-hash string-ci-hash symbol-hash number-hash
+   make-default-comparator default-hash comparator-register-default!
+   comparator-type-test-predicate comparator-equality-predicate
+   comparator-ordering-predicate comparator-hash-function
+   comparator-test-type comparator-check-type comparator-hash
+   hash-bound hash-salt
+   =? <? >? <=? >=?
+   comparator-if<=>
+   ;; need to export %salt, otherwise (hash-salt) won't work:
+   %salt%)
+
+  
+;;;; Main part of the SRFI 114 reference implementation
+
+;;; "There are two ways of constructing a software design: One way is to
+;;; make it so simple that there are obviously no deficiencies, and the
+;;; other way is to make it so complicated that there are no *obvious*
+;;; deficiencies." --Tony Hoare
+
+;;; Syntax (because syntax must be defined before it is used, contra Dr. Hardcase)
+
+;; Arithmetic if
+  
+(define-syntax comparator-if<=>
+  (syntax-rules ()
+    ((if<=> a b less equal greater)
+     (comparator-if<=> (make-default-comparator) a b less equal greater))
+    ((comparator-if<=> comparator a b less equal greater)
+     (cond
+       ((=? comparator a b) equal)
+       ((<? comparator a b) less)
+       (else greater)))))
+
+;; Upper bound of hash functions is 2^25-1
+(define-syntax hash-bound
+  (syntax-rules ()
+    ((hash-bound) 33554432)))
+
+(define %salt% (make-parameter 16064047))
+
+(define-syntax hash-salt
+   (syntax-rules ()
+     ((hash-salt) (%salt%))))
+
+(define-syntax with-hash-salt
+  (syntax-rules ()
+    ((with-hash-salt new-salt hash-func obj)
+     (parameterize ((%salt% new-salt)) (hash-func obj)))))
+
+;;; Definition of comparator records with accessors and basic comparator
+
+(define-record-type comparator
+  (make-raw-comparator type-test equality ordering hash ordering? hash?)
+  comparator?
+  (type-test comparator-type-test-predicate)
+  (equality comparator-equality-predicate)
+  (ordering comparator-ordering-predicate)
+  (hash comparator-hash-function)
+  (ordering? comparator-ordered?)
+  (hash? comparator-hashable?))
+
+;; Public constructor
+(define (make-comparator type-test equality ordering hash)
+  (make-raw-comparator
+    (if (eq? type-test #t) (lambda (x) #t) type-test)
+    (if (eq? equality #t) (lambda (x y) (eqv? (ordering x y) 0)) equality)
+    (if ordering ordering (lambda (x y) (error "ordering not supported")))
+    (if hash hash (lambda (x y) (error "hashing not supported")))
+    (if ordering #t #f)
+    (if hash #t #f)))
+
+;;; Invokers
+
+;; Invoke the test type
+(define (comparator-test-type comparator obj)
+  ((comparator-type-test-predicate comparator) obj))
+
+;; Invoke the test type and throw an error if it fails
+(define (comparator-check-type comparator obj)
+  (if (comparator-test-type comparator obj)
+    #t
+    (error "comparator type check failed" comparator obj)))
+
+;; Invoke the hash function
+(define (comparator-hash comparator obj)
+  ((comparator-hash-function comparator) obj))
+
+;;; Comparison predicates
+
+;; Binary versions for internal use
+
+(define (binary=? comparator a b)
+  ((comparator-equality-predicate comparator) a b))
+
+(define (binary<? comparator a b)
+  ((comparator-ordering-predicate comparator) a b))
+
+(define (binary>? comparator a b)
+  (binary<? comparator b a))
+
+(define (binary<=? comparator a b)
+  (not (binary>? comparator a b)))
+
+(define (binary>=? comparator a b)
+  (not (binary<? comparator a b)))
+
+;; General versions for export
+
+(define (=? comparator a b . objs)
+  (let loop ((a a) (b b) (objs objs))
+    (and (binary=? comparator a b)
+	 (if (null? objs) #t (loop b (car objs) (cdr objs))))))
+
+(define (<? comparator a b . objs)
+  (let loop ((a a) (b b) (objs objs))
+    (and (binary<? comparator a b)
+	 (if (null? objs) #t (loop b (car objs) (cdr objs))))))
+
+(define (>? comparator a b . objs)
+  (let loop ((a a) (b b) (objs objs))
+    (and (binary>? comparator a b)
+	 (if (null? objs) #t (loop b (car objs) (cdr objs))))))
+
+(define (<=? comparator a b . objs)
+  (let loop ((a a) (b b) (objs objs))
+    (and (binary<=? comparator a b)
+	 (if (null? objs) #t (loop b (car objs) (cdr objs))))))
+
+(define (>=? comparator a b . objs)
+  (let loop ((a a) (b b) (objs objs))
+    (and (binary>=? comparator a b)
+	 (if (null? objs) #t (loop b (car objs) (cdr objs))))))
+
+
+;;; Simple ordering and hash functions
+
+(define (boolean<? a b)
+  ;; #f < #t but not otherwise
+  (and (not a) b))
+
+
+(define (boolean-hash obj)
+  (if obj (%salt%) 0))
+
+(define (char-hash obj)
+  (modulo (* (%salt%) (char->integer obj)) (hash-bound)))
+
+(define (char-ci-hash obj)
+  (modulo (* (%salt%) (char->integer (char-foldcase obj))) (hash-bound)))
+
+(define (number-hash obj)
+  (cond
+    ((nan? obj) (%salt%))
+    ((and (infinite? obj) (positive? obj)) (* 2 (%salt%)))
+    ((infinite? obj) (* (%salt%) 3))
+    ((real? obj) (abs (exact (round obj))))
+    (else (+ (number-hash (real-part obj)) (number-hash (imag-part obj))))))
+
+;; Lexicographic ordering of complex numbers
+(define (complex<? a b)
+  (if (= (real-part a) (real-part b))
+    (< (imag-part a) (imag-part b))
+    (< (real-part a) (real-part b))))
+
+(define (string-ci-hash obj)
+    (string-hash (string-foldcase obj)))
+
+(define (symbol<? a b) (string<? (symbol->string a) (symbol->string b)))
+
+(define (symbol-hash obj)
+  (string-hash (symbol->string obj)))
+
+;;; Wrapped equality predicates
+;;; These comparators don't have ordering functions.
+
+(define (make-eq-comparator)
+  (make-comparator #t eq? #f default-hash))
+
+(define (make-eqv-comparator)
+  (make-comparator #t eqv? #f default-hash))
+
+(define (make-equal-comparator)
+  (make-comparator #t equal? #f default-hash))
+
+;;; Sequence ordering and hash functions
+;; The hash functions are based on djb2, but
+;; modulo 2^25 instead of 2^32 in hopes of sticking to fixnums.
+
+(define (make-hasher)
+  (let ((result (%salt%)))
+    (case-lambda
+     (() result)
+     ((n) (set! result (+ (modulo (* result 33) (hash-bound)) n))
+          result))))
+
+;;; Pair comparator
+(define (make-pair-comparator car-comparator cdr-comparator)
+   (make-comparator
+     (make-pair-type-test car-comparator cdr-comparator)
+     (make-pair=? car-comparator cdr-comparator)
+     (make-pair<? car-comparator cdr-comparator)
+     (make-pair-hash car-comparator cdr-comparator)))
+
+(define (make-pair-type-test car-comparator cdr-comparator)
+  (lambda (obj)
+    (and (pair? obj)
+         (comparator-test-type car-comparator (car obj))
+         (comparator-test-type cdr-comparator (cdr obj)))))
+
+(define (make-pair=? car-comparator cdr-comparator)
+   (lambda (a b)
+     (and ((comparator-equality-predicate car-comparator) (car a) (car b))
+          ((comparator-equality-predicate cdr-comparator) (cdr a) (cdr b)))))
+
+(define (make-pair<? car-comparator cdr-comparator)
+   (lambda (a b)
+      (if (=? car-comparator (car a) (car b))
+        (<? cdr-comparator (cdr a) (cdr b))
+        (<? car-comparator (car a) (car b)))))
+
+(define (make-pair-hash car-comparator cdr-comparator)
+   (lambda (obj)
+     (let ((acc (make-hasher)))
+       (acc (comparator-hash car-comparator (car obj)))
+       (acc (comparator-hash cdr-comparator (cdr obj)))
+       (acc))))
+
+;;; List comparator
+
+;; Cheap test for listness
+(define (norp? obj) (or (null? obj) (pair? obj)))
+
+(define (make-list-comparator element-comparator type-test empty? head tail)
+   (make-comparator
+     (make-list-type-test element-comparator type-test empty? head tail)
+     (make-list=? element-comparator type-test empty? head tail)
+     (make-list<? element-comparator type-test empty? head tail)
+     (make-list-hash element-comparator type-test empty? head tail)))
+
+
+(define (make-list-type-test element-comparator type-test empty? head tail)
+  (lambda (obj)
+    (and
+      (type-test obj)
+      (let ((elem-type-test (comparator-type-test-predicate element-comparator)))
+        (let loop ((obj obj))
+          (cond
+            ((empty? obj) #t)
+            ((not (elem-type-test (head obj))) #f)
+            (else (loop (tail obj)))))))))
+
+(define (make-list=? element-comparator type-test empty? head tail)
+  (lambda (a b)
+    (let ((elem=? (comparator-equality-predicate element-comparator)))
+      (let loop ((a a) (b b))
+        (cond
+          ((and (empty? a) (empty? b)) #t)
+          ((empty? a) #f)
+          ((empty? b) #f)
+          ((elem=? (head a) (head b)) (loop (tail a) (tail b)))
+          (else #f))))))
+
+(define (make-list<? element-comparator type-test empty? head tail)
+  (lambda (a b)
+    (let ((elem=? (comparator-equality-predicate element-comparator))
+          (elem<? (comparator-ordering-predicate element-comparator)))
+      (let loop ((a a) (b b))
+        (cond
+          ((and (empty? a) (empty? b)) #f)
+          ((empty? a) #t)
+          ((empty? b) #f)
+          ((elem=? (head a) (head b)) (loop (tail a) (tail b)))
+          ((elem<? (head a) (head b)) #t)
+          (else #f))))))
+
+(define (make-list-hash element-comparator type-test empty? head tail)
+  (lambda (obj)
+    (let ((elem-hash (comparator-hash-function element-comparator))
+          (acc (make-hasher)))
+      (let loop ((obj obj))
+        (cond
+          ((empty? obj) (acc))
+          (else (acc (elem-hash (head obj))) (loop (tail obj))))))))
+
+
+;;; Vector comparator
+
+(define (make-vector-comparator element-comparator type-test length ref)
+     (make-comparator
+       (make-vector-type-test element-comparator type-test length ref)
+       (make-vector=? element-comparator type-test length ref)
+       (make-vector<? element-comparator type-test length ref)
+       (make-vector-hash element-comparator type-test length ref)))
+
+(define (make-vector-type-test element-comparator type-test length ref)
+  (lambda (obj)
+    (and
+      (type-test obj)
+      (let ((elem-type-test (comparator-type-test-predicate element-comparator))
+            (len (length obj)))
+        (let loop ((n 0))
+          (cond
+            ((= n len) #t)
+            ((not (elem-type-test (ref obj n))) #f)
+            (else (loop (+ n 1)))))))))
+
+(define (make-vector=? element-comparator type-test length ref)
+   (lambda (a b)
+     (and
+       (= (length a) (length b))
+       (let ((elem=? (comparator-equality-predicate element-comparator))
+             (len (length b)))
+         (let loop ((n 0))
+           (cond
+             ((= n len) #t)
+             ((elem=? (ref a n) (ref b n)) (loop (+ n 1)))
+             (else #f)))))))
+
+(define (make-vector<? element-comparator type-test length ref)
+   (lambda (a b)
+     (cond
+       ((< (length a) (length b)) #t)
+       ((> (length a) (length b)) #f)
+        (else
+         (let ((elem=? (comparator-equality-predicate element-comparator))
+             (elem<? (comparator-ordering-predicate element-comparator))
+             (len (length a)))
+         (let loop ((n 0))
+           (cond
+             ((= n len) #f)
+             ((elem=? (ref a n) (ref b n)) (loop (+ n 1)))
+             ((elem<? (ref a n) (ref b n)) #t)
+             (else #f))))))))
+
+(define (make-vector-hash element-comparator type-test length ref)
+  (lambda (obj)
+    (let ((elem-hash (comparator-hash-function element-comparator))
+          (acc (make-hasher))
+          (len (length obj)))
+      (let loop ((n 0))
+        (cond
+          ((= n len) (acc))
+          (else (acc (elem-hash (ref obj n))) (loop (+ n 1))))))))
+
+;; This string-hash conflicts with SRFI-13.
+;; Since SRFI-13 won't always be available, I copied
+;; its string-hash (slightly adapted) here.
+;;
+;; Now all tests pass.
+;; 
+;; (define (string-hash obj)
+;;   (let ((acc (make-hasher))
+;;         (len (string-length obj)))
+;;     (let loop ((n 0))
+;;       (cond
+;;         ((= n len) (acc))
+;;         (else (acc (char->integer (string-ref obj n))) (loop (+ n 1)))))))
+
+(define (string-hash obj)
+  (let ((h (hash-table-hash (substring obj 0 (string-length obj)))))
+    (if (positive? (hash-bound))
+ 	(modulo h (hash-bound))
+ 	h)))
+  
+;;; The default comparator
+
+;;; Standard comparators and their functions
+
+;; The unknown-object comparator, used as a fallback to everything else
+;; Everything compares exactly the same and hashes to 0
+(define unknown-object-comparator
+  (make-comparator
+    (lambda (obj) #t)
+    (lambda (a b) #t)
+    (lambda (a b) #f)
+    (lambda (obj) 0)))
+
+;; Next index for added comparator
+
+(define first-comparator-index 9)
+(define *next-comparator-index* 9)
+(define *registered-comparators* (list unknown-object-comparator))
+
+;; Register a new comparator for use by the default comparator.
+(define (comparator-register-default! comparator)
+  (set! *registered-comparators* (cons comparator *registered-comparators*))
+  (set! *next-comparator-index* (+ *next-comparator-index* 1)))
+
+;; Return ordinal for object types: null sorts before pairs, which sort
+;; before booleans, etc.  Implementations can extend this.
+;; People who call comparator-register-default! effectively do extend it.
+(define (object-type obj)
+  (cond
+    ((null? obj) 0)
+    ((pair? obj) 1)
+    ((boolean? obj) 2)
+    ((char? obj) 3)
+    ((string? obj) 4)
+    ((symbol? obj) 5)
+    ((number? obj) 6)
+    ((vector? obj) 7)
+    ((bytevector? obj) 8)
+    ; Add more here if you want: be sure to update comparator-index variables
+    (else (registered-index obj))))
+
+;; Return the index for the registered type of obj.
+(define (registered-index obj)
+  (let loop ((i 0) (registry *registered-comparators*))
+    (cond
+      ((null? registry) (+ first-comparator-index i))
+      ((comparator-test-type (car registry) obj) (+ first-comparator-index i))
+      (else (loop (+ i 1) (cdr registry))))))
+
+;; Given an index, retrieve a registered conductor.
+;; Index must be >= first-comparator-index.
+(define (registered-comparator i)
+  (list-ref *registered-comparators* (- i first-comparator-index)))
+
+(define (dispatch-equality type a b)
+  (case type
+    ((0) #t) ; All empty lists are equal
+    ((1) ((make-pair=? (make-default-comparator) (make-default-comparator)) a b))
+    ((2) (boolean=? a b))
+    ((3) (char=? a b))
+    ((4) (string=? a b))
+    ((5) (symbol=? a b))
+    ((6) (= a b))
+    ((7) ((make-vector=? (make-default-comparator)
+                         vector? vector-length vector-ref) a b))
+    ((8) ((make-vector=? (make-comparator exact-integer? = < default-hash)
+                         bytevector? bytevector-length bytevector-u8-ref) a b))
+    ; Add more here
+    (else (binary=? (registered-comparator type) a b))))
+
+(define (dispatch-ordering type a b)
+  (case type
+    ((0) 0) ; All empty lists are equal
+    ((1) ((make-pair<? (make-default-comparator) (make-default-comparator)) a b))
+    ((2) (boolean<? a b))
+    ((3) (char<? a b))
+    ((4) (string<? a b))
+    ((5) (symbol<? a b))
+    ((6) (complex<? a b))
+    ((7) ((make-vector<? (make-default-comparator) vector? vector-length vector-ref) a b))
+    ((8) ((make-vector<? (make-comparator exact-integer? = < default-hash)
+			 bytevector? bytevector-length bytevector-u8-ref) a b))
+    ; Add more here
+    (else (binary<? (registered-comparator type) a b))))
+
+(define (default-hash obj)
+  (case (object-type obj)
+    ((0) 0)
+    ((1) ((make-pair-hash (make-default-comparator) (make-default-comparator)) obj))
+    ((2) (boolean-hash obj))
+    ((3) (char-hash obj))
+    ((4) (string-hash obj))
+    ((5) (symbol-hash obj))
+    ((6) (number-hash obj))
+    ((7) ((make-vector-hash (make-default-comparator) vector? vector-length vector-ref) obj))
+    ((8) ((make-vector-hash (make-default-comparator)
+                             bytevector? bytevector-length bytevector-u8-ref) obj))
+    ; Add more here
+    (else (comparator-hash (registered-comparator (object-type obj)) obj))))
+  
+(define (default-ordering a b)
+  (let ((a-type (object-type a))
+        (b-type (object-type b)))
+    (cond
+      ((< a-type b-type) #t)
+      ((> a-type b-type) #f)
+      (else (dispatch-ordering a-type a b)))))
+
+(define (default-equality a b)
+  (let ((a-type (object-type a))
+        (b-type (object-type b)))
+    (if (= a-type b-type) (dispatch-equality a-type a b) #f)))
+
+(define (make-default-comparator)
+  (make-comparator
+    (lambda (obj) #t)
+    default-equality
+    default-ordering
+    default-hash))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import SRFI-128)
+(provide "srfi-128")

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -26,6 +26,7 @@
 
 (require "test")
 
+
 (test-section "SRFIs")
 
 
@@ -971,6 +972,7 @@
 (test "rest-list #t"         '(1 "str" x) (receive (a b c) (rest-values rest-list #t `(100 . ,number?) `("str" . ,string?) `(x y z)) (list a b c)))
 (test "rest-list #f"         '(1 "str" y x) (receive (a b c d) (rest-values rest-list #f `(100 . ,number?) `("str" . ,string?) `(y z)) (list a b c d)))
 
+
 ;; ----------------------------------------------------------------------
 ;;  SRFI 54 ...
 ;; ----------------------------------------------------------------------
@@ -1124,6 +1126,8 @@
        "              12.000"
        (cat 12 20 (cons example? record->string) -3.))
 
+
+
 ;; ----------------------------------------------------------------------
 ;;  SRFI 60 ...
 ;; ----------------------------------------------------------------------
@@ -1185,6 +1189,7 @@
 (test "list->integer"   #b11101 (list->integer '(#f #f #f #f #f #t #t #t #f #t)))
 (test "booleans->integer"  #b11101
       (booleans->integer #f #f #f #f #f #t #t #t #f #t))
+
 
 ;; ----------------------------------------------------------------------
 ;;  SRFI 62 ...
@@ -2049,6 +2054,268 @@
 (test "string-append! constant 3" "abcdef" (string-append! (string-copy str1) str2)) ;  second arg may be constant
 (test "string-append! constant 3" "xdef" (string-append! (string-copy "x") str2)) ;  second arg may be constant
 
+
+;; ----------------------------------------------------------------------
+;;  SRFI 128 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 128 - Comparators")
+
+(require "srfi-128")
+
+(define (vector-cdr vec)
+    (let* ((len (vector-length vec))
+           (result (make-vector (- len 1))))
+      (let loop ((n 1))
+        (cond
+          ((= n len) result)
+          (else (vector-set! result (- n 1) (vector-ref vec n))
+                (loop (+ n 1)))))))
+
+(test "vector-cdr"   '#(2 3 4) (vector-cdr '#(1 2 3 4)))
+(test "vector-cdr 2" '#() (vector-cdr '#(1)))
+
+(define default-comparator (make-default-comparator))
+(define real-comparator (make-comparator real? = < number-hash))
+(define degenerate-comparator (make-comparator (lambda (x) #t) equal? #f #f))
+(define boolean-comparator
+  (make-comparator boolean? eq? (lambda (x y) (and (not x) y)) boolean-hash))
+(define bool-pair-comparator (make-pair-comparator boolean-comparator boolean-comparator))
+(define num-list-comparator
+  (make-list-comparator real-comparator list? null? car cdr))
+(define num-vector-comparator
+  (make-vector-comparator real-comparator vector? vector-length vector-ref))
+(define vector-qua-list-comparator
+  (make-list-comparator
+   real-comparator
+   vector?
+   (lambda (vec) (= 0 (vector-length vec)))
+   (lambda (vec) (vector-ref vec 0))
+   vector-cdr))
+(define list-qua-vector-comparator
+  (make-vector-comparator default-comparator list? length list-ref))
+(define eq-comparator (make-eq-comparator))
+(define eqv-comparator (make-eqv-comparator))
+(define equal-comparator (make-equal-comparator))
+(define symbol-comparator
+  (make-comparator
+   symbol?
+   eq?
+   (lambda (a b) (string<? (symbol->string a) (symbol->string b)))
+   symbol-hash))
+
+;; comparators/predicates
+(test "comparator? 1" #t (comparator? real-comparator))
+(test "comparator? 2" #t (not (comparator? =)))
+(test "ordered?" #t (comparator-ordered? real-comparator))
+(test "hashtable?" #t (comparator-hashable? real-comparator))
+(test "ordered? 2" #t (not (comparator-ordered? degenerate-comparator)))
+(test "hashtable? 2" #t (not (comparator-hashable? degenerate-comparator)))
+
+;; comparators/constructors
+
+(test "1" #t (=? boolean-comparator #t #t))
+(test "2" #t (not (=? boolean-comparator #t #f)))
+(test "3" #t (<? boolean-comparator #f #t))
+(test "4" #t (not (<? boolean-comparator #t #t)))
+(test "5" #t (not (<? boolean-comparator #t #f)))
+
+(test "6" #t (comparator-test-type bool-pair-comparator '(#t . #f)))
+(test "7" #t (not (comparator-test-type bool-pair-comparator 32)))
+(test "8" #t (not (comparator-test-type bool-pair-comparator '(32 . #f))))
+(test "9" #t (not (comparator-test-type bool-pair-comparator '(#t . 32))))
+(test "10" #t (not (comparator-test-type bool-pair-comparator '(32 . 34))))
+(test "11" #t (=? bool-pair-comparator '(#t . #t) '(#t . #t)))
+(test "12" #t (not (=? bool-pair-comparator '(#t . #t) '(#f . #t))))
+(test "13" #t (not (=? bool-pair-comparator '(#t . #t) '(#t . #f))))
+(test "14" #t (<? bool-pair-comparator '(#f . #t) '(#t . #t)))
+(test "15" #t (<? bool-pair-comparator '(#t . #f) '(#t . #t)))
+(test "16" #t (not (<? bool-pair-comparator '(#t . #t) '(#t . #t))))
+(test "17" #t (not (<? bool-pair-comparator '(#t . #t) '(#f . #t))))
+(test "18" #t (not (<? bool-pair-comparator '(#f . #t) '(#f . #f))))
+
+(test "19" #t (comparator-test-type num-vector-comparator '#(1 2 3)))
+(test "20" #t (comparator-test-type num-vector-comparator '#()))
+(test "21" #t (not (comparator-test-type num-vector-comparator 1)))
+(test "22" #t (not (comparator-test-type num-vector-comparator '#(a 2 3))))
+(test "23" #t (not (comparator-test-type num-vector-comparator '#(1 b 3))))
+(test "24" #t (not (comparator-test-type num-vector-comparator '#(1 2 c))))
+(test "25" #t (=? num-vector-comparator '#(1 2 3) '#(1 2 3)))
+(test "26" #t (not (=? num-vector-comparator '#(1 2 3) '#(4 5 6))))
+(test "27" #t (not (=? num-vector-comparator '#(1 2 3) '#(1 5 6))))
+(test "28" #t (not (=? num-vector-comparator '#(1 2 3) '#(1 2 6))))
+(test "29" #t (<? num-vector-comparator '#(1 2) '#(1 2 3)))
+(test "30" #t (<? num-vector-comparator '#(1 2 3) '#(2 3 4)))
+(test "31" #t (<? num-vector-comparator '#(1 2 3) '#(1 3 4)))
+(test "32" #t (<? num-vector-comparator '#(1 2 3) '#(1 2 4)))
+(test "33" #t (<? num-vector-comparator '#(3 4) '#(1 2 3)))
+(test "34" #t (not (<? num-vector-comparator '#(1 2 3) '#(1 2 3))))
+(test "35" #t (not (<? num-vector-comparator '#(1 2 3) '#(1 2))))
+(test "36" #t (not (<? num-vector-comparator '#(1 2 3) '#(0 2 3))))
+(test "37" #t (not (<? num-vector-comparator '#(1 2 3) '#(1 1 3))))
+
+(test "38" #t (not (<? vector-qua-list-comparator '#(3 4) '#(1 2 3))))
+(test "39" #t (<? list-qua-vector-comparator '(3 4) '(1 2 3)))
+
+(define bool-pair (cons #t #f))
+(define bool-pair-2 (cons #t #f))
+(define reverse-bool-pair (cons #f #t))
+
+(test "40" #t (=? eq-comparator #t #t))
+(test "41" #t (not (=? eq-comparator #f #t)))
+(test "42" #t (=? eqv-comparator bool-pair bool-pair))
+(test "43" #t (not (=? eqv-comparator bool-pair bool-pair-2)))
+(test "44" #t (=? equal-comparator bool-pair bool-pair-2))
+(test "45" #t (not (=? equal-comparator bool-pair reverse-bool-pair)))
+
+;; comparators/hash
+(test "46" #t (exact-integer? (boolean-hash #f)))
+(test "47" #t (not (negative? (boolean-hash #t))))
+(test "48" #t (exact-integer? (char-hash #\a)))
+(test "49" #t (not (negative? (char-hash #\b))))
+(test "50" #t (exact-integer? (char-ci-hash #\a)))
+(test "51" #t (not (negative? (char-ci-hash #\b))))
+(test "52" #t (= (char-ci-hash #\a) (char-ci-hash #\A)))
+(test "53" #t (exact-integer? (string-hash "f")))
+(test "54" #t (not (negative? (string-hash "g"))))
+(test "55" #t (exact-integer? (string-ci-hash "f")))
+(test "56" #t (not (negative? (string-ci-hash "g"))))
+(test "57" #t (= (string-ci-hash "f") (string-ci-hash "F")))
+(test "58" #t (exact-integer? (symbol-hash 'f)))
+(test "59" #t (not (negative? (symbol-hash 't))))
+(test "60" #t (exact-integer? (number-hash 3)))
+(test "61" #t (not (negative? (number-hash 3))))
+(test "62" #t (exact-integer? (number-hash -3)))
+(test "63" #t (not (negative? (number-hash -3))))
+(test "64" #t (exact-integer? (number-hash 3.0)))
+(test "65" #t (not (negative? (number-hash 3.0))))
+
+;; comparators/default
+(test "66" #t (<? default-comparator '() '(a)))
+(test "67" #t (not (=? default-comparator '() '(a))))
+(test "68" #t (=? default-comparator #t #t))
+(test "69" #t (not (=? default-comparator #t #f)))
+(test "70" #t (<? default-comparator #f #t))
+(test "71" #t (not (<? default-comparator #t #t)))
+(test "72" #t (=? default-comparator #\a #\a))
+(test "73" #t (<? default-comparator #\a #\b))
+
+(test "74" #t (comparator-test-type default-comparator '()))
+(test "75" #t (comparator-test-type default-comparator #t))
+(test "76" #t (comparator-test-type default-comparator #\t))
+(test "77" #t (comparator-test-type default-comparator '(a)))
+(test "78" #t (comparator-test-type default-comparator 'a))
+(test "79" #t (comparator-test-type default-comparator (make-bytevector 10)))
+(test "80" #t (comparator-test-type default-comparator 10))
+(test "81" #t (comparator-test-type default-comparator 10.0))
+(test "82" #t (comparator-test-type default-comparator "10.0"))
+(test "83" #t (comparator-test-type default-comparator '#(10)))
+
+(test "84" #t (=? default-comparator '(#t . #t) '(#t . #t)))
+(test "85" #t (not (=? default-comparator '(#t . #t) '(#f . #t))))
+(test "86" #t (not (=? default-comparator '(#t . #t) '(#t . #f))))
+(test "87" #t (<? default-comparator '(#f . #t) '(#t . #t)))
+(test "88" #t (<? default-comparator '(#t . #f) '(#t . #t)))
+(test "89" #t (not (<? default-comparator '(#t . #t) '(#t . #t))))
+(test "90" #t (not (<? default-comparator '(#t . #t) '(#f . #t))))
+(test "91" #t (not (<? default-comparator '#(#f #t) '#(#f #f))))
+
+(test "92" #t (=? default-comparator '#(#t #t) '#(#t #t)))
+(test "93" #t (not (=? default-comparator '#(#t #t) '#(#f #t))))
+(test "94" #t (not (=? default-comparator '#(#t #t) '#(#t #f))))
+(test "95" #t (<? default-comparator '#(#f #t) '#(#t #t)))
+(test "96" #t (<? default-comparator '#(#t #f) '#(#t #t)))
+(test "97" #t (not (<? default-comparator '#(#t #t) '#(#t #t))))
+(test "98" #t (not (<? default-comparator '#(#t #t) '#(#f #t))))
+(test "99" #t (not (<? default-comparator '#(#f #t) '#(#f #f))))
+
+(test "100" #t (= (comparator-hash default-comparator #t) (boolean-hash #t)))
+(test "101" #t (= (comparator-hash default-comparator #\t) (char-hash #\t)))
+(test "102" #t
+      (begin
+        (let ((a (comparator-hash default-comparator "t"))
+              (b (string-hash "t")))
+          (print "a= " a "\nb= " b "\n")
+          (= a b))))
+(test "103" #t (= (comparator-hash default-comparator 't) (symbol-hash 't)))
+(test "104" #t (= (comparator-hash default-comparator 10) (number-hash 10)))
+(test "105" #t (= (comparator-hash default-comparator 10.0) (number-hash 10.0)))
+
+(comparator-register-default!
+ (make-comparator procedure? (lambda (a b) #t) (lambda (a b) #f) (lambda (obj) 200)))
+(test "106" #t (=? default-comparator (lambda () #t) (lambda () #f)))
+(test "107" #t (not (<? default-comparator (lambda () #t) (lambda () #f))))
+(test "108" 200 (comparator-hash default-comparator (lambda () #t)))
+
+
+
+;; SRFI 128 does not actually require a comparator's four procedures
+;; to be eq? to the procedures originally passed to make-comparator.
+;; For interoperability/interchangeability between the comparators
+;; of SRFI 114 and SRFI 128, some of the procedures passed to
+;; make-comparator may need to be wrapped inside another lambda
+;; expression before they're returned by the corresponding accessor.
+;;
+;; So this next group of tests is incorrect, hence commented out
+;; and replaced by a slightly less naive group of tests.
+
+;; comparators/accessors"
+;; (define ttp (lambda (x) #t))
+;; (define eqp (lambda (x y) #t))
+;; (define orp (lambda (x y) #t))
+;; (define hf (lambda (x) 0))
+;; (define comp (make-comparator ttp eqp orp hf))
+;; (test "" ttp (comparator-type-test-predicate comp))
+;; (test "" eqp (comparator-equality-predicate comp))
+;; (test "" orp (comparator-ordering-predicate comp))
+;; (test "" hf (comparator-hash-function comp))
+
+;; comparators/accessors
+(define x1 0)
+(define x2 0)
+(define x3 0)
+(define x4 0)
+(define ttp (lambda (x) (set! x1 111) #t))
+(define eqp (lambda (x y) (set! x2 222) #t))
+(define orp (lambda (x y) (set! x3 333) #t))
+(define hf (lambda (x) (set! x4 444) 0))
+(define comp (make-comparator ttp eqp orp hf))
+(test "109" #t (and ((comparator-type-test-predicate comp) x1)   (= x1 111)))
+(test "110" #t (and ((comparator-equality-predicate comp) x1 x2) (= x2 222)))
+(test "111" #t (and ((comparator-ordering-predicate comp) x1 x3) (= x3 333)))
+(test "112" #t (and (zero? ((comparator-hash-function comp) x1)) (= x4 444)))
+
+;; comparators/invokers
+(test "113" #t (comparator-test-type real-comparator 3))
+(test "114" #t (comparator-test-type real-comparator 3.0))
+(test "115" #t (not (comparator-test-type real-comparator "3.0")))
+(test "116" #t (comparator-check-type boolean-comparator #t))
+(test "117" *test-failed* (comparator-check-type boolean-comparator 't))
+
+;; comparators/comparison
+(test "118" #t (=? real-comparator 2 2.0 2))
+(test "119" #t (<? real-comparator 2 3.0 4))
+(test "120" #t (>? real-comparator 4.0 3.0 2))
+(test "121" #t (<=? real-comparator 2.0 2 3.0))
+(test "122" #t (>=? real-comparator 3 3.0 2))
+(test "123" #t (not (=? real-comparator 1 2 3)))
+(test "124" #t (not (<? real-comparator 3 1 2)))
+(test "125" #t (not (>? real-comparator 1 2 3)))
+(test "126" #t (not (<=? real-comparator 4 3 3)))
+(test "127" #t (not (>=? real-comparator 3 4 4.0)))
+
+
+;; comparators/syntax
+(test "128" 'less (comparator-if<=> real-comparator 1 2 'less 'equal 'greater))
+(test "129" 'equal (comparator-if<=> real-comparator 1 1 'less 'equal 'greater))
+(test "130" 'greater (comparator-if<=> real-comparator 2 1 'less 'equal 'greater))
+(test "131" 'less (comparator-if<=> "1" "2" 'less 'equal 'greater))
+(test "132" 'equal (comparator-if<=> "1" "1" 'less 'equal 'greater))
+(test "133" 'greater (comparator-if<=> "2" "1" 'less 'equal 'greater))
+
+;; comparators/bound-salt"
+(test "hash bound" #t (exact-integer? (hash-bound)))
+(test "hash salt" #t (exact-integer? (hash-salt)))
+(test "hash salt<hash bound" #t (< (hash-salt) (hash-bound)))
 
 ;; ----------------------------------------------------------------------
 ;;  SRFI 141 ...


### PR DESCRIPTION
Only one test from the SRFI reference implementation doesn't pass:

```
test 102 on (= (comparator-hash default-comparator "t") (string-hash "t")) expected #t but got #f
```

However, if I do it on the REPL,

```
stklos> (load "lib/srfi-128.stk")
stklos> (define default-comparator (make-default-comparator))
;; default-comparator
stklos>  (= (comparator-hash default-comparator "t") (string-hash "t"))
#t
stklos> (comparator-hash default-comparator "t")
26797187
stklos> (string-hash "t")
26797187
```

So I don't know what's happening...
