### PR TITLE
Add SRFI-94 - Type-Restricted Numerical Functions

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -63,6 +63,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-87: => in case clauses
     - SRFI-88: Keyword Objects
     - SRFI-89: Optional Positional and Named Parameters
+    - SRFI-94: Type-Restricted Numerical Functions
     - SRFI-96: SLIB Prerequisites
     - SRFI-98: Interface to access environment variables
     - SRFI-100: define-lambda-object

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -110,6 +110,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-70.stk         \
           srfi-74.stk         \
           srfi-89.stk         \
+          srfi-94.stk         \
           srfi-96.stk         \
           srfi-100.stk        \
           srfi-113.stk        \
@@ -186,6 +187,7 @@ scheme_OBJS = compfile.ostk     \
           srfi-70.ostk          \
           srfi-74.ostk          \
           srfi-89.ostk          \
+          srfi-94.ostk          \
           srfi-96.ostk          \
           srfi-100.ostk         \
           srfi-113.ostk         \

--- a/lib/srfi-94.stk
+++ b/lib/srfi-94.stk
@@ -1,0 +1,233 @@
+
+;;;; srfi-94.stk		-- Implementation of SRFI-94
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Aubrey Jaffer, it is copyrighted as:
+;;;;
+;;;;;; Copyright (C) Aubrey Jaffer 2006. All Rights Reserved.
+;;;;;;
+;;;;;; Permission is hereby granted, free of charge, to any person
+;;;;;; obtaining a copy of this software and associated documentation files
+;;;;;; (the "Software"), to deal in the Software without restriction,
+;;;;;; including without limitation the rights to use, copy, modify, merge,
+;;;;;; publish, distribute, sublicense, and/or sell copies of the Software,
+;;;;;; and to permit persons to whom the Software is furnished to do so,
+;;;;;; subject to the following conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;;;;;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;;;;;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;;;;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 18-Jul-2020 12:43 (jpellegrini)
+;;;; Last file update: 06-Feb-2021 14:21 (jpellegrini)
+;;;;
+
+(require "srfi-60")			;ash, integer-length
+
+(define-module SRFI-94
+
+(export real-exp
+        real-ln
+        real-log
+        real-sin
+        real-cos
+        real-tan
+        real-asin
+        real-acos
+        real-atan
+        ;;atan - not even defined in this implementation. And STklos already does
+        ;;       what the SRFI says
+        real-sqrt
+        integer-sqrt
+        integer-log
+        integer-expt
+        real-expt
+        quo
+        rem
+        mod
+        ln
+        srfi-94:make-rectangular
+        srfi-94:make-polar
+        ;;abs - no need to change, STklos already does it as the SRFI says
+        srfi-94:quotient
+        srfi-94:remainder
+        srfi-94:modulo
+        )
+
+
+(define (type-error procedure . args)
+  (apply error (cons procedure
+                     (cons "bad number"
+                           args))))
+
+;@
+(define (integer-expt x1 x2)
+  (cond ((and (exact? x1) (integer? x1)
+	      (exact? x2) (integer? x2)
+	      (not (and (not (<= -1 x1 1)) (negative? x2))))
+	 (expt x1 x2))
+	(else (type-error 'integer-expt x1 x2))))
+;@
+(define (integer-log base k)
+  (define (ilog m b k)
+    (cond ((< k b) k)
+	  (else
+	   (set! n (+ n m))
+	   (let ((q (ilog (+ m m) (* b b) (quotient k b))))
+	     (cond ((< q b) q)
+		   (else (set! n (+ m n))
+			 (quotient q b)))))))
+  (define n 1)
+  (define (eigt? k j) (and (exact? k) (integer? k) (> k j)))
+  (cond ((not (and (eigt? base 1) (eigt? k 0)))
+	 (type-error 'integer-log base k))
+	((< k base) 0)
+	(else (ilog 1 base (quotient k base)) n)))
+
+;;;; http://www.cs.cmu.edu/afs/cs/project/ai-repository/ai/lang/lisp/code/math/isqrt/isqrt.txt
+;;; Akira Kurihara
+;;; School of Mathematics
+;;; Japan Women's University
+;@
+(define integer-sqrt
+  (let ((table '#(0
+		  1 1 1
+		  2 2 2 2 2
+		  3 3 3 3 3 3 3
+		  4 4 4 4 4 4 4 4 4))
+	(square (lambda (x) (* x x))))
+    (lambda (n)
+      (define (isqrt n)
+	(if (> n 24)
+	    (let* ((len/4 (quotient (- (integer-length n) 1) 4))
+		   (top (isqrt (ash n (* -2 len/4))))
+		   (init (ash top len/4))
+		   (q (quotient n init))
+		   (iter (quotient (+ init q) 2)))
+	      (cond ((odd? q) iter)
+		    ((< (remainder n init) (square (- iter init))) (- iter 1))
+		    (else iter)))
+	    (vector-ref table n)))
+      (if (and (exact? n) (integer? n) (not (negative? n)))
+	  (isqrt n)
+	  (type-error 'integer-sqrt n)))))
+
+(define (must-be-exact-integer2 name proc)
+  (lambda (n1 n2)
+    (if (and (integer? n1) (integer? n2) (exact? n1) (exact? n2))
+	(proc n1 n2)
+	(type-error name n1 n2))))
+;@
+(define srfi-94:quotient  (must-be-exact-integer2 'quotient quotient))
+(define srfi-94:remainder (must-be-exact-integer2 'remainder remainder))
+(define srfi-94:modulo    (must-be-exact-integer2 'modulo modulo))
+
+;;;; real-only functions
+;@
+(define (quo x1 x2) (truncate (/ x1 x2)))
+(define (rem x1 x2) (- x1 (* x2 (quo x1 x2))))
+(define (mod x1 x2) (- x1 (* x2 (floor (/ x1 x2)))))
+
+(define (must-be-real name proc)
+  (lambda (x1)
+    (if (real? x1) (proc x1) (type-error name x1))))
+(define (must-be-real+ name proc)
+  (lambda (x1)
+    (if (and (real? x1) (>= x1 0))
+	(proc x1)
+	(type-error name x1))))
+(define (must-be-real-1+1 name proc)
+  (lambda (x1)
+    (if (and (real? x1) (<= -1 x1 1))
+	(proc x1)
+	(type-error name x1))))
+;@
+(define ln log)
+;;(define abs       (must-be-real 'abs abs)) STklos already does this
+(define real-sin  (must-be-real 'real-sin sin))
+(define real-cos  (must-be-real 'real-cos cos))
+(define real-tan  (must-be-real 'real-tan tan))
+(define real-exp  (must-be-real 'real-exp exp))
+(define real-ln   (must-be-real+ 'ln ln))
+(define real-sqrt (must-be-real+ 'real-sqrt sqrt))
+(define real-asin (must-be-real-1+1 'real-asin asin))
+(define real-acos (must-be-real-1+1 'real-acos acos))
+
+(define (must-be-real2 name proc)
+  (lambda (x1 x2)
+    (if (and (real? x1) (real? x2)) (proc x1 x2) (type-error name x1 x2))))
+;@
+(define srfi-94:make-rectangular (must-be-real2 'make-rectangular make-rectangular))
+(define srfi-94:make-polar       (must-be-real2 'make-polar make-polar))
+
+;@
+(define real-log
+  (lambda (base x)
+    (if (and (real? x) (positive? x)
+	     (real? base) (positive? base))
+	(/ (ln x) (ln base))
+	(type-error 'real-log base x))))
+;@
+(define (real-expt x1 x2)
+  (cond ((and (real? x1)
+	      (real? x2)
+	      (or (not (negative? x1)) (integer? x2)))
+	 (expt x1 x2))
+	(else (type-error 'real-expt x1 x2))))
+
+;@
+(define real-atan
+  (lambda (y . x)
+    (if (and (real? y)
+	     (or (null? x)
+		 (and (= 1 (length x))
+		      (real? (car x)))))
+	(apply atan y x)
+	(apply type-error 'real-atan y x))))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(define %make-rectangular make-rectangular)
+(define %make-polar make-polar)
+(define %quotient quotient)
+(define %remainder remainder)
+(define %modulo modulo)
+
+
+(import SRFI-94)
+
+(set! make-rectangular srfi-94:make-rectangular)
+(set! make-polar srfi-94:make-polar)
+(set! quotient srfi-94:quotient)
+(set! remainder srfi-94:remainder)
+(set! modulo srfi-94:modulo)
+
+(provide "srfi-94")

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -132,7 +132,7 @@
     ;; 91  ....... withdrawn
     ;; 92  ....... withdrawn
     ;; 93  ....... withdrawn
-    ;; 94  Type-Restricted Numerical Functions
+    (94 "Type-Restricted Numerical Functions" () "srfi-94")
     ;; 95  Sorting and Merging
     (96 "SLIB Prerequisites" () "srfi-96")
     ;; 97 SRFI Libraries

--- a/tests/srfis/94.stk
+++ b/tests/srfis/94.stk
@@ -1,0 +1,134 @@
+
+(define epsilon 0.000001)
+(define (close x y)
+  (< (abs (- x y)) epsilon))
+
+(define (test-many proc inv-proc list-args)
+  (let ((proc-name (with-output-to-string
+                     (lambda ()
+                       (display proc)))))
+    (let ((procs-name (with-output-to-string
+                        (lambda ()
+                          (display inv-proc)
+                          "--" proc-name))))
+      (for-each (lambda (arg)
+                  (test (string-append procs-name " " (number->string arg))
+                        #t
+                        (close (inv-proc (proc arg)) arg))
+                  (test (string-append proc-name " " (number->string arg) " is real?")
+                        #t
+                        (real? (proc arg))))
+                list-args))))
+
+
+(test/error "real-exp args" (real-exp 0+0i))
+(test/error "real-ln args" (real-ln  0+0i))
+(test/error "real-log args 1" (real-log 0+0i 1))
+(test/error "real-log args 2" (real-log 1 0+0i))
+(test/error "real-sin args" (real-sin 0+0i))
+(test/error "real-cos args" (real-cos 0+0i))
+(test/error "real-tan args" (real-tan 0+0i))
+(test/error "real-asin args" (real-asin 0+0i))
+(test/error "real-acos args" (real-acos 0+0i))
+(test/error "real-atan args" (real-atan 0+0i))
+
+(test-many real-exp real-ln '(0.5 1.0 1.5 1/3 10 20.5))
+(test-many real-ln real-exp '(0.5 1.0 1.5 1/3 10 20.5))
+
+(test-many real-sin real-asin '(0.5 1.0 1.5 1/3))
+(test-many real-sin asin '(0.5 1.0 1.5 1/3))
+(test-many sin real-asin '(0.5 1.0 1.5 1/3))
+
+(test-many real-asin real-sin '(0.5 1.0 1/3))
+(test-many real-asin sin '(0.5 1.0 1/3))
+(test-many asin real-sin '(0.5 1.0 1/3))
+
+(test-many real-cos real-acos '(0.5 1.0 1.5 1/3))
+(test-many real-cos acos '(0.5 1.0 1.5 1/3))
+(test-many cos real-acos '(0.5 1.0 1.5 1/3))
+
+(test-many real-acos real-cos '(0.5 1.0 1/3))
+(test-many real-acos cos '(0.5 1.0 1/3))
+(test-many acos real-cos '(0.5 1.0 1/3))
+
+(test-many real-tan real-atan '(0.5 1.0 1.5 1/3))
+(test-many real-tan atan '(0.5 1.0 1.5 1/3))
+(test-many tan real-atan '(0.5 1.0 1.5 1/3))
+(test-many tan atan '(0.5 1.0 1.5 1/3))
+
+(test-many real-atan real-tan '(0.5 1.0 1.5 1/3))
+(test-many real-atan tan '(0.5 1.0 1.5 1/3))
+(test-many atan real-tan '(0.5 1.0 1.5 1/3))
+(test-many atan tan '(0.5 1.0 1.5 1/3))
+
+(test/error "atan args" (atan 1 0+0i))
+
+(test/error "real-sqrt args" (real-sqrt -1))
+
+(define (square x) (* x x))
+(test-many real-sqrt square '(0.5 1.0 2.0 4.0 1/3 10.5))
+
+(test/error "integer-sqrt args" (integer-sqrt 2))
+(test "integer-sqrt 1" 3 (integer-sqrt 9))
+(test "integer-sqrt 2" 3 (integer-sqrt 10))
+
+(test/error "integer-log args 1" (integer-log  -1 2))
+(test/error "integer-log args 2" (integer-log  1 -2))
+(test/error "integer-log args 3" (integer-log  (/ 1 2) 2))
+(test/error "integer-log args 4" (integer-log  3 2/5))
+(test "integer-log" 3 (integer-log  2 12))
+(test "integer-log" 4 (integer-log  2 16))
+
+(test/error "integer-expt args 1" (integer-expt -1 2))
+(test/error "integer-expt args 2" (integer-expt 1 -2))
+(test/error "integer-expt args 3" (integer-expt (/ 1 2) 2))
+(test/error "integer-expt args 4" (integer-expt 1 1/2))
+(test/error "integer-expt args 5" (integer-expt 0.5 1))
+(test "integer-expt" 81 (integer-expt 3 4))
+
+(test "integer-expt 0^n" 0 (integer-expt 0 2))
+(test "integer-expt 0^0" 1 (integer-expt 0 0))
+(test/error "integer-expt args 6" (integer-expt 0 -1))
+
+(test/error "real-expt args 1" (real-expt 1+01 1))
+(test/error "real-expt args 2" (real-expt 1 1+01))
+(test/error "real-expt args 3" (real-expt 0.0 -1))
+(test "real-expt" 2.25 (real-expt 1.5 2.0))
+
+(test/error "quo args" (quo 1 0))
+(test "quo" 3 (quo 2/3 1/5))
+
+(test/error "rem args" (rem 1 0))
+
+(test/error "mod args" (mod 1 0))
+(test "mod 1" 1/15 (mod 2/3 1/5))
+
+
+(for-each (lambda (args)
+            (let ((x1 (car args))
+                  (x2 (cadr args)))
+              (test (string-append "quo-rem" (number->string x1) " " (number->string x2))
+                    #t
+                    (= x1 (+ (* x2 (quo x1 x2))
+                             (rem x1 x2))))))
+          '( (.666 1/5)
+             (20.1 1/3)
+             (1/3 1/7)
+             (4 2)
+             (1 3)
+             (0.00000001 5) ))
+
+(test/error "make-rectangular args" (make-rectangular 2+1i 1.0))
+(test/error "make-polar args" (make-polar 2+1i 1.0))
+
+(test/error "quotient args" (quotient 2.0 1.0))
+(test/error "modulo args" (modulo 1.0 2.0))
+(test/error "remainder args" (remainder 2.0 1.0))
+
+;; SRFI-94 changes the semantics of these, and they are tested later, so we need
+;; to get their previous definitions:
+(define make-rectangular %make-rectangular)
+(define make-polar %make-polar)
+(define quotient %quotient)
+(define remainder %remainder)
+(define modulo %modulo)


### PR DESCRIPTION
This SRFI changes the semantics of some standard Scheme functions, so
I had to save the old definitions and recover them back at the end of
the tests:

```
(define make-rectangular %make-rectangular)
(define make-polar %make-polar)
(define quotient %quotient)
(define remainder %remainder)
(define modulo %modulo)
```

Also... The procedures are of course slow. I am willing to reimplement them in C, but I'm not sure it would be a good idea to grow the C code so often. Maybe, if this is to be optimized/reimplemented in C, this SRFI could dynamically load a `.so` file?