### PR TITLE
Use  $(DESTDIR) in install-sources target

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -238,7 +238,7 @@ install-sources:
 	@for i in $(SUBDIRS) ;do \
 	   (cd $$i; $(MAKE) install-sources)\
 	done
-	cp $(SRC_STK) $(scheme_BOOT) $(schemedir)
+	cp $(SRC_STK) $(scheme_BOOT) $(DESTDIR)/$(schemedir)
 
 
 


### PR DESCRIPTION
Otherwise installation on alternative locations won't work...

See in `Makefile.in` in other directories, for example: it will expand into `$(DESTDIR)/$(schemedir)`. In the `lib/` directory, since the Make target was written by hand, the `$(DESTDIR)` part is missing.