### PR TITLE
Export a procedure used by a macro in SRFI-64

### DIFF
--- a/lib/srfi-64.stk
+++ b/lib/srfi-64.stk
@@ -64,6 +64,7 @@
    
    ;;; for STklos - macros will use these symbols, and will only
    ;;; be expanded outside the module
+   %test-approximate=
    %test-begin
    %test-on-test-begin
    %test-result-expected-value!


### PR DESCRIPTION
Procedure %test-approximate= is used by macro test-approximate=,
but wasn't being exported