### PR TITLE
Add SRFI-156 - Syntactic combiners for binary predicates

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -66,6 +66,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-117: Queues based on lists
     - SRFI-141: Integer Division
     - SRFI-145: Assumptions
+    - SRFI-156: Syntactic combiners for binary predicates
     - SRFI-158: Generators and Accumulators
     - SRFI-169: Underscores in numbers
     - SRFI-171: Transducers

--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -625,6 +625,9 @@ described in this document (procedures
 (gen-embedded-srfi 145
                    [See the ,(ref :mark "assume" :text "assume") special form])
 
+;; SRFI 156 -- Syntactic combiners for binary predicates
+(gen-loaded-srfi 156)
+
 ;; SRFI 158 -- Generators and Accumulators
 (gen-loaded-srfi 158)
 

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -77,6 +77,7 @@
      (117 . "Queues based on lists")
      (141 . "Integer Division")
      (145 . "Assumptions")
+     (156 . "Syntactic combiners for binary predicates")
      (158 . "Generators and Accumulators")
      (169 . "Underscores in numbers")
      (171 . "Transducers")

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -90,6 +90,7 @@ scheme_SRCS = STklos.init     \
           srfi-100.stk        \
 	        srfi-117.stk        \
           srfi-141.stk        \
+          srfi-156.stk        \
           srfi-158.stk        \
           srfi-171.stk        \
           srfi-173.stk        \
@@ -142,6 +143,7 @@ scheme_OBJS = compfile.ostk    \
 	        srfi-117.ostk        \
           srfi-141.ostk        \
           srfi-117.ostk        \
+          srfi-156.ostk        \
           srfi-158.ostk        \
           srfi-171.ostk        \
           srfi-173.ostk        \

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -213,7 +213,7 @@
     ;; srfi-153                         ; ....... withdrawn
     ;; srfi-154                         ; First-class dynamic extents
     ;; srfi-155                         ; Promises
-    ;; srfi-156                         ; Syntactic combiners for binary predicates
+    srfi-156                            ; Syntactic combiners for binary predicates
     ;; srfi-157                         ; Continuation marks
     (srfi-158 "srfi-158")               ; Generators and Accumulators
     ;; srfi-159                         ; Combinator Formatting

--- a/lib/srfi-156.stk
+++ b/lib/srfi-156.stk
@@ -1,0 +1,152 @@
+;;;;
+;;;; srfi-156.stk		-- Implementation of SRFI-156
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Panicz Maciej Godek, it is copyrighted as:
+;;;;
+;;;;;;  Copyright (c) 2017 Panicz Maciej Godek
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 10-Jul-2020 06:55 (jpellegrini)
+;;;; Last file update: 10-Jul-2020 07:30 (jpellegrini)
+;;;;
+
+
+(define-syntax infix/postfix
+  (syntax-rules ()
+    ((infix/postfix x somewhat?)
+     (somewhat? x))
+    
+    ((infix/postfix left related-to? right)
+     (related-to? left right))
+    
+    ((infix/postfix left related-to? right . likewise)
+     (let ((right* right))
+       (and (infix/postfix left related-to? right*)
+            (infix/postfix right* . likewise))))))
+
+;; The folowing doesn't work in STklos, because STklos will introduce
+;; identical symbols for argumets of closures, like (lambda (a a) ...).
+;; I have written another macro, using define-macro, below. -- jpellegrini
+;;
+;; (define-syntax extract-placeholders
+;;   (syntax-rules (_)
+;;     ((extract-placeholders final () () body)
+;;      (final (infix/postfix . body)))
+    
+;;     ((extract-placeholders final () args body)
+;;      (lambda args (final (infix/postfix . body))))
+    
+;;     ((extract-placeholders final (_ op . rest) (args ...) (body ...))
+;;      (extract-placeholders final rest (args ... arg) (body ... arg op)))
+    
+;;     ((extract-placeholders final (arg op . rest) args (body ...))
+;;      (extract-placeholders final rest args (body ... arg op)))
+    
+;;     ((extract-placeholders final (_) (args ...) (body ...))
+;;      (extract-placeholders final () (args ... arg) (body ... arg)))
+    
+;;     ((extract-placeholders final (arg) args (body ...))
+;;      (extract-placeholders final () args (body ... arg)))))
+
+(define-macro  (extract-placeholders final a b body)
+  (cond ((and (null? a) (null? b))
+           `(,final ,(cons 'infix/postfix body)))
+          
+          ((null? a)
+           `(lambda ,b ,(list final (cons 'infix/postfix body))))
+          
+          ((and (> (length a) 1)
+                (eq? (car a) '_))
+           (let ((op (cadr a))
+                 (rest (cddr a))
+                 (arg (gensym "arg")))
+             `(extract-placeholders ,final
+                                    ,rest
+                                    ,(append b (list arg))
+                                    ,(append body (list arg op)))))
+
+          ((> (length a) 1)
+           (let ((arg (car a))
+                 (op (cadr a))
+                 (rest (cddr a)))
+             `(extract-placeholders ,final
+                                    ,rest
+                                    ,b
+                                    ,(append body (list arg op)))))
+
+          ((equal? a '(_))
+           (let ((arg (gensym "arg")))
+             `(extract-placeholders ,final
+                                    ()
+                                    ,(append b (list arg))
+                                    ,(append body (list arg)))))
+
+          ((= (length a) 1)
+           (let ((arg (car a)))
+             `(extract-placeholders ,final
+                                    ()
+                                    ,b
+                                    ,(append body (list arg)))))))
+
+(define-syntax identity-syntax
+  (syntax-rules ()
+    ((identity-syntax form)
+     form)))
+
+(define-syntax is
+  (syntax-rules ()
+    ((is . something)
+     (extract-placeholders identity-syntax something () ()))))
+
+(define-syntax isnt
+  (syntax-rules ()
+    ((isnt . something)
+     (extract-placeholders not something () ()))))
+
+
+(export-syntax infix/postfix
+               extract-placeholders
+               identity-syntax
+               is
+               isnt)
+
+(provide "srfi-156")

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -698,8 +698,215 @@
                       (- n (* blq d))
                       blr))))
           nums-dens)
-            
-            
+
+;; ----------------------------------------------------------------------
+;;  SRFI 156 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 156 - Syntactic combiners for binary predicates")
+
+(require "srfi-156")
+
+
+;; the tests were translated from the original SRFI reference implementation
+
+(test "" #t
+ (is 1 odd?))
+
+(test "" #t
+ (isnt 2 odd?))
+
+(test "" #t
+ (is '() null?))
+
+(test "" #t
+ (is procedure? procedure?))
+
+(test "" #t
+ (isnt 5 procedure?))
+
+;; two arguments:
+
+(test "" #t
+ (is 1 < 2))
+
+(test "" #t
+ (isnt 1 < 1))
+
+(test "" #t
+ (is (+ 2 2) = 4))
+
+(test "" #t
+ (is 'x eq? 'x))
+
+(test "" #t
+ (is procedure? eq? procedure?))
+
+(test "" #t
+ (eq? (is eq? eq? eq?)
+      (eq? eq? eq?)))
+
+(test "" #t
+ (is (is eq? eq? eq?) eq? (eq? eq? eq?)))
+
+(test "" '(y z)
+ (is 'y memq '(x y z)))
+
+(test "" '((1) (2) (1 2))
+ (is '(1) member '(() (1) (2) (1 2))))
+
+(test "" #t
+ (isnt 'x eq? 'y))
+
+(test "" #t
+ (is '(a b c) equal? '(a b c)))
+
+(test "" #t
+ (isnt '(a b c) equal? '(c b a)))
+
+(test "" #t
+ (is 0 = 0.0))
+
+(test "" #t
+ (is 1.0 = 1))
+
+(test "" #t
+ (isnt 1 = 0))
+
+(define (divisible-by? x y)
+  (is (modulo x y) = 0))
+
+(test "" #t
+ (is 9 divisible-by? 3))
+
+(test "" #t
+ (isnt 3 divisible-by? 9))
+
+;; ending with unary predicate:
+
+(test "" #t
+ (is 1 < 2 even?))
+
+(test "" #t
+ (isnt 1 < 2 odd?))
+
+(test "" #t
+ (isnt 2 < 1 even?))
+
+(test "" #t
+ (is 0 = 0.0 zero?))
+
+(test "" #t
+ (isnt 1.0 = 1 zero?))
+
+;; three arguments:
+
+(test "" #t
+ (is 1 < 2 <= 3))
+
+(test "" #t
+ (is 0 = 0.0 = 0+0i = 0.0+0.0i))
+
+(test "" #t
+ (isnt 1 <= 2 < 2))
+
+;; predicates don't need to be transitive
+;; (although that's not particularly elegant):
+
+(test "" #t
+ (is 1 < 2 > 1.5))
+
+(test "" #t
+ (isnt 1 < 2 > 3))
+
+(test "" #t
+ (isnt 3 < 2 < 1))
+
+(test "" '((x y) (y x))
+ (is 'x member '(x y) member '((x y) (y x))))
+
+;; more arguments:
+
+(test "" #t
+ (is -0.4 < -0.1 <= 0 = 0.0 < 0.1 < 0.4))
+
+(test "" #t
+ (isnt -0.4 < -0.1 <= 0 = 0.0 < 0.1 < -0.1))
+
+(test "" #t
+ (is 0 = 0.0 = 0+0i = 0.0+0.0i = (+) < (*) = 1 = 1.0 = 1+0i = 1.0+0.0i))
+
+;; ending with unary predicate:
+
+(test "" #t
+ (is -0.4 < -0.1 <= 0 <= 0.0 < 0.1 < 0.4 <= 2 even?))
+
+(test "" #t
+ (isnt -0.4 < -0.1 <= 0 <= 0.0 < 0.1 < 0.4 <= 2 odd?))
+
+;; as procedures (with underscore):
+
+(test "" #t
+ (equal? (filter (isnt _ even?) '(2 4 5 6 7 8))
+	 '(5 7)))
+
+(test "" #t
+ (equal? (filter (is _ < 2) '(1 3 2 0))
+	 '(1 0)))
+
+(test "" #t
+ (equal? (filter (is 1 < _) '(1 3 2 0))
+	 '(3 2)))
+
+(test "" #t
+ (equal? (filter (is 3 < _ <= 5) '(2 3 4 5 6 7))
+	 '(4 5)))
+
+(test "" #t
+ (equal? (filter (is 'x memq _) '((a b) (x) (p q) (x y) (c d) (z x)))
+	 '((x) (x y) (z x))))
+
+(test "" #t
+ (equal? (filter (isnt 'x memq _) '((a b) (x) (p q) (x y) (c d) (z x)))
+	 '((a b) (p q) (c d))))
+
+(test "" #t
+ (equal? (filter (isnt 3 < _ <= 5) '(2 3 4 5 6 7))
+	 '(2 3 6 7)))
+
+(test "" #t
+ (equal? (filter (is _ eq? 'a) '(m a m a))
+	 '(a a)))
+
+(test "" #t
+ (equal? (filter (isnt 'a eq? _) '(m a m a))
+	 '(m m)))
+
+;; multiple underscores:
+
+(test "" #t
+ ((is _ < 2 < _) 1 3))
+
+(test "" #t
+ ((isnt 1 < _ <= _ < 3) 2 4))
+
+(test "" #t
+ ((is _ < _ even?) 1 2))
+
+(test "" #t
+ ((isnt _ < _ odd?) 1 2))
+
+(test "" #t
+ ((is 1 < _ <= 3 < _ <= 5 < _) 3 5 6))
+
+(test "" #t
+ ((isnt 1 < _ <= 3 < _ <= 5 < _) 3 3 6))
+
+(test "" #t
+ ((is 1 < _ <= 3 < _ <= 5 < _ even?) 3 5 6))
+
+(test "" #t
+ ((isnt 1 < _ <= 3 < _ <= 5 < _ odd?) 3 5 6))
+
 ;; ----------------------------------------------------------------------
 ;;  SRFI 158 ...
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
There was one macro which the reference implementation contains, using `syntax-rules`, which did not work in STklos, so I write another, using `define-macro`. All tests pass.

* the problem was that STklos introduces identical symbols in different phases of macro expansion using syntax rules:

```
(define-syntax f
  (syntax-rules (k)
    ((f) #f)
    ((f k) 'K)
    ((f k x ...) (a (f x ...)))))
```

Here's the STklos expansion:

```
stklos> (macro-expand* '(f k k k))
(a (a 'K))
```

some other implementations will return
```
(a.0 (a.1 'K))
```

Anyway, not a problem, since we have `define-macro`!