### PR TITLE
Use an env var for strip

### DIFF
--- a/QUICK-INSTALL.md
+++ b/QUICK-INSTALL.md
@@ -50,7 +50,7 @@ four) step process:
 
 4. To install the version just compiled in the place you have chosen previously (or in `/usr/local`), type `make install` for a full install. The size of a full installation is approximately 6.5Mb (on a x86 64 bits architecture. On machines with a more limited space, you can use the following Makefile installation targets:
     - `install-base` to install only the VM and all the compiled Scheme files (size is ~2.0Mb). The installation is fully functional (except the `help` function which will yield an error).
-    - `install-base-no-strip` is identical to `install-base`, except that the `stklos` binary is not stripped (this could be useful when cross compiling **STklos**).
+    - `install-base-no-strip` is identical to `install-base`, except that the `stklos` binary is not stripped (this could be useful when cross compiling **STklos** or when generating packages with debug symbols).
     - `install-sources` to install the Scheme source files used whence building the system (adds ~1.5Mb to the installation)
     - `install-doc` to install the documentation (for the help command, manual pages, and reference manual in HTML and PDF formats). This adds ~3.0Mb) to the installation).
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,14 @@
 CC		 	= @CC@
 CFLAGS	    = @CFLAGS@ @STKCFLAGS@
 
+# In order to use strip when cross-compiling, we need it to be settable
+# as an env variable. Setting it in configure.ac doesn't seem to make the
+# desired effect, so we just do this simple conditional assignment here.
+# We do *not* do "STRIP ?= strip" because it may happen (did, actually)
+# that the variable STRIP is set but empty.
+# -- jpellegrini
+STRIP := $(or $(STRIP),strip)
+
 STKLOS_BINARY ?= ./stklos
 
 bindir      = $(prefix)/bin
@@ -94,7 +102,7 @@ generate-git-info:
 
 
 install-exec-hook:
-	if test "X$$STRIP" != "Xno" ;then strip $(DESTDIR)/$(bindir)/stklos; fi
+	if test "X$$STRIP" != "Xno" ;then $(STRIP) $(DESTDIR)/$(bindir)/stklos; fi
 	mv $(DESTDIR)/$(bindir)/stklos $(DESTDIR)/$(bindir)/stklos-@VERSION@
 	ln -s stklos-@VERSION@ $(DESTDIR)/$(bindir)/stklos
 


### PR DESCRIPTION
When cross-compiling, the strip binary will not work on the stklos
executable (binary format mismatch). One solution is to use a STRIP
variable, and set it to "stklos" if it is either missing or empty.

Tested on Debian GNU/Linux on amd64, and on the OpenWRT build root
(for MIPS).