### PR TITLE
Add SRFI-129 - Titlecase Procedures

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -64,6 +64,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-111: Boxes
     - SRFI-112: Environment Inquiry
     - SRFI-117: Queues based on lists
+    - SRFI-129: Titlecase procedures
     - SRFI-141: Integer Division
     - SRFI-145: Assumptions
     - SRFI-156: Syntactic combiners for binary predicates

--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -628,6 +628,9 @@ described in this document (procedures
 ;; SRFI 117 -- Queues based on lists
 (gen-loaded-srfi 117)
 
+;; SRFI 129 -- Titlecase Procedures
+(gen-loaded-srfi 129)
+
 ;; SRFI 141 -- Integer division
 (gen-loaded-srfi 141)
 

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -76,6 +76,7 @@
      (111 . "Boxes")
      (112 . "Environment Inquiry")
      (117 . "Queues based on lists")
+     (129 . "Titlecase procedures")
      (141 . "Integer Division")
      (145 . "Assumptions")
      (156 . "Syntactic combiners for binary predicates")

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -89,7 +89,8 @@ scheme_SRCS = STklos.init     \
           srfi-89.stk         \
           srfi-96.stk         \
           srfi-100.stk        \
-	        srfi-117.stk        \
+	  srfi-117.stk        \
+	  srfi-129.stk        \
           srfi-141.stk        \
           srfi-156.stk        \
           srfi-158.stk        \
@@ -143,9 +144,9 @@ scheme_OBJS = compfile.ostk    \
           srfi-89.ostk         \
           srfi-96.ostk         \
           srfi-100.ostk        \
-	        srfi-117.ostk        \
-          srfi-141.ostk        \
-          srfi-117.ostk        \
+	  srfi-117.ostk        \
+	  srfi-129.ostk        \
+	  srfi-141.ostk	       \
           srfi-156.ostk        \
           srfi-158.ostk        \
           srfi-171.ostk        \

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -185,7 +185,7 @@
     ;; srfi-126                         ; R6RS-based hashtables
     ;; srfi-127                         ; Lazy Sequences
     ;; srfi-128                         ; Comparators (reduced)
-    ;; srfi-129                         ; Titlecase procedures
+    ((srfi-129 titlecase) "srfi-129")   ; Titlecase procedures
     ;; srfi-130                         ; Cursor-based string library
     ;; srfi-131                         ; ERR5RS Record Syntax (reduced)
     ;; srfi-132                         ; Sort Libraries

--- a/lib/srfi-129.stk
+++ b/lib/srfi-129.stk
@@ -1,0 +1,234 @@
+;;;;
+;;;; srfi-129.stk		-- Implementation of SRFI-129
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by John Cowan, it is copyrighted as:
+;;;;
+
+;;;;; Copyright (c) 2015 John Cowan
+;;;;;
+;;;;; Permission is hereby granted, free of charge, to any person
+;;;;; obtaining a copy of this software and associated documentation
+;;;;; files (the "Software"), to deal in the Software without
+;;;;; restriction, including without limitation the rights to use, copy,
+;;;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;;;; of the Software, and to permit persons to whom the Software is
+;;;;; furnished to do so, subject to the following conditions:
+;;;;;
+;;;;; The above copyright notice and this permission notice shall be
+;;;;; included in all copies or substantial portions of the Software.
+;;;;;
+;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;;;;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;;;;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;;;;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;;;;; SOFTWARE.
+
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 04-Jul-2020 07:22 (jpellegrini)
+;;;; Last file update: 04-Jul-2020 09:10 (jpellegrini)
+;;;;
+
+(define-module SRFI-129
+  (export char-title-case? char-titlecase string-titlecase)
+
+;;;; Alists for titlecase functions
+
+;;; Assumes that char->integer and integer->char are a subset of Unicode
+;;; codepoint mappings rather than some random codes, as R5RS allows
+;;; but R[67]RS do not.  It may be necessary to remove some lines if
+;;; the codepoints referred to don't correspond to characters present
+;;; in the implementation.
+
+;;; These maps are valid from Unicode 5.0 to at least Unicode 8.0
+;;; and are expected to be stable for the foreseeable future.
+
+;; Alist mapping titlecase characters to themselves
+(define titlecase-chars '(
+  (#x01C5 #x01C5) ; LATIN CAPITAL LETTER D WITH SMALL LETTER Z WITH CARON
+  (#x01C8 #x01C8) ; LATIN CAPITAL LETTER L WITH SMALL LETTER J
+  (#x01CB #x01CB) ; LATIN CAPITAL LETTER N WITH SMALL LETTER J
+  (#x01F2 #x01F2) ; LATIN CAPITAL LETTER D WITH SMALL LETTER Z
+  (#x1F88 #x1F88) ; GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI
+  (#x1F89 #x1F89) ; GREEK CAPITAL LETTER ALPHA WITH DASIA AND PROSGEGRAMMENI
+  (#x1F8A #x1F8A) ; GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA AND PROSGEGRAMMENI
+  (#x1F8B #x1F8B) ; GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA AND PROSGEGRAMMENI
+  (#x1F8C #x1F8C) ; GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA AND PROSGEGRAMMENI
+  (#x1F8D #x1F8D) ; GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA AND PROSGEGRAMMENI
+  (#x1F8E #x1F8E) ; GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI
+  (#x1F8F #x1F8F) ; GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+  (#x1F98 #x1F98) ; GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI
+  (#x1F99 #x1F99) ; GREEK CAPITAL LETTER ETA WITH DASIA AND PROSGEGRAMMENI
+  (#x1F9A #x1F9A) ; GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA AND PROSGEGRAMMENI
+  (#x1F9B #x1F9B) ; GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA AND PROSGEGRAMMENI
+  (#x1F9C #x1F9C) ; GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA AND PROSGEGRAMMENI
+  (#x1F9D #x1F9D) ; GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA AND PROSGEGRAMMENI
+  (#x1F9E #x1F9E) ; GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI
+  (#x1F9F #x1F9F) ; GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+  (#x1FA8 #x1FA8) ; GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI
+  (#x1FA9 #x1FA9) ; GREEK CAPITAL LETTER OMEGA WITH DASIA AND PROSGEGRAMMENI
+  (#x1FAA #x1FAA) ; GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA AND PROSGEGRAMMENI
+  (#x1FAB #x1FAB) ; GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA AND PROSGEGRAMMENI
+  (#x1FAC #x1FAC) ; GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA AND PROSGEGRAMMENI
+  (#x1FAD #x1FAD) ; GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA AND PROSGEGRAMMENI
+  (#x1FAE #x1FAE) ; GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI
+  (#x1FAF #x1FAF) ; GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+  (#x1FBC #x1FBC) ; GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+  (#x1FCC #x1FCC) ; GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+  (#x1FFC #x1FFC) ; GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+))
+
+;; Alist mapping characters to their single-letter titlecase equivalents
+;;   when those are distinct from their uppercase equivalents
+(define title-single-map (append titlecase-chars '(
+  (#x01C4 #x01C5) ; LATIN CAPITAL LETTER DZ WITH CARON
+  (#x01C6 #x01C5) ; LATIN SMALL LETTER DZ WITH CARON
+  (#x01C7 #x01C8) ; LATIN CAPITAL LETTER LJ
+  (#x01C9 #x01C8) ; LATIN SMALL LETTER LJ
+  (#x01CA #x01CB) ; LATIN CAPITAL LETTER NJ
+  (#x01CC #x01CB) ; LATIN SMALL LETTER NJ
+  (#x01F1 #x01F2) ; LATIN CAPITAL LETTER DZ
+  (#x01F3 #x01F2) ; LATIN SMALL LETTER DZ
+)))
+
+;; Alist mapping characters to their multiple-letter titlecase equivalents
+(define title-multiple-map (append title-single-map '(
+  (#x00DF #x0053 #x0073) ; LATIN SMALL LETTER SHARP S
+  (#xFB00 #x0046 #x0066) ; LATIN SMALL LIGATURE FF
+  (#xFB01 #x0046 #x0069) ; LATIN SMALL LIGATURE FI
+  (#xFB02 #x0046 #x006C) ; LATIN SMALL LIGATURE FL
+  (#xFB03 #x0046 #x0066 #x0069) ; LATIN SMALL LIGATURE FFI
+  (#xFB04 #x0046 #x0066 #x006C) ; LATIN SMALL LIGATURE FFL
+  (#xFB05 #x0053 #x0074) ; LATIN SMALL LIGATURE LONG S T
+  (#xFB06 #x0053 #x0074) ; LATIN SMALL LIGATURE ST
+  (#x0587 #x0535 #x0582) ; ARMENIAN SMALL LIGATURE ECH YIWN
+  (#xFB13 #x0544 #x0576) ; ARMENIAN SMALL LIGATURE MEN NOW
+  (#xFB14 #x0544 #x0565) ; ARMENIAN SMALL LIGATURE MEN ECH
+  (#xFB15 #x0544 #x056B) ; ARMENIAN SMALL LIGATURE MEN INI
+  (#xFB16 #x054E #x0576) ; ARMENIAN SMALL LIGATURE VEW NOW
+  (#xFB17 #x0544 #x056D) ; ARMENIAN SMALL LIGATURE MEN XEH
+  (#x0149 #x02BC #x004E) ; LATIN SMALL LETTER N PRECEDED BY APOSTROPHE
+  (#x0390 #x0399 #x0308 #x0301) ; GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
+  (#x03B0 #x03A5 #x0308 #x0301) ; GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
+  (#x01F0 #x004A #x030C) ; LATIN SMALL LETTER J WITH CARON
+  (#x1E96 #x0048 #x0331) ; LATIN SMALL LETTER H WITH LINE BELOW
+  (#x1E97 #x0054 #x0308) ; LATIN SMALL LETTER T WITH DIAERESIS
+  (#x1E98 #x0057 #x030A) ; LATIN SMALL LETTER W WITH RING ABOVE
+  (#x1E99 #x0059 #x030A) ; LATIN SMALL LETTER Y WITH RING ABOVE
+  (#x1E9A #x0041 #x02BE) ; LATIN SMALL LETTER A WITH RIGHT HALF RING
+  (#x1F50 #x03A5 #x0313) ; GREEK SMALL LETTER UPSILON WITH PSILI
+  (#x1F52 #x03A5 #x0313 #x0300) ; GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA
+  (#x1F54 #x03A5 #x0313 #x0301) ; GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA
+  (#x1F56 #x03A5 #x0313 #x0342) ; GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI
+  (#x1FB6 #x0391 #x0342) ; GREEK SMALL LETTER ALPHA WITH PERISPOMENI
+  (#x1FC6 #x0397 #x0342) ; GREEK SMALL LETTER ETA WITH PERISPOMENI
+  (#x1FD2 #x0399 #x0308 #x0300) ; GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA
+  (#x1FD3 #x0399 #x0308 #x0301) ; GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+  (#x1FD6 #x0399 #x0342) ; GREEK SMALL LETTER IOTA WITH PERISPOMENI
+  (#x1FD7 #x0399 #x0308 #x0342) ; GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI
+  (#x1FE2 #x03A5 #x0308 #x0300) ; GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA
+  (#x1FE3 #x03A5 #x0308 #x0301) ; GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA
+  (#x1FE4 #x03A1 #x0313) ; GREEK SMALL LETTER RHO WITH PSILI
+  (#x1FE6 #x03A5 #x0342) ; GREEK SMALL LETTER UPSILON WITH PERISPOMENI
+  (#x1FE7 #x03A5 #x0308 #x0342) ; GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI
+  (#x1FF6 #x03A9 #x0342) ; GREEK SMALL LETTER OMEGA WITH PERISPOMENI
+  (#x1FB2 #x1FBA #x0345) ; GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI
+  (#x1FB4 #x0386 #x0345) ; GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+  (#x1FC2 #x1FCA #x0345) ; GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI
+  (#x1FC4 #x0389 #x0345) ; GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+  (#x1FF2 #x1FFA #x0345) ; GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI
+  (#x1FF4 #x038F #x0345) ; GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+  (#x1FB7 #x0391 #x0342 #x0345) ; GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
+  (#x1FC7 #x0397 #x0342 #x0345) ; GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
+  (#x1FF7 #x03A9 #x0342 #x0345) ; GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
+)))
+
+;; Alist mapping characters to their multiple-character lowercase equivalents
+(define lower-multiple-map '(
+  (#x0130 #x0069 #x0307) ; LATIN CAPITAL LETTER I WITH DOT ABOVE
+))
+
+
+;; Returns #t if argument is a titlecase character, #f if not
+(define (char-title-case? ch)
+  (let* ((codepoint (char->integer ch))
+         (result (assq codepoint titlecase-chars)))
+    (if result #t #f)))
+
+;; Returns the single-character titlecase mapping of argument
+(define (char-titlecase ch)
+  (let* ((codepoint (char->integer ch))
+        (result (assq codepoint title-single-map)))
+    (if result
+      (integer->char (cadr result))
+      (char-upcase ch))))
+
+
+;; Returns #t if a character is caseless, otherwise #f
+(define (char-caseless? ch)
+  (not (or (char-lower-case? ch) (char-upper-case? ch) (char-title-case? ch))))
+
+;; Push a list onto another list in reverse order
+(define (reverse-push new old)
+  (if (null? new)
+    old
+    (reverse-push (cdr new) (cons (car new) old))))
+
+;; Returns the string titlecase mapping of argument
+(define (string-titlecase str)
+  (let loop ((n 0) (result '()))
+    (if (= n (string-length str))
+       (apply string (map integer->char (reverse result)))
+       (let* ((ch (string-ref str n)) (codepoint (char->integer ch)))
+         (if (or (= n 0) (char-caseless? (string-ref str (- n 1))))
+           ; ch must be titlecased
+           (let ((multi-title (assq codepoint title-multiple-map)))
+             (if multi-title
+               ; ch has multiple- or single-character titlecase mapping
+               (loop (+ n 1) (reverse-push (cdr multi-title) result))
+               ; ch has single-character uppercase mapping
+               (loop (+ n 1) (reverse-push (list (char->integer (char-upcase ch))) result))))
+           ; ch must be lowercased
+           (let ((multi-downcase (assq codepoint lower-multiple-map)))
+             (if multi-downcase
+               ; ch has multiple-character lowercase mapping
+               (loop (+ n 1) (reverse-push (cdr multi-downcase) result))
+               ; ch has single-character lowercase mapping
+               (loop (+ n 1) (reverse-push (list (char->integer (char-downcase ch))) result)))))))))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import SRFI-129)
+
+;; If we just define the new string-titlecase in  SRFI-129
+;; and import it, STklos will still use the old definition,
+;; so we define %string-titlecase and explicitly redefine
+;; string-titlecase here:
+(define %string-titlecase string-titlecase)
+(define string-titlecase (in-module SRFI-129 string-titlecase))
+
+(provide "srfi-129")

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -733,6 +733,51 @@
 (define y1 (list-queue-unfold-right done? double add1 0 y0))
 (test "list-queue-unfold-right II" '(8 6 4 2 0) (list-queue-list y1))
 
+
+;; ----------------------------------------------------------------------
+;;  SRFI 129 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 129 - Titlecase procedures")
+
+(require "srfi-129")
+
+(test "" #t (char-title-case? #\x01C5))
+(test "" #t (char-title-case? #\x1FFC))
+(test "" #f (char-title-case? #\Z))
+(test "" #f (char-title-case? #\z))
+
+(test "char 1" #\x01C5 (char-titlecase #\x01C4))
+(test "char 2" #\x01C5 (char-titlecase #\x01C6))
+(test "char 3" #\Z (char-titlecase #\Z))
+(test "char 4" #\Z (char-titlecase #\z))
+
+(test "string 1" "\x01C5;" (string-titlecase "\x01C5;"))
+(test "string 2" "\x01C5;" (string-titlecase "\x01C4;"))    ;
+(test "string 3" "Ss" (string-titlecase "\x00DF;"))         ;
+(test "string 4" "Xi\x0307;" (string-titlecase "x\x0130;")) ;
+(test "string 5" "\x1F88;" (string-titlecase "\x1F80;"))
+(test "string 6" "\x1F88;" (string-titlecase "\x1F88;"))
+
+
+(define Floo "\xFB02;oo")
+(define Floo-bar "\xFB02;oo bar")
+(define Baffle "Ba\xFB04;e")
+(define LJUBLJANA "\x01C7;ub\x01C7;ana")
+(define Ljubljana "\x01C8;ub\x01C9;ana")
+(define ljubljana "\x01C9;ub\x01C9;ana")
+
+(test "string 7" "Bar Baz" (string-titlecase "bAr baZ"))
+(test "string 8" "Floo" (string-titlecase "floo"))
+(test "string 9" "Floo" (string-titlecase "FLOO"))
+(test "string 10" "Floo" (string-titlecase Floo))          ;
+(test "string 11" "Floo Bar" (string-titlecase "floo bar"))
+(test "string 12" "Floo Bar" (string-titlecase "FLOO BAR"))
+(test "string 13" "Floo Bar" (string-titlecase Floo-bar))  ;
+(test "string 14" Baffle (string-titlecase Baffle))
+(test "string 15" Ljubljana (string-titlecase LJUBLJANA))  ;
+(test "string 16" Ljubljana (string-titlecase Ljubljana))
+(test "string 17" Ljubljana (string-titlecase ljubljana))  ;
+
 ;; ----------------------------------------------------------------------
 ;;  SRFI 141 ...
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
I suppose it would make sense to use SRFI-129, since it is more general than the already present `string-titlecase` in STklos, and it offers two more procedures for characters. The tests added have a couple of comment marks at the end of the line, like this:

```
(test "string 3" "Ss" (string-titlecase "\x00DF;"))         ;
```

to show where this SRFI implementation differs from the embedded `string-titlecase` in STklos.

This SRFI exports

```
char-title-case?
char-titlecase
string-titlecase
```

One thing: if I create the module and export `string-titlecase`, the old one (defined as a primitive) will still be used, so I had to export a procedure `%string-titlecase` and later, after importing `SRFI-129` into the `STklos` module, redefin it:

```
;; If we just define the new string-titlecase in  SRFI-129
;; and import it, STklos will still use the old definition,
;; so we define %string-titlecase and explicitly redefine
;; string-titlecase here:
(define string-titlecase %string-titlecase)
```

I'm not sure if you think this is OK, or if there is a better way of doing this.
