### PR TITLE
Add @CPPFLAGS@ and -lc to shared lib compiling

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -190,9 +190,9 @@ SUFFIXES = .stk .ostk .scm
 	$(COMP) -o $*.ostk $*.scm
 
 .c.@SH_SUFFIX@ :
-	@CC@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../src @GCINC@ \
+	@CC@ @CPPFLAGS@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../src @GCINC@ \
 	-c -o $*.o $*.c
-	@SH_LOADER@ @SH_LOAD_FLAGS@  $*.@SH_SUFFIX@ $*.o
+	@SH_LOADER@ @SH_LOAD_FLAGS@  $*.@SH_SUFFIX@ $(LDFLAGS) -lc $*.o
 	/bin/rm -f $*.o
 
 #======================================================================


### PR DESCRIPTION
`@CPPFLAGS@` is important in hardening steps (Debian hardening testing tools complain -- this was an error reported by the CI tools)

The `-lc` part is to get dependency information. (This one was just a warning, not an error)