### PR TITLE
Fix list= in SRFI-1

### DIFF
--- a/lib/srfi-1.stk
+++ b/lib/srfi-1.stk
@@ -487,18 +487,18 @@
   (or (null? lists) ; special case
 
       (let lp1 ((list-a (car lists)) (others (cdr lists)))
-    (or (null? others)
-        (let ((list-b (car others))
-          (others (cdr others)))
-          (if (eq? list-a list-b)   ; EQ? => LIST=
-          (lp1 list-b others)
-          (let lp2 ((list-a list-a) (list-b list-b))
-            (if (null-list? list-a)
-            (and (null-list? list-b)
-                 (lp1 list-b others))
-            (and (not (null-list? list-b))
-                 (= (car list-a) (car list-b))
-                 (lp2 (cdr list-a) (cdr list-b)))))))))))
+	(or (null? others)
+	    (let ((list-b (car others))
+		  (others (cdr others)))
+	      (if (eq? list-a list-b)	; EQ? => LIST=
+		  (lp1 list-b others)
+		  (let lp2 ((pair-a list-a) (pair-b list-b))
+		    (if (null-list? pair-a)
+			(and (null-list? pair-b)
+			     (lp1 list-b others))
+			(and (not (null-list? pair-b))
+			     (= (car pair-a) (car pair-b))
+			     (lp2 (cdr pair-a) (cdr pair-b)))))))))))
 
 
 


### PR DESCRIPTION
I found this while preparing SRFI-134.

In `list=`, the reference implementation has a loop as this:

`(let lp2 ((pair-a list-a) (pair-b list-b))`

The STklos version had

`(let lp2 ((list-a list-a) (list-b list-b))`

but this makes the original list-b not accessible from inside the
loop, so for example

`(apply list= char-ci=? '((#\a #\b) (#\A #\B) (#\a #\B)))`

would fail when it should not.

This commit reverts to the reference implementation version of
`list=`.