### PR TITLE
Add SRFI-41 - Streams

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -79,6 +79,8 @@ SRC_STK = bigloo-support.stk  \
           pretty-print.stk    \
           recette.stk         \
           slib.stk            \
+          streams-primitive.stk \
+          streams-derived.stk \
           srfi-1.stk          \
           srfi-2.stk          \
           srfi-4.stk          \
@@ -95,6 +97,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-35.stk         \
           srfi-36.stk         \
           srfi-37.stk         \
+          srfi-41.stk         \
           srfi-48.stk         \
           srfi-51.stk         \
           srfi-54.stk         \
@@ -138,74 +141,77 @@ SRC_STK = bigloo-support.stk  \
 
 SRC_C = srfi-175-impl.c
 
-scheme_OBJS = compfile.ostk    \
-          bigmatch.ostk        \
-          full-syntax.ostk     \
-          full-conditions.ostk \
-          describe.ostk        \
-          env.ostk             \
-          getopt.ostk          \
-          help.ostk            \
-          http.ostk            \
-          lex-rt.ostk          \
-          pretty-print.ostk    \
-          recette.ostk         \
-          slib.ostk            \
-          srfi-1.ostk          \
-          srfi-2.ostk          \
-          srfi-4.ostk          \
-          srfi-5.ostk	       \
-          srfi-7.ostk          \
-          srfi-9.ostk          \
-          srfi-11.ostk         \
-          srfi-13.ostk         \
-          srfi-14.ostk         \
-          srfi-17.ostk         \
-          srfi-26.ostk         \
-          srfi-27.ostk         \
-          srfi-31.ostk         \
-          srfi-35.ostk         \
-          srfi-36.ostk         \
-          srfi-37.ostk         \
-          srfi-48.ostk         \
-          srfi-51.ostk         \
-          srfi-54.ostk         \
-          srfi-59.ostk         \
-          srfi-60.ostk         \
-          srfi-61.ostk         \
-          srfi-64.ostk         \
-          srfi-66.ostk         \
-          srfi-69.ostk         \
-          srfi-70.ostk         \
-          srfi-74.ostk         \
-          srfi-89.ostk         \
-          srfi-96.ostk         \
-          srfi-100.ostk        \
-          srfi-113.ostk        \
-          srfi-117.ostk        \
-          srfi-127.ostk        \
-          srfi-128.ostk        \
-          srfi-129.ostk        \
-          srfi-130.ostk        \
-          srfi-134.ostk        \
-          srfi-135.ostk        \
-          srfi-137.ostk        \
-          srfi-141.ostk        \
-          srfi-151.ostk        \
-          srfi-156.ostk        \
-          srfi-158.ostk        \
-          srfi-161.ostk        \
-          srfi-171.ostk        \
-          srfi-173.ostk        \
-          srfi-174.ostk        \
-          srfi-175.ostk        \
-          srfi-180.ostk        \
-          srfi-185.ostk        \
-          srfi-189.ostk        \
-          srfi-190.ostk        \
-          srfi-196.ostk        \
-          srfi-207.ostk        \
-          tar.ostk             \
+scheme_OBJS = compfile.ostk     \
+          bigmatch.ostk         \
+          full-syntax.ostk      \
+          full-conditions.ostk  \
+          describe.ostk         \
+          env.ostk              \
+          getopt.ostk           \
+          help.ostk             \
+          http.ostk             \
+          lex-rt.ostk           \
+          pretty-print.ostk     \
+          recette.ostk          \
+          slib.ostk             \
+          streams-primitive.stk \
+          streams-derived.stk   \
+          srfi-1.ostk           \
+          srfi-2.ostk           \
+          srfi-4.ostk           \
+          srfi-5.ostk	        \
+          srfi-7.ostk           \
+          srfi-9.ostk           \
+          srfi-11.ostk          \
+          srfi-13.ostk          \
+          srfi-14.ostk          \
+          srfi-17.ostk          \
+          srfi-26.ostk          \
+          srfi-27.ostk          \
+          srfi-31.ostk          \
+          srfi-35.ostk          \
+          srfi-36.ostk          \
+          srfi-37.ostk          \
+          srfi-41.ostk          \
+          srfi-48.ostk          \
+          srfi-51.ostk          \
+          srfi-54.ostk          \
+          srfi-59.ostk          \
+          srfi-60.ostk          \
+          srfi-61.ostk          \
+          srfi-64.ostk          \
+          srfi-66.ostk          \
+          srfi-69.ostk          \
+          srfi-70.ostk          \
+          srfi-74.ostk          \
+          srfi-89.ostk          \
+          srfi-96.ostk          \
+          srfi-100.ostk         \
+          srfi-113.ostk         \
+          srfi-117.ostk         \
+          srfi-127.ostk         \
+          srfi-128.ostk         \
+          srfi-129.ostk         \
+          srfi-130.ostk         \
+          srfi-134.ostk         \
+          srfi-135.ostk         \
+          srfi-137.ostk         \
+          srfi-141.ostk         \
+          srfi-151.ostk         \
+          srfi-156.ostk         \
+          srfi-158.ostk         \
+          srfi-161.ostk         \
+          srfi-171.ostk         \
+          srfi-173.ostk         \
+          srfi-174.ostk         \
+          srfi-175.ostk         \
+          srfi-180.ostk         \
+          srfi-185.ostk         \
+          srfi-189.ostk         \
+          srfi-190.ostk         \
+          srfi-196.ostk         \
+          srfi-207.ostk         \
+          tar.ostk              \
           trace.ostk
 
 scheme_SOLIBS = srfi-175-impl.@SH_SUFFIX@

--- a/lib/srfi-41.stk
+++ b/lib/srfi-41.stk
@@ -1,0 +1,48 @@
+;;;;
+;;;; srfi-41.stk		-- Implementation of SRFI-41
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 09-Jul-2020 23:22 (jpellegrini)
+;;;; Last file update: 10-Jul-2020 08:31 (jpellegrini)
+;;;;
+
+(require "srfi-9")
+
+(define-module SRFI-41
+  (export stream-null stream-cons stream? stream-null? stream-pair? stream-car
+          stream-cdr stream-lambda define-stream list->stream port->stream stream
+          stream->list stream-append stream-concat stream-constant stream-drop
+          stream-drop-while stream-filter stream-fold stream-for-each stream-from
+          stream-iterate stream-length stream-let stream-map stream-match _
+          stream-of stream-range stream-ref stream-reverse stream-scan stream-take
+          stream-take-while stream-unfold stream-unfolds stream-zip)
+  (export-syntax stream-lambda)
+  
+  (require "streams-primitive")
+  (require "streams-derived")
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import SRFI-41)
+(provide "srfi-41")

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -79,7 +79,7 @@
     (38 "External representation of shared structures")
     (39 "Parameters objects" (parameters))
     ;; 40  A Library of Streams
-    ;; 41  ?????????? Disappeared
+    (41 "Streams" (streams) "srfi-41")
     ;; 42  Eager Comprehensions
     ;; 43  Vector library
     ;; 44  Collections

--- a/lib/streams-derived.stk
+++ b/lib/streams-derived.stk
@@ -1,0 +1,517 @@
+;;;;
+;;;; srfi-41.stk		-- Implementation of SRFI-41 (derived part)
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file, except for the stream-match macro, is a derivative work
+;;;; from the  implementation of
+;;;; this SRFI by Philip L. Bewig, it is copyrighted as:
+
+;;;;;;  Copyright (c) 2007 Philip L. Bewig.
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+
+;;;; The stream-match macro is part of Chibi Scheme, written by Alex
+;;;; Shinn, and is copyrighted as:
+
+;;;;; Copyright (c) 2009-2018 Alex Shinn
+;;;;; All rights reserved.
+;;;;;
+;;;;; Redistribution and use in source and binary forms, with or without
+;;;;; modification, are permitted provided that the following conditions
+;;;;; are met:
+;;;;; 1. Redistributions of source code must retain the above copyright
+;;;;;    notice, this list of conditions and the following disclaimer.
+;;;;; 2. Redistributions in binary form must reproduce the above copyright
+;;;;;    notice, this list of conditions and the following disclaimer in the
+;;;;;    documentation and/or other materials provided with the distribution.
+;;;;; 3. The name of the author may not be used to endorse or promote products
+;;;;;    derived from this software without specific prior written permission.
+;;;;;
+;;;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+;;;;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;;;;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;;;;; IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+;;;;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;;;;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;;;;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;;;;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;;;;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;;;;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 09-Jul-2020 12:22 (jpellegrini)
+;;;; Last file update: 10-Jul-2020 00:15 (jpellegrini)
+;;;;
+
+(require "srfi-9")
+(require "srfi-1")
+(require "streams-primitive")
+
+(define-module STREAMS-DERIVED
+  (import STREAMS-PRIMITIVE SRFI-1)
+  (export define-stream list->stream port->stream stream stream->list
+          stream-append stream-concat stream-constant stream-drop
+          stream-drop-while stream-filter stream-fold stream-for-each stream-from
+          stream-iterate stream-length stream-let stream-map stream-match _
+          stream-of stream-range stream-ref stream-reverse stream-scan stream-take
+          stream-take-while stream-unfold stream-unfolds stream-zip)
+  (require "srfi-9")
+
+  (define exists any)
+
+  (define-syntax define-stream
+    (syntax-rules ()
+      ((define-stream (name . formal) body0 body1 ...)
+        (define name (stream-lambda formal body0 body1 ...)))))
+
+  (define (list->stream objs)
+    (define list->stream
+      (stream-lambda (objs)
+        (if (null? objs)
+            stream-null
+            (stream-cons (car objs) (list->stream (cdr objs))))))
+    (if (not (list? objs))
+        (error 'list->stream "non-list argument")
+        (list->stream objs)))
+
+  (define (port->stream . port)
+    (define port->stream
+      (stream-lambda (p)
+        (let ((c (read-char p)))
+          (if (eof-object? c)
+              stream-null
+              (stream-cons c (port->stream p))))))
+    (let ((p (if (null? port) (current-input-port) (car port))))
+      (if (not (input-port? p))
+          (error 'port->stream "non-input-port argument")
+          (port->stream p))))
+
+  (define-syntax stream
+    (syntax-rules ()
+      ((stream) stream-null)
+      ((stream x y ...) (stream-cons x (stream y ...)))))
+
+  (define (stream->list . args)
+    (let ((n (if (= 1 (length args)) #f (car args)))
+          (strm (if (= 1 (length args)) (car args) (cadr args))))
+      (cond ((not (stream? strm)) (error 'stream->list "non-stream argument"))
+            ((and n (not (integer? n))) (error 'stream->list "non-integer count"))
+            ((and n (negative? n)) (error 'stream->list "negative count"))
+            (else (let loop ((n (if n n -1)) (strm strm))
+                    (if (or (zero? n) (stream-null? strm))
+                        '()
+                        (cons (stream-car strm) (loop (- n 1) (stream-cdr strm)))))))))
+
+  (define (stream-append . strms)
+    (define stream-append
+      (stream-lambda (strms)
+        (cond ((null? (cdr strms)) (car strms))
+              ((stream-null? (car strms)) (stream-append (cdr strms)))
+              (else (stream-cons (stream-car (car strms))
+                                 (stream-append (cons (stream-cdr (car strms)) (cdr strms))))))))
+    (cond ((null? strms) stream-null)
+          ((exists (lambda (x) (not (stream? x))) strms)
+            (error 'stream-append "non-stream argument"))
+          (else (stream-append strms))))
+
+  (define (stream-concat strms)
+    (define stream-concat
+      (stream-lambda (strms)
+        (cond ((stream-null? strms) stream-null)
+              ((not (stream? (stream-car strms)))
+                (error 'stream-concat "non-stream object in input stream"))
+              ((stream-null? (stream-car strms))
+                (stream-concat (stream-cdr strms)))
+              (else (stream-cons
+                      (stream-car (stream-car strms))
+                      (stream-concat
+                        (stream-cons (stream-cdr (stream-car strms)) (stream-cdr strms))))))))
+    (if (not (stream? strms))
+        (error 'stream-concat "non-stream argument")
+        (stream-concat strms)))
+
+  (define stream-constant
+    (stream-lambda objs
+      (cond ((null? objs) stream-null)
+            ((null? (cdr objs)) (stream-cons (car objs) (stream-constant (car objs))))
+            (else (stream-cons (car objs)
+                               (apply stream-constant (append (cdr objs) (list (car objs)))))))))
+
+  (define (stream-drop n strm)
+    (define stream-drop
+      (stream-lambda (n strm)
+        (if (or (zero? n) (stream-null? strm))
+            strm
+            (stream-drop (- n 1) (stream-cdr strm)))))
+    (cond ((not (integer? n)) (error 'stream-drop "non-integer argument"))
+          ((negative? n) (error 'stream-drop "negative argument"))
+          ((not (stream? strm)) (error 'stream-drop "non-stream argument"))
+          (else (stream-drop n strm))))
+
+  (define (stream-drop-while pred? strm)
+    (define stream-drop-while
+      (stream-lambda (strm)
+        (if (and (stream-pair? strm) (pred? (stream-car strm)))
+            (stream-drop-while (stream-cdr strm))
+            strm)))
+    (cond ((not (procedure? pred?)) (error 'stream-drop-while "non-procedural argument"))
+          ((not (stream? strm)) (error 'stream-drop-while "non-stream argument"))
+          (else (stream-drop-while strm))))
+
+  (define (stream-filter pred? strm)
+    (define stream-filter
+      (stream-lambda (strm)
+        (cond ((stream-null? strm) stream-null)
+              ((pred? (stream-car strm))
+                (stream-cons (stream-car strm) (stream-filter (stream-cdr strm))))
+              (else (stream-filter (stream-cdr strm))))))
+    (cond ((not (procedure? pred?)) (error 'stream-filter "non-procedural argument"))
+          ((not (stream? strm)) (error 'stream-filter "non-stream argument"))
+          (else (stream-filter strm))))
+
+  (define (stream-fold proc base strm)
+    (cond ((not (procedure? proc)) (error 'stream-fold "non-procedural argument"))
+          ((not (stream? strm)) (error 'stream-fold "non-stream argument"))
+          (else (let loop ((base base) (strm strm))
+                  (if (stream-null? strm)
+                      base
+                      (loop (proc base (stream-car strm)) (stream-cdr strm)))))))
+
+  (define (stream-for-each proc . strms)
+    (define (stream-for-each strms)
+      (if (not (exists stream-null? strms))
+          (begin (apply proc (map stream-car strms))
+                 (stream-for-each (map stream-cdr strms)))))
+    (cond ((not (procedure? proc)) (error 'stream-for-each "non-procedural argument"))
+          ((null? strms) (error 'stream-for-each "no stream arguments"))
+          ((exists (lambda (x) (not (stream? x))) strms)
+            (error 'stream-for-each "non-stream argument"))
+          (else (stream-for-each strms))))
+
+  (define (stream-from first . step)
+    (define stream-from
+      (stream-lambda (first delta)
+        (stream-cons first (stream-from (+ first delta) delta))))
+    (let ((delta (if (null? step) 1 (car step))))
+      (cond ((not (number? first)) (error 'stream-from "non-numeric starting number"))
+            ((not (number? delta)) (error 'stream-from "non-numeric step size"))
+            (else (stream-from first delta)))))
+
+  (define (stream-iterate proc base)
+    (define stream-iterate
+      (stream-lambda (base)
+        (stream-cons base (stream-iterate (proc base)))))
+    (if (not (procedure? proc))
+        (error 'stream-iterate "non-procedural argument")
+        (stream-iterate base)))
+
+  (define (stream-length strm)
+    (if (not (stream? strm))
+        (error 'stream-length "non-stream argument")
+        (let loop ((len 0) (strm strm))
+          (if (stream-null? strm)
+              len
+              (loop (+ len 1) (stream-cdr strm))))))
+
+  (define-syntax stream-let
+    (syntax-rules ()
+      ((stream-let tag ((name val) ...) body1 body2 ...)
+       ((letrec ((tag (stream-lambda (name ...) body1 body2 ...))) tag) val ...))))
+
+  (define (stream-map proc . strms)
+    (define stream-map
+      (stream-lambda (strms)
+        (if (exists stream-null? strms)
+            stream-null
+            (stream-cons (apply proc (map stream-car strms))
+                         (stream-map (map stream-cdr strms))))))
+    (cond ((not (procedure? proc)) (error 'stream-map "non-procedural argument"))
+          ((null? strms) (error 'stream-map "no stream arguments"))
+          ((exists (lambda (x) (not (stream? x))) strms)
+            (error 'stream-map "non-stream argument"))
+          (else (stream-map strms))))
+
+;;; The following uses syntax-case. For this macro only, we have
+;;; switched to Chibi's implementation
+  ;; (define-syntax stream-match
+  ;;   (syntax-rules ()
+  ;;     ((stream-match strm-expr clause ...)
+  ;;       (let ((strm strm-expr))
+  ;;         (cond
+  ;;           ((not (stream? strm)) (error 'stream-match "non-stream argument"))
+  ;;           ((stream-match-test strm clause) => car) ...
+  ;;           (else (error 'stream-match "pattern failure")))))))
+
+  ;; (define-syntax stream-match-test
+  ;;   (syntax-rules ()
+  ;;     ((stream-match-test strm (pattern fender expr))
+  ;;       (stream-match-pattern strm pattern () (and fender (list expr))))
+  ;;     ((stream-match-test strm (pattern expr))
+  ;;       (stream-match-pattern strm pattern () (list expr)))))
+
+  ;; (define-syntax stream-match-pattern
+  ;;   (lambda (x)
+  ;;     (define (wildcard? x)
+  ;;       (and (identifier? x)
+  ;;            (free-identifier=? x (syntax _))))
+  ;;     (syntax-case x () 
+  ;;       ((stream-match-pattern strm () (binding ...) body)
+  ;;         (syntax (and (stream-null? strm) (let (binding ...) body))))
+  ;;       ((stream-match-pattern strm (w? . rest) (binding ...) body)
+  ;;         (wildcard? #'w?) 
+  ;;         (syntax (and (stream-pair? strm)
+  ;;                      (let ((strm (stream-cdr strm)))
+  ;;                        (stream-match-pattern strm rest (binding ...) body)))))
+  ;;       ((stream-match-pattern strm (var . rest) (binding ...) body)
+  ;;         (syntax (and (stream-pair? strm)
+  ;;                      (let ((temp (stream-car strm)) (strm (stream-cdr strm))) 
+  ;;                        (stream-match-pattern strm rest ((var temp) binding ...) body)))))
+  ;;       ((stream-match-pattern strm w? (binding ...) body)
+  ;;         (wildcard? #'w?)
+  ;;         (syntax (let (binding ...) body)))
+  ;;       ((stream-match-pattern strm var (binding ...) body) 
+  ;;         (syntax (let ((var strm) binding ...) body))))))
+
+;;; BEGIN portion taken from Chibi
+(define-syntax stream-match
+  (syntax-rules ()
+    ((stream-match expr clause ...)
+     (let ((strm expr))
+       (if (not (stream? strm))
+           (error 'stream-match "non-stream argument")
+           (stream-match-next strm clause ...))))))
+
+(define-syntax stream-match-next
+  (syntax-rules ()
+    ((stream-match-next strm)
+     (error 'stream-match "pattern failure"))
+    ((stream-match-next strm clause . clauses)
+     (let ((fail (lambda () (stream-match-next strm . clauses))))
+       (stream-match-one strm clause (fail))))))
+
+(define-syntax stream-match-one
+  (syntax-rules (_)
+    ((stream-match-one strm (() . body) fail)
+     (if (stream-null? strm)
+         (stream-match-body fail . body)
+         fail))
+    ((stream-match-one strm (_ . body) fail)
+     (stream-match-body fail . body))
+    ((stream-match-one strm ((a . b) . body) fail)
+     (if (stream-pair? strm)
+         (stream-match-one
+          (stream-car strm)
+          (a
+           (stream-match-one (stream-cdr strm) (b . body) fail))
+          fail)
+         fail))
+    ((stream-match-one strm (a . body) fail)
+     (let ((a strm))
+       (stream-match-body fail . body)))))
+
+(define-syntax stream-match-body
+  (syntax-rules ()
+    ((stream-match-body fail fender expr)
+     (if fender expr fail))
+    ((stream-match-body fail expr)
+     expr)))
+;;; END of portion from Chibi
+
+
+  (define-syntax stream-of
+    (syntax-rules ()
+      ((_ expr rest ...)
+        (stream-of-aux expr stream-null rest ...))))
+
+
+  (define-macro (stream-of-aux2 expr base v . rest)
+    (let ((var  (car v))
+          (loop (gensym "loop"))
+          (strm (gensym "strm"))
+          (stream (caddr v)))
+      `(stream-let ,loop ((,strm ,stream))
+                   (if (stream-null? ,strm)
+                       ,base
+                       (let ((,var (stream-car ,strm)))
+                         (stream-of-aux ,expr (,loop (stream-cdr ,strm)) ,@rest ))))))
+
+    
+  (define-syntax stream-of-aux
+    (syntax-rules (in is)
+      ((stream-of-aux expr base)
+        (stream-cons expr base))
+
+      ((stream-of-aux expr base (var in stream) rest ...)
+       (stream-of-aux2 expr base (var in stream) rest ...))
+        ;; (stream-let loop ((strm stream))
+        ;;   (if (stream-null? strm)
+        ;;       base
+        ;;       (let ((var (stream-car strm)))
+        ;;         (stream-of-aux expr (loop (stream-cdr strm)) rest ...)))))
+      
+      ((stream-of-aux expr base (var is exp) rest ...)
+        (let ((var exp)) (stream-of-aux expr base rest ...)))
+      
+      ((stream-of-aux expr base pred? rest ...)
+        (if pred? (stream-of-aux expr base rest ...) base))))
+
+  (define (stream-range first past . step)
+    (define stream-range
+      (stream-lambda (first past delta lt?)
+        (if (lt? first past)
+            (stream-cons first (stream-range (+ first delta) past delta lt?))
+            stream-null)))
+    (cond ((not (number? first)) (error 'stream-range "non-numeric starting number"))
+          ((not (number? past)) (error 'stream-range "non-numeric ending number"))
+          (else (let ((delta (cond ((pair? step) (car step)) ((< first past) 1) (else -1))))
+                  (if (not (number? delta))
+                      (error 'stream-range "non-numeric step size")
+                      (let ((lt? (if (< 0 delta) < >)))
+                        (stream-range first past delta lt?)))))))
+
+  (define (stream-ref strm n)
+    (cond ((not (stream? strm)) (error 'stream-ref "non-stream argument"))
+          ((not (integer? n)) (error 'stream-ref "non-integer argument"))
+          ((negative? n) (error 'stream-ref "negative argument"))
+          (else (let loop ((strm strm) (n n))
+                  (cond ((stream-null? strm) (error 'stream-ref "beyond end of stream"))
+                        ((zero? n) (stream-car strm))
+                        (else (loop (stream-cdr strm) (- n 1))))))))
+
+  (define (stream-reverse strm)
+    (define stream-reverse
+      (stream-lambda (strm rev)
+        (if (stream-null? strm)
+            rev
+            (stream-reverse (stream-cdr strm) (stream-cons (stream-car strm) rev)))))
+    (if (not (stream? strm))
+        (error 'stream-reverse "non-stream argument")
+        (stream-reverse strm stream-null)))
+
+  (define (stream-scan proc base strm)
+    (define stream-scan
+      (stream-lambda (base strm)
+        (if (stream-null? strm)
+            (stream base)
+            (stream-cons base (stream-scan (proc base (stream-car strm)) (stream-cdr strm))))))
+    (cond ((not (procedure? proc)) (error 'stream-scan "non-procedural argument"))
+          ((not (stream? strm)) (error 'stream-scan "non-stream argument"))
+          (else (stream-scan base strm))))
+
+  (define (stream-take n strm)
+    (define stream-take
+      (stream-lambda (n strm)
+        (if (or (stream-null? strm) (zero? n))
+            stream-null
+            (stream-cons (stream-car strm) (stream-take (- n 1) (stream-cdr strm))))))
+    (cond ((not (stream? strm)) (error 'stream-take "non-stream argument"))
+          ((not (integer? n)) (error 'stream-take "non-integer argument"))
+          ((negative? n) (error 'stream-take "negative argument"))
+          (else (stream-take n strm))))
+
+  (define (stream-take-while pred? strm)
+    (define stream-take-while
+      (stream-lambda (strm)
+        (cond ((stream-null? strm) stream-null)
+              ((pred? (stream-car strm))
+                (stream-cons (stream-car strm) (stream-take-while (stream-cdr strm))))
+              (else stream-null))))
+    (cond ((not (stream? strm)) (error 'stream-take-while "non-stream argument"))
+          ((not (procedure? pred?)) (error 'stream-take-while "non-procedural argument"))
+          (else (stream-take-while strm))))
+
+  (define (stream-unfold mapper pred? generator base)
+    (define stream-unfold
+      (stream-lambda (base)
+        (if (pred? base)
+            (stream-cons (mapper base) (stream-unfold (generator base)))
+            stream-null)))
+    (cond ((not (procedure? mapper)) (error 'stream-unfold "non-procedural mapper"))
+          ((not (procedure? pred?)) (error 'stream-unfold "non-procedural pred?"))
+          ((not (procedure? generator)) (error 'stream-unfold "non-procedural generator"))
+          (else (stream-unfold base))))
+
+  (define (stream-unfolds gen seed)
+    (define (len-values gen seed)
+      (call-with-values
+        (lambda () (gen seed))
+        (lambda vs (- (length vs) 1))))
+    (define unfold-result-stream
+      (stream-lambda (gen seed)
+        (call-with-values
+          (lambda () (gen seed))
+          (lambda (next . results)
+            (stream-cons results (unfold-result-stream gen next))))))
+    (define result-stream->output-stream
+      (stream-lambda (result-stream i)
+        (let ((result (list-ref (stream-car result-stream) (- i 1))))
+          (cond ((pair? result)
+                  (stream-cons
+                    (car result)
+                    (result-stream->output-stream (stream-cdr result-stream) i)))
+                ((not result)
+                  (result-stream->output-stream (stream-cdr result-stream) i))
+                ((null? result) stream-null)
+                (else (error 'stream-unfolds "can't happen"))))))
+    (define (result-stream->output-streams result-stream)
+      (let loop ((i (len-values gen seed)) (outputs '()))
+        (if (zero? i)
+            (apply values outputs)
+            (loop (- i 1) (cons (result-stream->output-stream result-stream i) outputs)))))
+    (if (not (procedure? gen))
+        (error 'stream-unfolds "non-procedural argument")
+        (result-stream->output-streams (unfold-result-stream gen seed))))
+
+  (define (stream-zip . strms)
+    (define stream-zip
+      (stream-lambda (strms)
+        (if (exists stream-null? strms)
+            stream-null
+            (stream-cons (map stream-car strms) (stream-zip (map stream-cdr strms))))))
+    (cond ((null? strms) (error 'stream-zip "no stream arguments"))
+          ((exists (lambda (x) (not (stream? x))) strms)
+            (error 'stream-zip "non-stream argument"))
+          (else (stream-zip strms))))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import STREAMS-DERIVED)
+(provide "streams-derived")

--- a/lib/streams-primitive.stk
+++ b/lib/streams-primitive.stk
@@ -1,0 +1,142 @@
+;;;;
+;;;; srfi-41.stk		-- Implementation of SRFI-41 (primitive part)
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Philip L. Bewig, it is copyrighted as:
+
+;;;;;;  Copyright (c) 2007 Philip L. Bewig.
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 07-Jul-2020 15:12 (jpellegrini)
+;;;; Last file update: 08-Jul-2020 12:43 (jpellegrini)
+;;;;
+
+(require "srfi-9")
+
+(define-module STREAMS-PRIMITIVE
+  (export stream-null stream-cons stream? stream-null? stream-pair?
+          stream-car stream-cdr)
+  
+  (export make-stream make-stream-pare)
+  (export %stream-eager)
+  (export-syntax stream-lambda)
+
+  (require "srfi-9")
+
+  ;;(define-record-type (stream-type make-stream stream?)
+  ;;  (fields (mutable box stream-promise stream-promise!)))
+  (define-record-type <stream>
+    (make-stream box)
+    stream?
+    (box stream-promise stream-promise!))
+  
+  (define-syntax stream-lazy
+    (syntax-rules ()
+      ((stream-lazy expr)
+        (make-stream
+          (cons 'lazy (lambda () expr))))))
+
+  (define (%stream-eager expr)
+    (make-stream
+      (cons 'eager expr)))
+
+  (define-syntax stream-delay
+    (syntax-rules ()
+      ((stream-delay expr)
+        (stream-lazy (%stream-eager expr)))))
+
+  (define (stream-force promise)
+    (let ((content (stream-promise promise)))
+      (case (car content)
+        ((eager) (cdr content))
+        ((lazy)  (let* ((promise* ((cdr content)))
+                        (content  (stream-promise promise)))
+                   (if (not (eqv? (car content) 'eager))
+                       (begin (set-car! content (car (stream-promise promise*)))
+                              (set-cdr! content (cdr (stream-promise promise*)))
+                              (stream-promise! promise* content)))
+                   (stream-force promise))))))
+
+  (define stream-null (stream-delay (cons 'stream 'null)))
+
+;;  (define-record-type (stream-pare-type make-stream-pare stream-pare?)
+;;    (fields (immutable kar stream-kar) (immutable kdr stream-kdr)))
+  (define-record-type <stream-pare>
+    (make-stream-pare kar kdr)
+    stream-pare?
+    (kar stream-kar)
+    (kdr stream-kdr))
+
+  (define (stream-pair? obj)
+    (and (stream? obj) (stream-pare? (stream-force obj))))
+
+  (define (stream-null? obj)
+    (and (stream? obj)
+         (eqv? (stream-force obj)
+               (stream-force stream-null))))
+
+  (define-syntax stream-cons
+    (syntax-rules ()
+      ((stream-cons obj strm)
+        (%stream-eager (make-stream-pare (stream-delay obj) (stream-lazy strm))))))
+
+  (define (stream-car strm)
+    (cond ((not (stream? strm)) (error  'stream-car "non-stream"))
+          ((stream-null? strm) (error 'stream-car "null stream"))
+          (else (stream-force (stream-kar (stream-force strm))))))
+
+  (define (stream-cdr strm)
+    (cond ((not (stream? strm)) (error 'stream-cdr "non-stream"))
+          ((stream-null? strm) (error 'stream-cdr "null stream"))
+          (else (stream-kdr (stream-force strm)))))
+
+  (define-syntax stream-lambda
+    (syntax-rules ()
+      ((stream-lambda formals body0 body1 ...)
+        (lambda formals (stream-lazy (let () body0 body1 ...))))))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import STREAMS-PRIMITIVE)
+(provide "streams-primitive")

--- a/tests/srfis/41.stk
+++ b/tests/srfis/41.stk
@@ -1,0 +1,470 @@
+
+;; ----------------------------------------------------------------------
+;;  SRFI 41 ...
+;; ----------------------------------------------------------------------
+;(test-subsection "SRFI 41 - Streams")
+
+;(require "srfi-41")
+
+;; wrapper for srfi-41-test-assert:
+(define-macro (srfi-41-test-assert expr result)
+  (let ((name (symbol->string (gensym "srfi-41-"))))
+    `(test ,name ,result ,expr)))
+
+(define strm123
+  (stream-cons
+   1 (stream-cons
+      2 (stream-cons
+         3 stream-null))))
+
+(define %old-error error)
+(define (error where what)
+  (with-output-to-string
+    (lambda ()
+      (display where)
+      (display ": ")
+      (display what))))
+                                          
+(define (identity obj) obj)
+
+(define (const obj) (lambda x obj))
+
+(define (negate pred?) (lambda (x) (not (pred? x))))
+
+(define (lsec proc . args) (lambda x (apply proc (append args x))))
+
+(define (rsec proc . args) (lambda x (apply proc (reverse (append (reverse args) (reverse x))))))
+
+(define nats
+  (stream-cons 0
+    (stream-map add1 nats)))
+
+(define (compose . fns)
+  (let comp ((fns fns))
+    (cond
+      ((null? fns) 'error)
+      ((null? (cdr fns)) (car fns))
+      (else
+        (lambda args
+          (call-with-values
+            (lambda ()
+              (apply
+                (comp (cdr fns))
+                args))
+            (car fns)))))))
+
+(define-stream (stream-unique eql? strm)
+  (if (stream-null? strm)
+      stream-null
+      (stream-cons (stream-car strm)
+        (stream-unique eql?
+          (stream-drop-while
+            (lambda (x)
+              (eql? (stream-car strm) x))
+            strm)))))
+
+(define-stream (stream-merge lt? . strms)
+  (define-stream (merge xx yy)
+    (stream-match xx (() yy) ((x . xs)
+      (stream-match yy (() xx) ((y . ys)
+        (if (lt? y x)
+            (stream-cons y (merge xx ys))
+            (stream-cons x (merge xs yy))))))))
+  (stream-let loop ((strms strms))
+    (cond ((null? strms) stream-null)
+          ((null? (cdr strms)) (car strms))
+          (else (merge (car strms)
+                       (apply stream-merge lt?
+                         (cdr strms)))))))
+
+(define (insert a)
+  (stream-lambda (xs ys)
+    (stream-append xs (stream a) ys)))
+
+
+(define-stream (msort lt? strm)
+  (let* ((n (quotient (stream-length strm) 2))
+         (ts (stream-take n strm))
+         (ds (stream-drop n strm)))
+    (if (zero? n)
+        strm
+        (stream-merge lt?
+          (msort < ts) (msort < ds)))))
+
+(define-stream (qsort lt? strm)
+  (if (stream-null? strm)
+      stream-null
+      (let ((x (stream-car strm))
+            (xs (stream-cdr strm)))
+        (stream-append
+          (qsort lt?
+            (stream-filter
+              (lambda (u) (lt? u x))
+              xs))
+          (stream x)
+          (qsort lt?
+            (stream-filter
+              (lambda (u) (not (lt? u x)))
+              xs))))))
+
+  (define-stream (isort lt? strm)
+    (define-stream (insert strm x)
+      (stream-match strm
+        (() (stream x))
+        ((y . ys)
+          (if (lt? y x)
+              (stream-cons y (insert ys x))
+              (stream-cons x strm)))))
+    (stream-fold insert stream-null strm))
+
+(define primes (let ()
+  (define-stream (next base mult strm)
+    (let ((first (stream-car strm))
+          (rest (stream-cdr strm)))
+      (cond ((< first mult)
+              (stream-cons first
+                (next base mult rest)))
+            ((< mult first)
+              (next base (+ base mult) strm))
+            (else (next base
+                    (+ base mult) rest)))))
+  (define-stream (sift base strm)
+    (next base (+ base base) strm))
+  (define-stream (sieve strm)
+    (let ((first (stream-car strm))
+          (rest (stream-cdr strm)))
+      (stream-cons first
+        (sieve (sift first rest)))))
+  (sieve (stream-from 2))))
+
+(define hamming
+  (stream-unique =
+    (stream-cons 1
+      (stream-merge <
+        (stream-map (lsec * 2) hamming)
+        (stream-merge <
+          (stream-map (lsec * 3) hamming)
+          (stream-map (lsec * 5) hamming))))))
+
+  ; stream-null
+  (srfi-41-test-assert (stream? stream-null) #t)
+  (srfi-41-test-assert (stream-null? stream-null) #t)
+  (srfi-41-test-assert (stream-pair? stream-null) #f)
+  
+  ; stream-cons
+  (srfi-41-test-assert (stream? (stream-cons 1 stream-null)) #t)
+  (srfi-41-test-assert (stream-null? (stream-cons 1 stream-null)) #f)
+  (srfi-41-test-assert (stream-pair? (stream-cons 1 stream-null)) #t)
+  
+  ; stream?
+  (srfi-41-test-assert (stream? stream-null) #t)
+  (srfi-41-test-assert (stream? (stream-cons 1 stream-null)) #t)
+  (srfi-41-test-assert (stream? "four") #f)
+  
+  ; stream-null?
+  (srfi-41-test-assert (stream-null? stream-null) #t)
+  (srfi-41-test-assert (stream-null? (stream-cons 1 stream-null)) #f)
+  (srfi-41-test-assert (stream-null? "four") #f)
+  
+  ; stream-pair?
+  (srfi-41-test-assert (stream-pair? stream-null) #f)
+  (srfi-41-test-assert (stream-pair? (stream-cons 1 stream-null)) #t)
+  (srfi-41-test-assert (stream-pair? "four") #f)
+  
+  ; stream-car
+  (srfi-41-test-assert (stream-car "four") "stream-car: non-stream")
+  (srfi-41-test-assert (stream-car stream-null) "stream-car: null stream")
+  (srfi-41-test-assert (stream-car strm123) 1)
+  
+  ; stream-cdr
+  (srfi-41-test-assert (stream-cdr "four") "stream-cdr: non-stream")
+  (srfi-41-test-assert (stream-cdr stream-null) "stream-cdr: null stream")
+  (srfi-41-test-assert (stream-car (stream-cdr strm123)) 2)
+  
+  ; stream-lambda
+  (srfi-41-test-assert
+    (stream->list
+      (letrec ((double
+        (stream-lambda (strm)
+          (if (stream-null? strm)
+              stream-null
+              (stream-cons
+                (* 2 (stream-car strm))
+                (double (stream-cdr strm)))))))
+        (double strm123)))
+    '(2 4 6))
+  
+  ; define-stream
+  (srfi-41-test-assert
+    (stream->list
+      (let ()
+        (define-stream (double strm)
+          (if (stream-null? strm)
+              stream-null
+              (stream-cons
+                (* 2 (stream-car strm))
+                (double (stream-cdr strm)))))
+        (double strm123)))
+    '(2 4 6))
+  
+  ; list->stream
+  (srfi-41-test-assert (list->stream "four") "list->stream: non-list argument")
+  (srfi-41-test-assert (stream->list (list->stream '())) '())
+  (srfi-41-test-assert (stream->list (list->stream '(1 2 3))) '(1 2 3))
+  
+  ;; ; port->stream
+  ;; ;; (let* ((p (open-input-file "streams.ss"))
+  ;; ;;        (s (port->stream p)))
+  ;; ;;   (srfi-41-test-assert (port->stream "four") "port->stream: non-input-port argument")
+  ;; ;;   (srfi-41-test-assert (string=? (list->string (stream->list 11 s)) "; Copyright") #t)
+  ;; ;;   (close-input-port p))
+  
+  ; stream
+  (srfi-41-test-assert (stream->list (stream)) '())
+  (srfi-41-test-assert (stream->list (stream 1)) '(1))
+  (srfi-41-test-assert (stream->list (stream 1 2 3)) '(1 2 3))
+ 
+  ;; ; stream->list
+  (srfi-41-test-assert (stream->list '()) "stream->list: non-stream argument")
+  (srfi-41-test-assert (stream->list "four" strm123) "stream->list: non-integer count")
+  (srfi-41-test-assert (stream->list -1 strm123) "stream->list: negative count")
+  (srfi-41-test-assert (stream->list (stream)) '())
+  (srfi-41-test-assert (stream->list strm123) '(1 2 3))
+  (srfi-41-test-assert (stream->list 5 strm123) '(1 2 3))
+  (srfi-41-test-assert (stream->list 3 (stream-from 1)) '(1 2 3))
+  
+  ; stream-append
+  (srfi-41-test-assert (stream-append "four") "stream-append: non-stream argument")
+
+  (srfi-41-test-assert (stream->list (stream-append strm123)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-append strm123 strm123)) '(1 2 3 1 2 3))
+  (srfi-41-test-assert (stream->list (stream-append strm123 strm123 strm123)) '(1 2 3 1 2 3 1 2 3))
+  (srfi-41-test-assert (stream->list (stream-append strm123 stream-null)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-append stream-null strm123)) '(1 2 3))
+
+
+  ; stream-concat
+  (srfi-41-test-assert (stream-concat "four") "stream-concat: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-concat (stream strm123))) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-concat (stream strm123 strm123))) '(1 2 3 1 2 3))
+  
+  ; stream-constant
+  (srfi-41-test-assert (stream-ref (stream-constant 1) 100) 1)
+  (srfi-41-test-assert (stream-ref (stream-constant 1 2) 100) 1)
+  (srfi-41-test-assert (stream-ref (stream-constant 1 2 3) 3) 1)
+  
+  ; stream-drop
+  (srfi-41-test-assert (stream-drop "four" strm123) "stream-drop: non-integer argument")
+  (srfi-41-test-assert (stream-drop -1 strm123) "stream-drop: negative argument")
+  (srfi-41-test-assert (stream-drop 2 "four") "stream-drop: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-drop 0 stream-null)) '())
+  (srfi-41-test-assert (stream->list (stream-drop 0 strm123)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-drop 1 strm123)) '(2 3))
+  (srfi-41-test-assert (stream->list (stream-drop 5 strm123)) '())
+  
+  ; stream-drop-while
+  (srfi-41-test-assert (stream-drop-while "four" strm123) "stream-drop-while: non-procedural argument")
+  (srfi-41-test-assert (stream-drop-while odd? "four") "stream-drop-while: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-drop-while odd? stream-null)) '())
+  (srfi-41-test-assert (stream->list (stream-drop-while odd? strm123)) '(2 3))
+  (srfi-41-test-assert (stream->list (stream-drop-while even? strm123)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-drop-while positive? strm123)) '())
+  (srfi-41-test-assert (stream->list (stream-drop-while negative? strm123)) '(1 2 3))
+  
+  ; stream-filter
+  (srfi-41-test-assert (stream-filter "four" strm123) "stream-filter: non-procedural argument")
+  (srfi-41-test-assert (stream-filter odd? '()) "stream-filter: non-stream argument")
+  (srfi-41-test-assert (stream-null? (stream-filter odd? (stream))) #t)
+  (srfi-41-test-assert (stream->list (stream-filter odd? strm123)) '(1 3))
+  (srfi-41-test-assert (stream->list (stream-filter even? strm123)) '(2))
+  (srfi-41-test-assert (stream->list (stream-filter positive? strm123)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-filter negative? strm123)) '())
+  (let loop ((n 10))
+    (srfi-41-test-assert (odd? (stream-ref (stream-filter odd? (stream-from 0)) n)) #t)
+    (if (positive? n) (loop (- n 1))))
+  (let loop ((n 10))
+    (srfi-41-test-assert (even? (stream-ref (stream-filter odd? (stream-from 0)) n)) #f)
+    (if (positive? n) (loop (- n 1))))
+  
+  ; stream-fold
+  (srfi-41-test-assert (stream-fold "four" 0 strm123) "stream-fold: non-procedural argument")
+  (srfi-41-test-assert (stream-fold + 0 '()) "stream-fold: non-stream argument")
+  (srfi-41-test-assert (stream-fold + 0 strm123) 6)
+  
+  ; stream-for-each
+  (srfi-41-test-assert (stream-for-each "four" strm123) "stream-for-each: non-procedural argument")
+;  (srfi-41-test-assert (stream-for-each display) "stream-for-each: no stream arguments")
+  (srfi-41-test-assert (stream-for-each display "four") "stream-for-each: non-stream argument")
+  (srfi-41-test-assert (let ((sum 0)) (stream-for-each (lambda (x) (set! sum (+ sum x))) strm123) sum) 6)
+
+  ; stream-from
+  (srfi-41-test-assert (stream-from "four") "stream-from: non-numeric starting number")
+  (srfi-41-test-assert (stream-from 1 "four") "stream-from: non-numeric step size")
+  (srfi-41-test-assert (stream-ref (stream-from 0) 100) 100)
+  (srfi-41-test-assert (stream-ref (stream-from 1 2) 100) 201)
+  (srfi-41-test-assert (stream-ref (stream-from 0 -1) 100) -100)
+  
+  ; stream-iterate
+  (srfi-41-test-assert (stream-iterate "four" 0) "stream-iterate: non-procedural argument")
+  (srfi-41-test-assert (stream->list 3 (stream-iterate (lsec + 1) 1)) '(1 2 3))
+  
+  ; stream-length
+  (srfi-41-test-assert (stream-length "four") "stream-length: non-stream argument")
+  (srfi-41-test-assert (stream-length (stream)) 0)
+  (srfi-41-test-assert (stream-length strm123) 3)
+  
+  ; stream-let
+  (srfi-41-test-assert (stream->list
+            (stream-let loop ((strm strm123))
+              (if (stream-null? strm)
+                  stream-null
+                  (stream-cons
+                    (* 2 (stream-car strm))
+                    (loop (stream-cdr strm))))))
+          '(2 4 6))
+  
+  ; stream-map
+  (srfi-41-test-assert (stream-map "four" strm123) "stream-map: non-procedural argument")
+;  (srfi-41-test-assert (stream-map odd?) "stream-map: no stream arguments")
+  (srfi-41-test-assert (stream-map odd? "four") "stream-map: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-map - strm123)) '(-1 -2 -3))
+  (srfi-41-test-assert (stream->list (stream-map + strm123 strm123)) '(2 4 6))
+  (srfi-41-test-assert (stream->list (stream-map + strm123 (stream-from 1))) '(2 4 6))
+  (srfi-41-test-assert (stream->list (stream-map + (stream-from 1) strm123)) '(2 4 6))
+  (srfi-41-test-assert (stream->list (stream-map + strm123 strm123 strm123)) '(3 6 9))
+  
+  ; stream-match
+  (srfi-41-test-assert (stream-match '(1 2 3) (_ 'ok)) "stream-match: non-stream argument")
+  (srfi-41-test-assert (stream-match strm123 (() 42)) "stream-match: pattern failure")
+  (srfi-41-test-assert (stream-match stream-null (() 'ok)) 'ok)
+  (srfi-41-test-assert (stream-match strm123 (() 'no) (else 'ok)) 'ok)
+  (srfi-41-test-assert (stream-match (stream 1) (() 'no) ((a) a)) 1)
+  (srfi-41-test-assert (stream-match (stream 1) (() 'no) ((_) 'ok)) 'ok)
+  (srfi-41-test-assert (stream-match strm123 ((a b c) (list a b c))) '(1 2 3))
+  (srfi-41-test-assert (stream-match strm123 ((a . _) a)) 1)
+  (srfi-41-test-assert (stream-match strm123 ((a b . _) (list a b))) '(1 2))
+  (srfi-41-test-assert (stream-match strm123 ((a b . c) (list a b (stream-car c)))) '(1 2 3))
+  (srfi-41-test-assert (stream-match strm123 (s (stream->list s))) '(1 2 3))
+  (srfi-41-test-assert (stream-match strm123 ((a . _) (= a 1) 'ok)) 'ok)
+  (srfi-41-test-assert (stream-match strm123 ((a . _) (= a 2) 'yes) (_ 'no)) 'no)
+  (srfi-41-test-assert (stream-match strm123 ((a b c) (= a b) 'yes) (_ 'no)) 'no)
+  (srfi-41-test-assert (stream-match (stream 1 1 2) ((a b c) (= a b) 'yes) (_ 'no)) 'yes)
+  
+  ; stream-of
+  (srfi-41-test-assert (stream->list
+            (stream-of (+ y 6)
+              (x in (stream-range 1 6))
+              (odd? x)
+              (y is (* x x)))) '(7 15 31))
+  (srfi-41-test-assert (stream->list
+            (stream-of (* x y)
+              (x in (stream-range 1 4))
+              (y in (stream-range 1 5))))
+          '(1 2 3 4 2 4 6 8 3 6 9 12))
+  (srfi-41-test-assert (stream-car (stream-of 1)) 1)
+
+  ; stream-range
+  (srfi-41-test-assert (stream-range "four" 0) "stream-range: non-numeric starting number")
+  (srfi-41-test-assert (stream-range 0 "four") "stream-range: non-numeric ending number")
+  (srfi-41-test-assert (stream-range 1 2 "three") "stream-range: non-numeric step size")
+  (srfi-41-test-assert (stream->list (stream-range 0 5)) '(0 1 2 3 4))
+  (srfi-41-test-assert (stream->list (stream-range 5 0)) '(5 4 3 2 1))
+  (srfi-41-test-assert (stream->list (stream-range 0 5 2)) '(0 2 4))
+  (srfi-41-test-assert (stream->list (stream-range 5 0 -2)) '(5 3 1))
+  (srfi-41-test-assert (stream->list (stream-range 0 1 -1)) '())
+  
+  ; stream-ref
+  (srfi-41-test-assert (stream-ref '() 4) "stream-ref: non-stream argument")
+  (srfi-41-test-assert (stream-ref nats 3.5) "stream-ref: non-integer argument")
+  (srfi-41-test-assert (stream-ref nats -3) "stream-ref: negative argument")
+  (srfi-41-test-assert (stream-ref strm123 5) "stream-ref: beyond end of stream")
+  (srfi-41-test-assert (stream-ref strm123 0) 1)
+  (srfi-41-test-assert (stream-ref strm123 1) 2)
+  (srfi-41-test-assert (stream-ref strm123 2) 3)
+  
+  ; stream-reverse
+  (srfi-41-test-assert (stream-reverse '()) "stream-reverse: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-reverse (stream))) '())
+  (srfi-41-test-assert (stream->list (stream-reverse strm123)) '(3 2 1))
+  
+  ; stream-scan
+  (srfi-41-test-assert (stream-scan "four" 0 strm123) "stream-scan: non-procedural argument")
+  (srfi-41-test-assert (stream-scan + 0 '()) "stream-scan: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-scan + 0 strm123)) '(0 1 3 6))
+  
+  ; stream-take
+  (srfi-41-test-assert (stream-take 5 "four") "stream-take: non-stream argument")
+  (srfi-41-test-assert (stream-take "four" strm123) "stream-take: non-integer argument")
+  (srfi-41-test-assert (stream-take -4 strm123) "stream-take: negative argument")
+  (srfi-41-test-assert (stream->list (stream-take 5 stream-null)) '())
+  (srfi-41-test-assert (stream->list (stream-take 0 stream-null)) '())
+  (srfi-41-test-assert (stream->list (stream-take 0 strm123)) '())
+  (srfi-41-test-assert (stream->list (stream-take 2 strm123)) '(1 2))
+  (srfi-41-test-assert (stream->list (stream-take 3 strm123)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-take 5 strm123)) '(1 2 3))
+  
+  ; stream-take-while
+  (srfi-41-test-assert (stream-take-while odd? "four") "stream-take-while: non-stream argument")
+  (srfi-41-test-assert (stream-take-while "four" strm123) "stream-take-while: non-procedural argument")
+  (srfi-41-test-assert (stream->list (stream-take-while odd? strm123)) '(1))
+  (srfi-41-test-assert (stream->list (stream-take-while even? strm123)) '())
+  (srfi-41-test-assert (stream->list (stream-take-while positive? strm123)) '(1 2 3))
+  (srfi-41-test-assert (stream->list (stream-take-while negative? strm123)) '())
+  
+  ; stream-unfold
+  (srfi-41-test-assert (stream-unfold "four" odd? + 0) "stream-unfold: non-procedural mapper")
+  (srfi-41-test-assert (stream-unfold + "four" + 0) "stream-unfold: non-procedural pred?")
+  (srfi-41-test-assert (stream-unfold + odd? "four" 0) "stream-unfold: non-procedural generator")
+  (srfi-41-test-assert (stream->list (stream-unfold (rsec expt 2) (rsec < 10) (rsec + 1) 0))
+          '(0 1 4 9 16 25 36 49 64 81))
+  
+  ; stream-unfolds
+  (srfi-41-test-assert
+    (stream->list
+      (stream-unfolds
+        (lambda (x)
+          (let ((n (car x)) (s (cdr x)))
+            (if (zero? n)
+                (values 'dummy '())
+                (values
+                  (cons (- n 1) (stream-cdr s))
+                  (list (stream-car s))))))
+        (cons 5 (stream-from 0))))
+      '(0 1 2 3 4))
+  
+  ; stream-zip
+;  (srfi-41-test-assert (stream-zip) "stream-zip: no stream arguments")
+  (srfi-41-test-assert (stream-zip "four") "stream-zip: non-stream argument")
+  (srfi-41-test-assert (stream-zip strm123 "four") "stream-zip: non-stream argument")
+  (srfi-41-test-assert (stream->list (stream-zip strm123 stream-null)) '())
+  (srfi-41-test-assert (stream->list (stream-zip strm123)) '((1) (2) (3)))
+  (srfi-41-test-assert (stream->list (stream-zip strm123 strm123)) '((1 1) (2 2) (3 3)))
+  (srfi-41-test-assert (stream->list (stream-zip strm123 (stream-from 1))) '((1 1) (2 2) (3 3)))
+  (srfi-41-test-assert (stream->list (stream-zip strm123 strm123 strm123)) '((1 1 1) (2 2 2) (3 3 3)))
+
+ ; other tests
+  (srfi-41-test-assert
+    (stream-car
+      (stream-reverse
+        (stream-take-while
+          (rsec < 1000)
+          primes)))
+    997)
+  
+  (srfi-41-test-assert
+    (equal?
+      (stream->list (qsort < (stream 3 1 5 2 4)))
+      (stream->list (isort < (stream 2 5 1 4 3))))
+    #t)
+  
+  (srfi-41-test-assert
+    (equal?
+      (stream->list (msort < (stream 3 1 5 2 4)))
+      (stream->list (isort < (stream 2 5 1 4 3))))
+    #t)
+  
+  ; http://www.research.att.com/~njas/sequences/A051037
+  (srfi-41-test-assert (stream-ref hamming 999) 51200000)
+
+;;; revert to old error procedure!
+(set! error %old-error)


### PR DESCRIPTION
So, here is SRFI-41!

But I have some remarks. 


* modified to not use R6RS records
* one macro was taken from Chibi, because the reference implementation uses syntax-case
* I have created three modules, "streams-primitive", "streams-derived" and "srfi-41", which loads the other two. But I only included "srfi-41" in SRFI-0. I suppose it would be nice to have "srfi-41 primitive" and "srfi-41 derived", but I'm not sure. What do you think?
* Also corrected a little problem in SRFI-0 (SRFI-41 did not disappear! And SRFI-40 was withdrawn...)
* In order to take full advantage of the tests written by the original author, I have redefined (temporarilly) the error procedure, so it will print the error and continue (the tests actually match the exact error string)
 
And a more complicated one:

* I had to rewrite one macro using `define-macro`, see issue #55 .

Maybe it would be better to postpone accepting this PR until this is resolved (but I thought it would be nice to have it "almost ready" -- I can make small adjustments and push when a solution is chosen)