### PR TITLE
Add SRFI-5

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -20,6 +20,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-1: List Library
     - SRFI-2: AND-LET*: an AND with local bindings, a guarded LET* special form
     - SRFI-4: Homogeneous numeric vector datatypes
+    - SRFI-5: A compatible let form with signatures and rest arguments
     - SRFI-6: Basic String Ports
     - SRFI-7: Feature-based program configuration language 
     - SRFI-8: Receive: Binding to multiple values

--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -117,6 +117,10 @@ To use SRFI-4, you need to insert the following expression])
 (fontified-code [(require "srfi-4")])
 (p [in your code or uses the ,(code "cond-expand") special form.]))
 
+;; SRFI 5 -- A compatible let form with signatures and rest arguments
+(gen-embedded-srfi 5)
+
+
 ;; ----------------------------------------------------------------------
 ;; SRFI 6 -- String Ports
 ;; ----------------------------------------------------------------------

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -31,6 +31,7 @@
      (1  . "List Library")
      (2  . "AND-LET*: an AND with local bindings, a guarded LET* special form")
      (4  . "Homogeneous numeric vector datatypes")
+     (5  . "A compatible let form with signatures and rest arguments")
      (6  . "Basic String Ports")
      (7  . "Feature-based program configuration language ")
      (8  . "Receive: Binding to multiple values")

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1120,15 +1120,16 @@ doc>
               (cond
                ((null? l) #t)
                ((pair? l) (let ((b (car l)))
-                            (if (and (list? b)
-                                     (= (length b) 2)
-                                     (symbol? (car b)))
-                                (if (and unique? (memq (car b) seen))
-                                    (compiler-error 'let bindings
-                                                     "duplicate binding ~S" (car b))
-                                    (aux (cdr l) (cons (car b) seen)))
-                                (compiler-error 'let bindings
-                                                 "malformed binding ~S" b))))
+                            (cond ((and (list? b)
+                                        (= (length b) 2)
+                                        (symbol? (car b)))
+                                   (if (and unique? (memq (car b) seen))
+                                       (compiler-error 'let bindings
+                                                       "duplicate binding ~S" (car b))
+                                       (aux (cdr l) (cons (car b) seen))))
+                                  ((symbol? b) #t) ;; SRFI-5 rest list
+                                  (else (compiler-error 'let bindings
+                                                        "malformed binding ~S" b)))))
                (else #f)))))
     (aux bindings '())))
 
@@ -1154,6 +1155,7 @@ doc>
                               (let () ,@body))
                            env args tail?))))))))
 
+
 ;;
 ;; LET (& named let)
 ;;
@@ -1162,29 +1164,86 @@ doc>
   (if (< len 4)
       (compiler-error 'let args "ill formed named let ~S" args)
       (when (valid-let-bindings? bindings #t)
-        (compile `((letrec ((,name (lambda ,(map car bindings) ,@body)))
+        (let-values (((args vals) (split-args-values bindings)))
+          (compile `((letrec ((,name (lambda ,args ,@body)))
                        ,name)
-                   ,@(map cadr bindings))
+                   ,@vals)
                  env
                  args
-                 tail?))))
+                 tail?)))))
+
+;; set-last-cdr! sets the CDR of the last element of a list.
+;; Useful for producing improper lists such as the list of
+;; names for rest arguments.
+;;
+;; * the list must be mutable!
+;;
+;; (define lst (list-copy '(a b c)))
+;; lst => (a b c)
+;; (set-last-cdr! lst 'E)
+;; lst => (a b c . E)
+(define (set-last-cdr! lst elt)
+  (cond ((not (or (list? lst)
+                  (pair? lst)))
+         (compiler-error 'set-last-cdr! lst "Not a cons cell ~S" lst))
+        ((null? (cdr lst))
+         (set-cdr! lst elt))
+        (else
+         (set-last-cdr! (cdr lst) elt))))
+
+;; split-args-values returns two values:
+;; 1. - the list of formal arguments. this will be
+;;      a proper list using standard LET, and an improper
+;;      list using SRFI-5 rest arguments.
+;; 2. - the init values of the arguments. This is always
+;;      a proper list.
+;;
+;; (split-args-values '( (a 10) (b 20) ))
+;; => (a b)
+;; => (10 20)
+;;
+;; (split-args-values '( (a 10) (b 20) c 1 2 3 ))
+;; => (a b . c)
+;; => (10 20 1 2 3)
+(define (split-args-values bindings)
+  (define (split-args-values-aux bindings seen-args seen-values)
+    (cond ((null?    bindings) (values (reverse seen-args) (reverse seen-values)))
+          ((pair?   (car bindings)) (split-args-values-aux (cdr bindings)
+                                                           (cons (caar  bindings) seen-args)
+                                                           (cons (cadar bindings) seen-values)))
+          ((symbol? (car bindings))
+           (let ((args-copy (list-copy (reverse seen-args)))) ;; needs to be mutable
+             (set-last-cdr! args-copy (car bindings)) ; include rest argument name
+             (values args-copy                        ; previous arg names
+                     (append (reverse seen-values) (cdr bindings))))) ; rest argument value list
+          (else (compiler-error 'let bindings "ill formed let ~S" bindings))))
+  (split-args-values-aux bindings '() '()))
 
 
+;; modified by jpellegrini 2020-08-04 for SRFI-5 support
 (define (compile-let args env tail?)
   (let ((len (length args)))
-    (if (< len 3)
+    (if (< len 2)
         (compiler-error 'let args "ill formed let ~S" args)
         (let ((bindings (cadr args))
               (body     (cddr args)))
-          (if (symbol? bindings)
+          (if (symbol? bindings)  ;; named let
               ;; Transform named let in letrec
               (compile-named-let bindings (car body) (cdr body) len args env tail?)
               (when (valid-let-bindings? bindings #t)
-                (if (null? bindings)
-                    (compile-body body env args tail?)
-                    (compile `((lambda ,(map car bindings) ,@body)
-                               ,@(map cadr bindings))
-                             env args tail?))))))))
+                (if (and (list? bindings)          ;; SRFI-5 allows one to write named LETs
+                         (not (null? bindings))    ;; as (let (proc bindings body)
+                         (symbol? (car bindings))) ;;
+                      (compile-let `(let ,(car bindings) ,(cdr bindings) ,@body)
+                                   env tail?)
+                    (if (< len 3)
+                        (compiler-error 'let args "ill formed let ~S" args)
+                        ;; The split-args-values procedure will automatically
+                        ;; take care of SRFI-5 LET rest lists
+                        (let-values (((args vals) (split-args-values bindings)))
+                          (compile `((lambda ,args ,@body)
+                                     ,@vals)
+                                   env args tail?))))))))))
 
 ;;
 ;; LET*

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -59,7 +59,7 @@
     ((srfi-2 and-let*)  "srfi-2")       ; AND-LET*
     ;; srfi-3                           ; ....... withdrawn
     ((srfi-4 hvectors)  "srfi-4")       ; Homogeneous vectors
-    ;; srfi-5                           ; let with signature & rest args
+    ((srfi-5 let)       "srfi-5")       ; let with signature & rest args
     srfi-6                              ; String ports
     ((srfi-7 program)   "srfi-7")       ; PROGRAM
     srfi-8                              ; RECEIVE

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -28,6 +28,53 @@
 
 (test-section "SRFIs")
 
+;; ----------------------------------------------------------------------
+;;  SRFI 5 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 5 - A compatible let form ...")
+
+;; A binding list must be a sequence of pairs, and with SRFI-5,
+;; these mayy be followed by a SYMBOL and a free list.
+;; But it MUST be a symbol!
+(test/error "error in bindings"
+            (let ((a 1)
+                  (b 2)
+                  3 4 5)))
+
+;; ;; The two following tests are Andy Gaynor's examples from the SRFI:
+ (test "fibonacci"
+       55
+       (let (fibonacci (n 10) (i 0) (f0 0) (f1 1))
+         (if (= i n)
+             f0
+             (fibonacci n (+ i 1) f1 (+ f0 f1)))))
+
+(test "contrived"
+      "345"
+      (with-output-to-string
+        (lambda ()
+          (let (blast (port (current-output-port)) . (x (+ 1 2) 4 5))
+            (if (null? x)
+                'just-a-silly-contrived-example
+                (begin
+                  (write (car x) port)
+                  (apply blast port (cdr x))))))))
+
+(test "recursive list sum"
+      21
+      (let (loop (sum 0) (lst '(1 2 3 4 5 6)))
+        (if (null? lst)
+            sum
+            (loop (+ (car lst) sum) (cdr lst)))))
+
+(test "recursive list sum with rest arguments"
+      21
+      (let (loop (sum 0) . (lst 1 2 3 4 5 6))
+        (if (null? lst)
+            sum
+            (apply loop (+ (car lst) sum) (cdr lst)))))
+
+
 
 ;; ----------------------------------------------------------------------
 ;;  SRFI 13 ...


### PR DESCRIPTION
Since STklos compiles `LET` (and does not define it as a macro),
the changes are on compiler.stk only (besides the usual changes in
srfi-0.stk, test-srfi.stk and documentation)

The SRFI has no accompaining test suite, so I have written a couple
of tests.