### PR TITLE
Fix typos

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -1857,7 +1857,7 @@ SCM STk_sub2(SCM o1, SCM o2)
           o1 = make_rational(sub2(num1, num2), den);
           break;
         }
-      default: error_cannot_operate("substraction", o1, o2);
+      default: error_cannot_operate("subtraction", o1, o2);
   }
   return o1;
 }

--- a/src/port.c
+++ b/src/port.c
@@ -1288,7 +1288,7 @@ DEFINE_PRIMITIVE("signal-error", scheme_signal_error, vsubr, (int argc, SCM *arg
 {
   SCM type_error;
 
-  if (! argc) STk_error("error condtion expected");
+  if (! argc) STk_error("error condition expected");
 
   type_error = *argv;
   argc -= 1;


### PR DESCRIPTION
Hi @egallesio !
Some more of the impressive work by Debian's `lintian` tool: it runs `strings` on the binaries and detects typos!

```
I: stklos: spelling-error-in-binary usr/bin/stklos condtion condition
I: stklos: spelling-error-in-binary usr/bin/stklos substraction subtraction
```
