### PR TITLE
Add SRFI-130 - Cursor-based string library

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -72,6 +72,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-118: Simple adjustable-size strings 
     - SRFI-128: Comparators (reduced)
     - SRFI-129: Titlecase procedures
+    - SRFI-130: Cursor-based string library
     - SRFI-141: Integer Division
     - SRFI-145: Assumptions
     - SRFI-151: Bitwise Operations

--- a/doc/skb/srfi.skb
+++ b/doc/skb/srfi.skb
@@ -655,6 +655,9 @@ described in this document (procedures
 ;; SRFI 129 -- Titlecase Procedures
 (gen-loaded-srfi 129)
 
+;; SRFI 130 -- Cursor-based string library
+(gen-loaded-srfi 130)
+
 ;; SRFI 141 -- Integer division
 (gen-loaded-srfi 141)
 

--- a/doc/skb/srfi.stk
+++ b/doc/skb/srfi.stk
@@ -83,6 +83,7 @@
      (118 . "Simple adjustable-size strings ")
      (128 . "Comparators (reduced)")
      (129 . "Titlecase procedures")
+     (130 . "Cursor-based string library")
      (141 . "Integer Division")
      (145 . "Assumptions")
      (151 . "Bitwise Operations")

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -112,6 +112,9 @@ SRC_STK = bigloo-support.stk  \
           srfi-117.stk        \
           srfi-128.stk        \
           srfi-129.stk        \
+          srfi-130.stk        \
+          srfi-130-macros.stk \
+          srfi-130-portable.stk \
           srfi-141.stk        \
           srfi-151.stk        \
           srfi-156.stk        \
@@ -178,6 +181,9 @@ scheme_OBJS = compfile.ostk    \
           srfi-117.ostk        \
           srfi-128.ostk        \
           srfi-129.ostk        \
+          srfi-130.ostk        \
+          srfi-130-macros.ostk \
+          srfi-130-portable.ostk \
           srfi-141.ostk        \
           srfi-151.ostk        \
           srfi-156.ostk        \

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -188,7 +188,7 @@
     ((srfi-128 comparators-reduced) "srfi-128")
                                         ; Comparators (reduced)
     ((srfi-129 titlecase) "srfi-129")   ; Titlecase procedures
-    ;; srfi-130                         ; Cursor-based string library
+    (srfi-130 "srfi-130")               ; Cursor-based string library
     ;; srfi-131                         ; ERR5RS Record Syntax (reduced)
     ;; srfi-132                         ; Sort Libraries
     ;; srfi-133                         ; Vector Library (R7RS-compatible)

--- a/lib/srfi-130.stk
+++ b/lib/srfi-130.stk
@@ -1,0 +1,1689 @@
+;;;;
+;;;; srfi-130.stk		-- Implementation of SRFI-130
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Olin Shivers and John Cowan, it is copyrighted as:
+;;;;
+;;;;;;  Copyright (c) Olin Shivers (1998, 1999, 2000) and John Cowan (2016).
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 13-Nov-2020 21:10 (jpellegrini)
+;;;; Last file update: 14-Nov-2020 00:03 (jpellegrini)
+;;;;
+
+(require "srfi-13")
+
+(define-module SRFI-130
+   
+  (export string-cursor? string-ref/cursor)
+  (export string-cursor-start string-cursor-end
+          string-cursor-prev string-cursor-next
+          string-cursor-forward string-cursor-back
+          string-cursor=? string-cursor<? string-cursor>?
+          string-cursor<=? string-cursor>=?
+          string-cursor-diff string-cursor->index string-index->cursor)
+  (export string-null? string-every string-any)
+  (export string-tabulate string-unfold string-unfold-right)
+  (export string->list/cursors string->vector/cursors
+          reverse-list->string string-join)
+  (export string-ref substring/cursors string-copy/cursors
+          string-take string-drop string-take-right string-drop-right
+          string-pad string-pad-right
+          string-trim string-trim-right string-trim-both)
+  (export string-prefix-length string-suffix-length
+          string-prefix? string-suffix?)
+  (export string-index string-index-right string-skip string-skip-right
+          string-contains string-contains-right)
+  (export string-reverse string-concatenate string-concatenate-reverse
+          string-fold string-fold-right string-for-each-cursor
+          string-replicate string-count string-replace
+          string-split string-filter string-remove)
+
+  ;;;; Definitions of macros
+
+
+;;; Shivers-compatible let-optionals*
+;;; This version from Scheme-48 1.9.2,
+;;; using error instead of assertion-violation
+(define-syntax let-optionals*
+  (syntax-rules ()
+    ((let-optionals* arg (opt-clause ...) body ...)
+     (let ((rest arg))
+       (%let-optionals* rest (opt-clause ...) body ...)))))
+
+(define-syntax %let-optionals*
+  (syntax-rules ()
+    ((%let-optionals* arg (((var ...) xparser) opt-clause ...) body ...)
+     (call-with-values (lambda () (xparser arg))
+       (lambda (rest var ...)
+         (%let-optionals* rest (opt-clause ...) body ...))))
+
+    ((%let-optionals* arg ((var default) opt-clause ...) body ...)
+     (call-with-values (lambda () (if (null? arg) (values default '())
+				      (values (car arg) (cdr arg))))
+       (lambda (var rest)
+	 (%let-optionals* rest (opt-clause ...) body ...))))
+
+    ((%let-optionals* arg ((var default test) opt-clause ...) body ...)
+     (call-with-values (lambda ()
+			 (if (null? arg) (values default '())
+			     (let ((var (car arg)))
+			       (if test (values var (cdr arg))
+				   (error "arg failed LET-OPT test" var)))))
+       (lambda (var rest)
+	 (%let-optionals* rest (opt-clause ...) body ...))))
+
+    ((%let-optionals* arg ((var default test supplied?) opt-clause ...) body ...)
+     (call-with-values (lambda ()
+			 (if (null? arg) (values default #f '())
+			     (let ((var (car arg)))
+			       (if test (values var #t (cdr arg))
+				   (error "arg failed LET-OPT test" var)))))
+       (lambda (var supplied? rest)
+	 (%let-optionals* rest (opt-clause ...) body ...))))
+
+    ((%let-optionals* arg (rest) body ...)
+     (let ((rest arg)) body ...))
+
+    ((%let-optionals* arg () body ...)
+     (if (null? arg) (begin body ...)
+	 (error "Too many arguments in let-opt" arg)))))
+
+
+
+;;;
+;;; END OF MACROS
+;;;
+
+
+(define check-arg
+   (lambda (pred val proc)
+     (if (pred val) val (error "Bad arg" val pred proc))))
+
+;;; - LET-OPTIONALS* macro for parsing, defaulting &
+;;;   type-checking optional parameters from a rest argument;
+;;;
+;;; The code depends upon a small set of core string primitives from R5RS:
+;;;     MAKE-STRING STRING-REF STRING? STRING-LENGTH SUBSTRING
+;;; (Actually, SUBSTRING is not a primitive, but we assume that an
+;;; implementation's native version is probably faster than one we could
+;;; define, so we import it from R5RS.)
+;;;
+;;;
+
+(define (add1 n) (+ 1 n))
+
+;;; Enough introductory blather. On to the source code. (But see the end of
+;;; the file for further notes on porting & performance tuning.)
+
+
+;;; Cursor operations
+(define (string-cursor? x) (and (integer? x) (exact? x) (>= x 0)))
+(define (string-cursor-start s) 0)
+(define (string-cursor-end s) (string-length s))
+(define (string-cursor-prev s n) (- n 1))
+(define (string-cursor-next s n) (+ n 1))
+(define (string-cursor-forward s n len) (+ n len))
+(define (string-cursor-back s n len) (- n len))
+(define (string-cursor=? a b) (= a b))
+(define (string-cursor<? a b) (< a b))
+(define (string-cursor>? a b) (> a b))
+(define (string-cursor<=? a b) (<= a b))
+(define (string-cursor>=? a b) (>= a b))
+(define (string-cursor-diff s a b) (- b a))
+(define (string-cursor->index s n) n)
+(define (string-index->cursor s n) n)
+
+;;; Support for START/END substring specs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; This macro parses optional start/end arguments from arg lists, defaulting
+;;; them to 0/(string-length s), and checks them for correctness.
+
+(define-syntax let-string-start+end
+  (syntax-rules ()
+    ((let-string-start+end (start end) proc s-exp args-exp body ...)
+     (receive (start end) (string-parse-final-start+end proc s-exp args-exp)
+       body ...))
+    ((let-string-start+end (start end rest) proc s-exp args-exp body ...)
+     (receive (rest start end) (string-parse-start+end proc s-exp args-exp)
+       body ...))))
+
+;;; This one parses out a *pair* of final start/end indices.
+;;; Not exported; for internal use.
+(define-syntax let-string-start+end2
+  (syntax-rules ()
+    ((l-s-s+e2 (start1 end1 start2 end2) proc s1 s2 args body ...)
+     (let ((procv proc)) ; Make sure PROC is only evaluated once.
+       (let-string-start+end (start1 end1 rest) procv s1 args
+         (let-string-start+end (start2 end2) procv s2 rest
+           body ...))))))
+
+
+;;; Returns three values: rest start end
+
+(define (string-parse-start+end proc s args)
+  (if (not (string? s)) (error "Non-string value" proc s))
+  (let ((slen (string-length s)))
+    (if (pair? args)
+
+	(let ((start (car args))
+	      (args (cdr args)))
+	  (if (and (integer? start) (exact? start) (>= start 0))
+	      (receive (end args)
+		  (if (pair? args)
+		      (let ((end (car args))
+			    (args (cdr args)))
+			(if (and (integer? end) (exact? end) (<= end slen))
+			    (values end args)
+			    (error "Illegal substring END spec" proc end s)))
+		      (values slen args))
+		(if (<= start end) (values args start end)
+		    (error "Illegal substring START/END spec"
+			   proc start end s)))
+	      (error "Illegal substring START spec" proc start s)))
+
+	(values '() 0 slen))))
+
+(define (string-parse-final-start+end proc s args)
+  (receive (rest start end) (string-parse-start+end proc s args)
+    (if (pair? rest) (error "Extra arguments to procedure" proc rest)
+	(values start end))))
+
+(define (substring-spec-ok? s start end)
+  (and (string? s)
+       (integer? start)
+       (exact? start)
+       (integer? end)
+       (exact? end)
+       (<= 0 start)
+       (<= start end)
+       (<= end (string-length s))))
+
+(define (check-substring-spec proc s start end)
+  (if (not (substring-spec-ok? s start end))
+      (error "Illegal substring spec." proc s start end)))
+
+
+;;; Defined by R5RS, so commented out here.
+;(define (string . chars)
+;  (let* ((len (length chars))
+;         (ans (make-string len)))
+;    (do ((i 0 (+ i 1))
+;	 (chars chars (cdr chars)))
+;	((>= i len))
+;      (string-set! ans i (car chars)))
+;    ans))
+;
+;(define (string . chars) (string-unfold null? car cdr chars))
+
+
+
+;;; substring/cursors S START [END]
+;;; string-copy/cursors      S [START END]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; All this goop is just arg parsing & checking surrounding a call to the
+;;; actual primitive, %SUBSTRING/CURSORS.
+
+(define (substring/cursors s start end)
+  (check-arg string? s substring/cursors)
+  (let ((slen (string-length s)))
+    (check-arg (lambda (start) (and (integer? start) (exact? start) (<= 0 start)))
+	       start substring/cursors)
+    (check-arg (lambda (end) (and (integer? end) (exact? end) (<= start end) (<= end slen)))
+	       end substring/cursors)
+    (%substring/cursors s start end)))
+
+;;; Split out so that other routines in this library can avoid arg-parsing
+;;; overhead for END parameter.
+(define (%substring/cursors s start end)
+  (if (and (zero? start) (= end (string-length s))) s
+      (substring s start end)))
+
+(define (string-copy/cursors s . maybe-start+end)
+  (let-string-start+end (start end) string-copy/cursors s maybe-start+end
+    (substring s start end)))
+
+;This library uses the R5RS SUBSTRING, but doesn't export it.
+;Here is a definition, just for completeness.
+;(define (substring s start end)
+;  (check-substring-spec substring s start end)
+;  (let* ((slen (- end start))
+;         (ans (make-string slen)))
+;    (do ((i 0 (+ i 1))
+;         (j start (+ j 1)))
+;        ((>= i slen) ans)
+;      (string-set! ans i (string-ref s j)))))
+
+;;; Basic iterators and other higher-order abstractions
+;;; (string-map proc s [start end])
+;;; (string-fold kons knil s [start end])
+;;; (string-fold-right kons knil s [start end])
+;;; (string-unfold       p f g seed [base make-final])
+;;; (string-unfold-right p f g seed [base make-final])
+;;; (string-for-each       proc s [start end])
+;;; (string-for-each-cursor proc s [start end])
+;;; (string-every char/pred s [start end])
+;;; (string-any   char/pred s [start end])
+;;; (string-tabulate proc len)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; You want compiler support for high-level transforms on fold and unfold ops.
+;;; You'd at least like a lot of inlining for clients of these procedures.
+;;; Don't hold your breath.
+
+(define (string-map proc s . maybe-start+end)
+  (check-arg procedure? proc string-map)
+  (let-string-start+end (start end) string-map s maybe-start+end
+    (%string-map proc s start end)))
+
+(define (%string-map proc s start end)	; Internal utility
+  (let* ((len (- end start))
+	 (ans (make-string len)))
+    (do ((i (- end 1) (- i 1))
+	 (j (- len 1) (- j 1)))
+	((< j 0))
+      (string-set! ans j (proc (string-ref s i))))
+    ans))
+
+(define (string-fold kons knil s . maybe-start+end)
+  (check-arg procedure? kons string-fold)
+  (let-string-start+end (start end) string-fold s maybe-start+end
+    (let lp ((v knil) (i start))
+      (if (< i end) (lp (kons (string-ref s i) v) (+ i 1))
+	  v))))
+
+(define (string-fold-right kons knil s . maybe-start+end)
+  (check-arg procedure? kons string-fold-right)
+  (let-string-start+end (start end) string-fold-right s maybe-start+end
+    (let lp ((v knil) (i (- end 1)))
+      (if (>= i start) (lp (kons (string-ref s i) v) (- i 1))
+	  v))))
+
+;;; (string-unfold p f g seed [base make-final])
+;;; This is the fundamental constructor for strings.
+;;; - G is used to generate a series of "seed" values from the initial seed:
+;;;     SEED, (G SEED), (G^2 SEED), (G^3 SEED), ...
+;;; - P tells us when to stop -- when it returns true when applied to one
+;;;   of these seed values.
+;;; - F maps each seed value to the corresponding character
+;;;   in the result string. These chars are assembled into the
+;;;   string in a left-to-right order.
+;;; - BASE is the optional initial/leftmost portion of the constructed string;
+;;;   it defaults to the empty string "".
+;;; - MAKE-FINAL is applied to the terminal seed value (on which P returns
+;;;   true) to produce the final/rightmost portion of the constructed string.
+;;;   It defaults to (LAMBDA (X) "").
+;;;
+;;; In other words, the following (simple, inefficient) definition holds:
+;;; (define (string-unfold p f g seed base make-final)
+;;;   (string-append base
+;;;                  (let recur ((seed seed))
+;;;                    (if (p seed) (make-final seed)
+;;;                        (string-append (string (f seed))
+;;;                                       (recur (g seed)))))))
+;;;
+;;; STRING-UNFOLD is a fairly powerful constructor -- you can use it to
+;;; reverse a string, copy a string, convert a list to a string, read
+;;; a port into a string, and so forth. Examples:
+;;; (port->string port) =
+;;;   (string-unfold (compose eof-object? peek-char)
+;;;                  read-char values port)
+;;;
+;;; (list->string lis) = (string-unfold null? car cdr lis)
+;;;
+;;; (tabulate-string f size) = (string-unfold (lambda (i) (= i size)) f add1 0)
+
+;;; A problem with the following simple formulation is that it pushes one
+;;; stack frame for every char in the result string -- an issue if you are
+;;; using it to read a 100kchar string. So we don't use it -- but I include
+;;; it to give a clear, straightforward description of what the function
+;;; does.
+
+;(define (string-unfold p f g seed base make-final)
+;  (let ((ans (let recur ((seed seed) (i (string-length base)))
+;               (if (p seed)
+;                   (let* ((final (make-final seed))
+;                          (ans (make-string (+ i (string-length final)))))
+;                     (string-copy/cursors! ans i final)
+;                     ans)
+;
+;                   (let* ((c (f seed))
+;                          (s (recur (g seed) (+ i 1))))
+;                     (string-set! s i c)
+;                     s)))))
+;    (string-copy/cursors! ans 0 base)
+;    ans))
+
+;;; The strategy is to allocate a series of chunks into which we stash the
+;;; chars as we generate them. Chunk size goes up in powers of two starting
+;;; with 40 and levelling out at 4k, i.e.
+;;;     40 40 80 160 320 640 1280 2560 4096 4096 4096 4096 4096...
+;;; This should work pretty well for short strings, 1-line (80 char) strings,
+;;; and longer ones. When done, we allocate an answer string and copy the
+;;; chars over from the chunk buffers.
+
+(define (string-unfold p f g seed . base+make-final)
+  (check-arg procedure? p string-unfold)
+  (check-arg procedure? f string-unfold)
+  (check-arg procedure? g string-unfold)
+  (let-optionals* base+make-final
+                  ((base       ""              (string? base))
+		   (make-final (lambda (x) "") (procedure? make-final)))
+    (let lp ((chunks '())		; Previously filled chunks
+	     (nchars 0)			; Number of chars in CHUNKS
+	     (chunk (make-string 40))	; Current chunk into which we write
+	     (chunk-len 40)
+	     (i 0)			; Number of chars written into CHUNK
+	     (seed seed))
+      (let lp2 ((i i) (seed seed))
+	(if (not (p seed))
+	    (let ((c (f seed))
+		  (seed (g seed)))
+	      (if (< i chunk-len)
+		  (begin (string-set! chunk i c)
+			 (lp2 (+ i 1) seed))
+
+		  (let* ((nchars2 (+ chunk-len nchars))
+			 (chunk-len2 (min 4096 nchars2))
+			 (new-chunk (make-string chunk-len2)))
+		    (string-set! new-chunk 0 c)
+		    (lp (cons chunk chunks) (+ nchars chunk-len)
+			new-chunk chunk-len2 1 seed))))
+
+	    ;; We're done. Make the answer string & install the bits.
+	    (let* ((final (make-final seed))
+		   (flen (string-length final))
+		   (base-len (string-length base))
+		   (j (+ base-len nchars i))
+		   (ans (make-string (+ j flen))))
+	      (%string-copy/cursors! ans j final 0 flen)	; Install FINAL.
+	      (let ((j (- j i)))
+		(%string-copy/cursors! ans j chunk 0 i)		; Install CHUNK[0,I).
+		(let lp ((j j) (chunks chunks))		; Install CHUNKS.
+		  (if (pair? chunks)
+		      (let* ((chunk  (car chunks))
+			     (chunks (cdr chunks))
+			     (chunk-len (string-length chunk))
+			     (j (- j chunk-len)))
+			(%string-copy/cursors! ans j chunk 0 chunk-len)
+			(lp j chunks)))))
+	      (%string-copy/cursors! ans 0 base 0 base-len)	; Install BASE.
+	      ans))))))
+
+(define (string-unfold-right p f g seed . base+make-final)
+  (let-optionals* base+make-final
+                  ((base       ""              (string? base))
+		   (make-final (lambda (x) "") (procedure? make-final)))
+    (let lp ((chunks '())		; Previously filled chunks
+	     (nchars 0)			; Number of chars in CHUNKS
+	     (chunk (make-string 40))	; Current chunk into which we write
+	     (chunk-len 40)
+	     (i 40)			; Number of chars available in CHUNK
+	     (seed seed))
+      (let lp2 ((i i) (seed seed))	; Fill up CHUNK from right
+	(if (not (p seed))		; to left.
+	    (let ((c (f seed))
+		  (seed (g seed)))
+	      (if (> i 0)
+		  (let ((i (- i 1)))
+		    (string-set! chunk i c)
+		    (lp2 i seed))
+
+		  (let* ((nchars2 (+ chunk-len nchars))
+			 (chunk-len2 (min 4096 nchars2))
+			 (new-chunk (make-string chunk-len2))
+			 (i (- chunk-len2 1)))
+		    (string-set! new-chunk i c)
+		    (lp (cons chunk chunks) (+ nchars chunk-len)
+			new-chunk chunk-len2 i seed))))
+
+	    ;; We're done. Make the answer string & install the bits.
+	    (let* ((final (make-final seed))
+		   (flen (string-length final))
+		   (base-len (string-length base))
+		   (chunk-used (- chunk-len i))
+		   (j (+ base-len nchars chunk-used))
+		   (ans (make-string (+ j flen))))
+	      (%string-copy/cursors! ans 0 final 0 flen)	; Install FINAL.
+	      (%string-copy/cursors! ans flen chunk i chunk-len); Install CHUNK[I,).
+	      (let lp ((j (+ flen chunk-used))		; Install CHUNKS.
+		       (chunks chunks))
+		  (if (pair? chunks)
+		      (let* ((chunk  (car chunks))
+			     (chunks (cdr chunks))
+			     (chunk-len (string-length chunk)))
+			(%string-copy/cursors! ans j chunk 0 chunk-len)
+			(lp (+ j chunk-len) chunks))
+		      (%string-copy/cursors! ans j base 0 base-len))); Install BASE.
+	      ans))))))
+
+
+(define (string-for-each proc s . maybe-start+end)
+  (check-arg procedure? proc string-for-each)
+  (let-string-start+end (start end) string-for-each s maybe-start+end
+    (let lp ((i start))
+      (if (< i end)
+	  (begin (proc (string-ref s i))
+		 (lp (+ i 1)))))))
+
+(define (string-for-each-cursor proc s . maybe-start+end)
+  (check-arg procedure? proc string-for-each-cursor)
+  (let-string-start+end (start end) string-for-each-cursor s maybe-start+end
+    (let lp ((i start))
+      (if (< i end) (begin (proc i) (lp (+ i 1)))))))
+
+(define (string-every criterion s . maybe-start+end)
+  (let-string-start+end (start end) string-every s maybe-start+end
+    (cond ((char? criterion)
+	   (let lp ((i start))
+	     (or (>= i end)
+		 (and (char=? criterion (string-ref s i))
+		      (lp (+ i 1))))))
+
+	  ((procedure? criterion)		; Slightly funky loop so that
+	   (or (= start end)			; final (PRED S[END-1]) call
+	       (let lp ((i start))		; is a tail call.
+		 (let ((c (string-ref s i))
+		       (i1 (+ i 1)))
+		   (if (= i1 end) (criterion c)	; Tail call.
+		       (and (criterion c) (lp i1)))))))
+
+	  (else (error "Second param is neither char nor predicate procedure."
+		       string-every criterion)))))
+
+
+(define (string-any criterion s . maybe-start+end)
+  (let-string-start+end (start end) string-any s maybe-start+end
+    (cond ((char? criterion)
+	   (let lp ((i start))
+	     (and (< i end)
+		  (or (char=? criterion (string-ref s i))
+		      (lp (+ i 1))))))
+
+	  ((procedure? criterion)		; Slightly funky loop so that
+	   (and (< start end)			; final (PRED S[END-1]) call
+		(let lp ((i start))		; is a tail call.
+		  (let ((c (string-ref s i))
+			(i1 (+ i 1)))
+		    (if (= i1 end) (criterion c)	; Tail call
+			(or (criterion c) (lp i1)))))))
+
+	  (else (error "Second param is neither char nor predicate procedure."
+		       string-any criterion)))))
+
+
+(define (string-tabulate proc len)
+  (check-arg procedure? proc string-tabulate)
+  (check-arg (lambda (val) (and (integer? val) (exact? val) (<= 0 val)))
+	     len string-tabulate)
+  (let ((s (make-string len)))
+    (do ((i (- len 1) (- i 1)))
+	((< i 0))
+      (string-set! s i (proc i)))
+    s))
+
+
+
+;;; string-prefix-length s1 s2 [start1 end1 start2 end2]
+;;; string-suffix-length s1 s2 [start1 end1 start2 end2]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Find the length of the common prefix/suffix.
+;;; It is not required that the two substrings passed be of equal length.
+;;; This was microcode in MIT Scheme -- a very tightly bummed primitive.
+;;; %STRING-PREFIX-LENGTH is the core routine of all string-comparisons,
+;;; so should be as tense as possible.
+
+(define (%string-prefix-length s1 start1 end1 s2 start2 end2)
+  (let* ((delta (min (- end1 start1) (- end2 start2)))
+	 (end1 (+ start1 delta)))
+
+    (if (and (eq? s1 s2) (= start1 start2))	; EQ fast path
+	delta
+
+	(let lp ((i start1) (j start2))		; Regular path
+	  (if (or (>= i end1)
+		  (not (char=? (string-ref s1 i)
+			       (string-ref s2 j))))
+	      (- i start1)
+	      (lp (+ i 1) (+ j 1)))))))
+
+(define (%string-suffix-length s1 start1 end1 s2 start2 end2)
+  (let* ((delta (min (- end1 start1) (- end2 start2)))
+	 (start1 (- end1 delta)))
+
+    (if (and (eq? s1 s2) (= end1 end2))		; EQ fast path
+	delta
+
+	(let lp ((i (- end1 1)) (j (- end2 1)))	; Regular path
+	  (if (or (< i start1)
+		  (not (char=? (string-ref s1 i)
+			       (string-ref s2 j))))
+	      (- (- end1 i) 1)
+	      (lp (- i 1) (- j 1)))))))
+
+(define (string-prefix-length s1 s2 . maybe-starts+ends)
+  (let-string-start+end2 (start1 end1 start2 end2)
+			 string-prefix-length s1 s2 maybe-starts+ends
+    (%string-prefix-length s1 start1 end1 s2 start2 end2)))
+
+(define (string-suffix-length s1 s2 . maybe-starts+ends)
+  (let-string-start+end2 (start1 end1 start2 end2)
+			 string-suffix-length s1 s2 maybe-starts+ends
+    (%string-suffix-length s1 start1 end1 s2 start2 end2)))
+
+;;; string-prefix?    s1 s2 [start1 end1 start2 end2]
+;;; string-suffix?    s1 s2 [start1 end1 start2 end2]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; These are all simple derivatives of the previous counting funs.
+
+(define (string-prefix? s1 s2 . maybe-starts+ends)
+  (let-string-start+end2 (start1 end1 start2 end2)
+			 string-prefix? s1 s2 maybe-starts+ends
+    (%string-prefix? s1 start1 end1 s2 start2 end2)))
+
+(define (string-suffix? s1 s2 . maybe-starts+ends)
+  (let-string-start+end2 (start1 end1 start2 end2)
+			 string-suffix? s1 s2 maybe-starts+ends
+    (%string-suffix? s1 start1 end1 s2 start2 end2)))
+
+;;; Here are the internal routines that do the real work.
+
+(define (%string-prefix? s1 start1 end1 s2 start2 end2)
+  (let ((len1 (- end1 start1)))
+    (and (<= len1 (- end2 start2))	; Quick check
+	 (= (%string-prefix-length s1 start1 end1
+				   s2 start2 end2)
+	    len1))))
+
+(define (%string-suffix? s1 start1 end1 s2 start2 end2)
+  (let ((len1 (- end1 start1)))
+    (and (<= len1 (- end2 start2))	; Quick check
+	 (= len1 (%string-suffix-length s1 start1 end1
+					s2 start2 end2)))))
+
+
+;;; Cutting & pasting strings
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; string-take string nchars
+;;; string-drop string nchars
+;;;
+;;; string-take-right string nchars
+;;; string-drop-right string nchars
+;;;
+;;; string-pad string k [char start end]
+;;; string-pad-right string k [char start end]
+;;;
+;;; string-trim       string [char/pred start end]
+;;; string-trim-right string [char/pred start end]
+;;; string-trim-both  string [char/pred start end]
+;;;
+;;; These trimmers invert the meaning from MIT Scheme -- you
+;;; say what you want to trim.
+
+(define (string-take s n)
+  (check-arg string? s string-take)
+  (check-arg (lambda (val) (and (integer? n) (exact? n)
+				(<= 0 n (string-length s))))
+	     n string-take)
+  (%substring/cursors s 0 n))
+
+(define (string-take-right s n)
+  (check-arg string? s string-take-right)
+  (let ((len (string-length s)))
+    (check-arg (lambda (val) (and (integer? n) (exact? n) (<= 0 n len)))
+	       n string-take-right)
+    (%substring/cursors s (- len n) len)))
+
+(define (string-drop s n)
+  (check-arg string? s string-drop)
+  (let ((len (string-length s)))
+    (check-arg (lambda (val) (and (integer? n) (exact? n) (<= 0 n len)))
+	       n string-drop)
+  (%substring/cursors s n len)))
+
+(define (string-drop-right s n)
+  (check-arg string? s string-drop-right)
+  (let ((len (string-length s)))
+    (check-arg (lambda (val) (and (integer? n) (exact? n) (<= 0 n len)))
+	       n string-drop-right)
+    (%substring/cursors s 0 (- len n))))
+
+
+(define (string-trim s . criterion+start+end)
+  (let-optionals* criterion+start+end ((criterion char-whitespace?) rest)
+    (let-string-start+end (start end) string-trim s rest
+      (let ((i (string-skip s criterion start end)))
+        (if (= i end)
+            ""
+	    (%substring/cursors s i end))))))
+
+(define (string-trim-right s . criterion+start+end)
+  (let-optionals* criterion+start+end ((criterion char-whitespace?) rest)
+    (let-string-start+end (start end) string-trim-right s rest
+      (let ((i (string-skip-right s criterion start end)))
+        (if (= i start)
+            ""
+	    (%substring/cursors s start i))))))
+
+(define (string-trim-both s . criterion+start+end)
+  (let-optionals* criterion+start+end ((criterion char-whitespace?) rest)
+    (let-string-start+end (start end) string-trim-both s rest
+      (let ((i (string-skip s criterion start end)))
+        (if (= i end)
+            ""
+            (%substring/cursors
+             s i (string-skip-right s criterion i end)))))))
+
+
+(define (string-pad-right s n . char+start+end)
+  (let-optionals* char+start+end ((char #\space (char? char)) rest)
+    (let-string-start+end (start end) string-pad-right s rest
+      (check-arg (lambda (n) (and (integer? n) (exact? n) (<= 0 n)))
+		 n string-pad-right)
+      (let ((len (- end start)))
+	(if (<= n len)
+	    (%substring/cursors s start (+ start n))
+	    (let ((ans (make-string n char)))
+	      (%string-copy/cursors! ans 0 s start end)
+	      ans))))))
+
+(define (string-pad s n . char+start+end)
+  (let-optionals* char+start+end ((char #\space (char? char)) rest)
+    (let-string-start+end (start end) string-pad s rest
+      (check-arg (lambda (n) (and (integer? n) (exact? n) (<= 0 n)))
+		 n string-pad)
+      (let ((len (- end start)))
+	(if (<= n len)
+	    (%substring/cursors s (- end n) end)
+	    (let ((ans (make-string n char)))
+	      (%string-copy/cursors! ans (- n len) s start end)
+	      ans))))))
+
+
+
+;;; Filtering strings
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; string-remove char/pred string [start end]
+;;; string-filter char/pred string [start end]
+;;;
+;;; If the criterion is a predicate, we don't do this double-scan strategy,
+;;;   because the predicate might have side-effects or be very expensive to
+;;;   compute. So we preallocate a temp buffer pessimistically, and only do
+;;;   one scan over S. This is likely to be faster and more space-efficient
+;;;   than consing a list.
+
+(define (string-remove criterion s . maybe-start+end)
+  (let-string-start+end (start end) string-remove s maybe-start+end
+	(let* ((slen (- end start))
+	       (temp (make-string slen))
+	       (ans-len (string-fold (lambda (c i)
+				       (if (criterion c) i
+					   (begin (string-set! temp i c)
+						  (+ i 1))))
+				     0 s start end)))
+	  (if (= ans-len slen) temp (substring temp 0 ans-len)))))
+
+
+
+(define (string-filter criterion s . maybe-start+end)
+  (let-string-start+end (start end) string-filter s maybe-start+end
+	(let* ((slen (- end start))
+	       (temp (make-string slen))
+	       (ans-len (string-fold (lambda (c i)
+				       (if (criterion c)
+					   (begin (string-set! temp i c)
+						  (+ i 1))
+					   i))
+				     0 s start end)))
+	  (if (= ans-len slen) temp (substring temp 0 ans-len)))))
+
+
+
+
+;;; String search
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; string-index       string char/pred [start end]
+;;; string-index-right string char/pred [start end]
+;;; string-skip        string char/pred [start end]
+;;; string-skip-right  string char/pred [start end]
+;;; string-count       string char/pred [start end]
+;;;     There's a lot of replicated code here for efficiency.
+;;;     For example, the char/pred discrimination has
+;;;     been lifted above the inner loop of each proc.
+
+(define (string-index str criterion . maybe-start+end)
+  (let-string-start+end (start end) string-index str maybe-start+end
+    (cond ((char? criterion)
+	   (let lp ((i start))
+	     (if (< i end)
+		 (if (char=? criterion (string-ref str i))
+                     i
+		     (lp (+ i 1)))
+                 end)))
+	  ((procedure? criterion)
+	   (let lp ((i start))
+	     (if (< i end)
+                 (if (criterion (string-ref str i))
+                     i
+                     (lp (+ i 1)))
+                 end)))
+	  (else (error "Second param is neither char nor predicate procedure."
+		       string-index criterion)))))
+
+(define (string-index-right str criterion . maybe-start+end)
+  (let-string-start+end (start end) string-index-right str maybe-start+end
+    (cond ((char? criterion)
+	   (let lp ((i (- end 1)))
+	     (if (>= i start) start
+		  (if (char=? criterion (string-ref str i)) (+ i 1)
+		      (lp (- i 1))))))
+	  ((procedure? criterion)
+	   (let lp ((i (- end 1)))
+	     (if (< i start) start
+		  (if (criterion (string-ref str i)) (+ i 1)
+		      (lp (- i 1))))))
+	  (else (error "Second param is neither char nor predicate procedure."
+		       string-index-right criterion)))))
+
+(define (string-skip str criterion . maybe-start+end)
+  (let-string-start+end (start end) string-skip str maybe-start+end
+    (cond ((char? criterion)
+	   (let lp ((i start))
+	     (if (< i end)
+		 (if (char=? criterion (string-ref str i))
+		     (lp (+ i 1))
+		     i)
+                 end)))
+	  ((procedure? criterion)
+	   (let lp ((i start))
+	     (if (< i end)
+		 (if (criterion (string-ref str i))
+                     (lp (+ i 1))
+		     i)
+                 end)))
+	  (else (error "Second param is neither char nor predicate procedure."
+		       string-skip criterion)))))
+
+(define (string-skip-right str criterion . maybe-start+end)
+  (let-string-start+end (start end) string-skip-right str maybe-start+end
+    (cond ((char? criterion)
+	   (let lp ((i (- end 1)))
+	     (if (>= i start) start
+		  (if (char=? criterion (string-ref str i))
+		      (lp (- i 1))
+		      (+ i 1)))))
+	  ((procedure? criterion)
+	   (let lp ((i (- end 1)))
+	     (if (< i start)
+                 start
+                 (if (criterion (string-ref str i))
+                     (lp (- i 1))
+                     (+ i 1)))))
+	  (else (error "CRITERION param is neither procedure nor char."
+		       string-skip-right criterion)))))
+
+
+(define (string-count s criterion . maybe-start+end)
+  (let-string-start+end (start end) string-count s maybe-start+end
+    (cond ((char? criterion)
+	   (do ((i start (+ i 1))
+		(count 0 (if (char=? criterion (string-ref s i))
+			     (+ count 1)
+			     count)))
+	       ((>= i end) count)))
+
+	  ((procedure? criterion)
+	   (do ((i start (+ i 1))
+		(count 0 (if (criterion (string-ref s i)) (+ count 1) count)))
+	       ((>= i end) count)))
+
+	  (else (error "CRITERION param is neither procedure nor char."
+		       string-count criterion)))))
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; %string-copy/cursors! to tstart from [fstart fend]
+;;; 	Guaranteed to work, even if s1 eq s2.
+;;; Library-internal routine
+(define (%string-copy/cursors! to tstart from fstart fend)
+  (if (> fstart tstart)
+      (do ((i fstart (+ i 1))
+	   (j tstart (+ j 1)))
+	  ((>= i fend))
+	(string-set! to j (string-ref from i)))
+
+      (do ((i (- fend 1)                    (- i 1))
+	   (j (+ -1 tstart (- fend fstart)) (- j 1)))
+	  ((< i fstart))
+	(string-set! to j (string-ref from i)))))
+
+
+
+;;; Returns starting-position in STRING or #f if not true.
+;;; This implementation is slow & simple. It is useful as a "spec" or for
+;;; comparison testing with fancier implementations.
+;;; See below for fast KMP version.
+
+;(define (string-contains string substring . maybe-starts+ends)
+;  (let-string-start+end2 (start1 end1 start2 end2)
+;                         string-contains string substring maybe-starts+ends
+;    (let* ((len (- end2 start2))
+;	   (i-bound (- end1 len)))
+;      (let lp ((i start1))
+;	(and (< i i-bound)
+;	     (if (string= string substring i (+ i len) start2 end2)
+;		 i
+;		 (lp (+ i 1))))))))
+
+
+;;; Searching for an occurrence of a substring
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (string-contains text pattern . maybe-starts+ends)
+  (let-string-start+end2 (t-start t-end p-start p-end)
+                         string-contains text pattern maybe-starts+ends
+    (%kmp-search pattern text char=? p-start p-end t-start t-end)))
+
+(define (string-contains-right text pattern . maybe-starts+ends)
+  (let-string-start+end2 (t-start t-end p-start p-end)
+                         string-contains-right text pattern maybe-starts+ends
+    (let* ((t-len (string-length text))
+           (p-len (string-length pattern))
+           (p-size (- p-end p-start))
+           (rt-start (- t-len t-end))
+           (rt-end (- t-len t-start))
+           (rp-start (- p-len p-end))
+           (rp-end (- p-len p-start))
+           (res (%kmp-search (string-reverse pattern)
+                             (string-reverse text)
+                             char=? rp-start rp-end rt-start rt-end)))
+      (if res
+        (- t-len res p-size)
+        #f))))
+
+;;; Knuth-Morris-Pratt string searching
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; See
+;;;     "Fast pattern matching in strings"
+;;;     SIAM J. Computing 6(2):323-350 1977
+;;;     D. E. Knuth, J. H. Morris and V. R. Pratt
+;;; also described in
+;;;     "Pattern matching in strings"
+;;;     Alfred V. Aho
+;;;     Formal Language Theory - Perspectives and Open Problems
+;;;     Ronald V. Brook (editor)
+;;; This algorithm is O(m + n) where m and n are the
+;;; lengths of the pattern and string respectively
+
+;;; KMP search source[start,end) for PATTERN. Return starting index of
+;;; leftmost match or #f.
+
+(define (%kmp-search pattern text c= p-start p-end t-start t-end)
+  (let ((plen (- p-end p-start))
+	(rv (make-kmp-restart-vector pattern c= p-start p-end)))
+
+    ;; The search loop. TJ & PJ are redundant state.
+    (let lp ((ti t-start) (pi 0)
+	     (tj (- t-end t-start)) ; (- tlen ti) -- how many chars left.
+	     (pj plen))		 ; (- plen pi) -- how many chars left.
+
+      (if (= pi plen)
+	  (- ti plen)			; Win.
+	  (and (<= pj tj)		; Lose.
+	       (if (c= (string-ref text ti) ; Search.
+		       (string-ref pattern (+ p-start pi)))
+		   (lp (+ 1 ti) (+ 1 pi) (- tj 1) (- pj 1)) ; Advance.
+
+		   (let ((pi (vector-ref rv pi))) ; Retreat.
+		     (if (= pi -1)
+			 (lp (+ ti 1) 0  (- tj 1) plen) ; Punt.
+			 (lp ti       pi tj       (- plen pi))))))))))
+
+;;; (make-kmp-restart-vector pattern [c= start end]) -> integer-vector
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Compute the KMP restart vector RV for string PATTERN.  If
+;;; we have matched chars 0..i-1 of PATTERN against a search string S, and
+;;; PATTERN[i] doesn't match S[k], then reset i := RV[i], and try again to
+;;; match S[k].  If RV[i] = -1, then punt S[k] completely, and move on to
+;;; S[k+1] and PATTERN[0] -- no possible match of PAT[0..i] contains S[k].
+;;;
+;;; In other words, if you have matched the first i chars of PATTERN, but
+;;; the i+1'th char doesn't match, RV[i] tells you what the next-longest
+;;; prefix of PATTERN is that you have matched.
+;;;
+;;; - C= (default CHAR=?) is used to compare characters for equality.
+;;;   Pass in CHAR-CI=? for case-folded string search.
+;;;
+;;; - START & END restrict the pattern to the indicated substring; the
+;;;   returned vector will be of length END - START. The numbers stored
+;;;   in the vector will be values in the range [0,END-START) -- that is,
+;;;   they are valid indices into the restart vector; you have to add START
+;;;   to them to use them as indices into PATTERN.
+;;;
+;;; I've split this out as a separate function in case other constant-string
+;;; searchers might want to use it.
+;;;
+;;; E.g.:
+;;;    a b d  a b x
+;;; #(-1 0 0 -1 1 2)
+
+#;(define (make-kmp-restart-vector pattern . maybe-c=+start+end)
+  (let-optionals* maybe-c=+start+end
+                  ((c= char=? (procedure? c=))
+		   ((start end) (lambda (args)
+				  (string-parse-start+end make-kmp-restart-vector
+							  pattern args))))
+    (let* ((rvlen (- end start))
+	   (rv (make-vector rvlen -1)))
+      (if (> rvlen 0)
+	  (let ((rvlen-1 (- rvlen 1))
+		(c0 (string-ref pattern start)))
+
+	    ;; Here's the main loop. We have set rv[0] ... rv[i].
+	    ;; K = I + START -- it is the corresponding index into PATTERN.
+	    (let lp1 ((i 0) (j -1) (k start))
+	      (if (< i rvlen-1)
+		  ;; lp2 invariant:
+		  ;;   pat[(k-j) .. k-1] matches pat[start .. start+j-1]
+		  ;;   or j = -1.
+		  (let lp2 ((j j))
+		    (cond ((= j -1)
+			   (let ((i1 (+ 1 i)))
+			     (if (not (c= (string-ref pattern (+ k 1)) c0))
+				 (vector-set! rv i1 0))
+			     (lp1 i1 0 (+ k 1))))
+			  ;; pat[(k-j) .. k] matches pat[start..start+j].
+			  ((c= (string-ref pattern k) (string-ref pattern (+ j start)))
+			   (let* ((i1 (+ 1 i))
+				  (j1 (+ 1 j)))
+			     (vector-set! rv i1 j1)
+			     (lp1 i1 j1 (+ k 1))))
+
+			  (else (lp2 (vector-ref rv j)))))))))
+      rv)))
+
+
+(define (make-kmp-restart-vector pattern . maybe-c=+start+end)
+  (let-optionals* maybe-c=+start+end
+                  ((c= char=?) rest) ; (procedure? c=))
+     (receive (rest2 start end) (string-parse-start+end make-kmp-restart-vector pattern rest)
+       (let* ((rvlen (- end start))
+	      (rv (make-vector rvlen -1)))
+      (if (> rvlen 0)
+	  (let ((rvlen-1 (- rvlen 1))
+		(c0 (string-ref pattern start)))
+
+	    ;; Here's the main loop. We have set rv[0] ... rv[i].
+	    ;; K = I + START -- it is the corresponding index into PATTERN.
+	    (let lp1 ((i 0) (j -1) (k start))
+	      (if (< i rvlen-1)
+
+		  ;; lp2 invariant:
+		  ;;   pat[(k-j) .. k-1] matches pat[start .. start+j-1]
+		  ;;   or j = -1.
+		  (let lp2 ((j j))
+
+		    (cond ((= j -1)
+			   (let ((i1 (+ i 1))
+				 (ck+1 (string-ref pattern (add1 k))))
+			     (vector-set! rv i1 (if (c= ck+1 c0) -1 0))
+			     (lp1 i1 0 (+ k 1))))
+
+			  ;; pat[(k-j) .. k] matches pat[start..start+j].
+			  ((c= (string-ref pattern k)
+			       (string-ref pattern (+ j start)))
+			   (let* ((i1 (+ 1 i))
+				  (j1 (+ 1 j)))
+			     (vector-set! rv i1 j1)
+			     (lp1 i1 j1 (+ k 1))))
+
+			  (else (lp2 (vector-ref rv j)))))))))
+      rv))))
+
+
+;;; We've matched I chars from PAT. C is the next char from the search string.
+;;; Return the new I after handling C.
+;;;
+;;; The pattern is (VECTOR-LENGTH RV) chars long, beginning at index PAT-START
+;;; in PAT (PAT-START is usually 0). The I chars of the pattern we've matched
+;;; are
+;;;     PAT[PAT-START .. PAT-START + I].
+;;;
+;;; It's *not* an oversight that there is no friendly error checking or
+;;; defaulting of arguments. This is a low-level, inner-loop procedure
+;;; that we want integrated/inlined into the point of call.
+
+(define (kmp-step pat rv c i c= p-start)
+  (let lp ((i i))
+    (if (c= c (string-ref pat (+ i p-start)))	; Match =>
+	(+ i 1)					;   Done.
+	(let ((i (vector-ref rv i)))		; Back up in PAT.
+	  (if (= i -1) 0			; Can't back up further.
+	      (lp i))))))			; Keep trying for match.
+
+;;; Zip through S[start,end), looking for a match of PAT. Assume we've
+;;; already matched the first I chars of PAT when we commence at S[start].
+;;; - <0:  If we find a match *ending* at index J, return -J.
+;;; - >=0: If we get to the end of the S[start,end) span without finding
+;;;   a complete match, return the number of chars from PAT we'd matched
+;;;   when we ran off the end.
+;;;
+;;; This is useful for searching *across* buffers -- that is, when your
+;;; input comes in chunks of text. We hand-integrate the KMP-STEP loop
+;;; for speed.
+
+(define (string-kmp-partial-search pat rv s i . c=+p-start+s-start+s-end)
+;  (check-arg vector? rv string-kmp-partial-search)
+  (let-optionals* c=+p-start+s-start+s-end
+      ((c=      char=?) ; (procedure? c=))
+       (p-start 0) rest) ; (and (integer? p-start) (exact? p-start) (<= 0 p-start)))
+    (receive (rest2 s-start s-end) (string-parse-start+end string-kmp-partial-search s rest)
+    ;; Enough prelude. Here's the actual code.
+    (let ((patlen (vector-length rv)))
+      (let lp ((si s-start)		; An index into S.
+	       (vi i))			; An index into RV.
+	(cond ((= vi patlen) (- si))	; Win.
+	      ((= si s-end) vi)		; Ran off the end.
+	      (else			; Match s[si] & loop.
+	       (let ((c (string-ref s si)))
+		 (lp (+ si 1)
+		     (let lp2 ((vi vi))	; This is just KMP-STEP.
+		       (if (c= c (string-ref pat (+ vi p-start)))
+			   (+ vi 1)
+			   (let ((vi (vector-ref rv vi)))
+			     (if (= vi -1) 0
+				 (lp2 vi))))))))))))) )
+
+
+;;; Misc
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; (string-null? s)
+;;; (string-reverse  s [start end])
+;;; (reverse-list->string clist)
+;;; (string->list/cursors s [start end])
+
+(define (string-null? s) (zero? (string-length s)))
+
+(define (string-reverse s . maybe-start+end)
+  (let-string-start+end (start end) string-reverse s maybe-start+end
+    (let* ((len (- end start))
+	   (ans (make-string len)))
+      (do ((i start (+ i 1))
+	   (j (- len 1) (- j 1)))
+	  ((< j 0))
+	(string-set! ans j (string-ref s i)))
+      ans)))
+
+(define (reverse-list->string clist)
+  (let* ((len (length clist))
+	 (s (make-string len)))
+    (do ((i (- len 1) (- i 1))   (clist clist (cdr clist)))
+	((not (pair? clist)))
+      (string-set! s i (car clist)))
+    s))
+
+
+;(define (string->list/cursors s . maybe-start+end)
+;  (apply string-fold-right cons '() s maybe-start+end))
+
+(define (string->list/cursors s . maybe-start+end)
+  (let-string-start+end (start end) string->list/cursors s maybe-start+end
+    (do ((i (- end 1) (- i 1))
+	 (ans '() (cons (string-ref s i) ans)))
+	((< i start) ans))))
+
+(define (string->vector/cursors s . maybe-start+end)
+  (let-string-start+end (start end) string->list/cursors s maybe-start+end
+    (define ans (make-vector (- end start)))
+    (do ((i (- end 1) (- i 1)))
+	((< i start) ans)
+      (vector-set! ans (- i start) (string-ref s i)))))
+
+;;; Defined by R5RS, so commented out here.
+;(define (list->string lis) (string-unfold null? car cdr lis))
+
+
+;;; string-concatenate        string-list -> string
+;;; string-concatenate/shared string-list -> string
+; Alas, Scheme 48's APPLY blows up if you have many, many arguments.
+;(define (string-concatenate strings) (apply string-append strings))
+
+;;; Here it is written out. I avoid using REDUCE to add up string lengths
+;;; to avoid non-R5RS dependencies.
+(define (string-concatenate strings)
+  (let* ((total (do ((strings strings (cdr strings))
+		     (i 0 (+ i (string-length (car strings)))))
+		    ((not (pair? strings)) i)))
+	 (ans (make-string total)))
+    (let lp ((i 0) (strings strings))
+      (if (pair? strings)
+	  (let* ((s (car strings))
+		 (slen (string-length s)))
+	    (%string-copy/cursors! ans i s 0 slen)
+	    (lp (+ i slen) (cdr strings)))))
+    ans))
+
+
+;;; Defined by R5RS, so commented out here.
+;(define (string-append . strings) (string-concatenate strings))
+
+;;; string-concatenate-reverse        string-list [final-string end] -> string
+;;; string-concatenate-reverse/shared string-list [final-string end] -> string
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Return
+;;;   (string-concatenate
+;;;     (reverse
+;;;       (cons (substring final-string 0 end) string-list)))
+
+(define (string-concatenate-reverse string-list . maybe-final+end)
+  (let-optionals* maybe-final+end ((final "" (string? final))
+				   (end (string-length final)
+					(and (integer? end)
+					     (exact? end)
+					     (<= 0 end (string-length final)))))
+    (let ((len (let lp ((sum 0) (lis string-list))
+		 (if (pair? lis)
+		     (lp (+ sum (string-length (car lis))) (cdr lis))
+		     sum))))
+
+      (%finish-string-concatenate-reverse len string-list final end))))
+
+(define (string-concatenate-reverse/shared string-list . maybe-final+end)
+  (let-optionals* maybe-final+end ((final "" (string? final))
+				   (end (string-length final)
+					(and (integer? end)
+					     (exact? end)
+					     (<= 0 end (string-length final)))))
+    ;; Add up the lengths of all the strings in STRING-LIST; also get a
+    ;; pointer NZLIST into STRING-LIST showing where the first non-zero-length
+    ;; string starts.
+    (let lp ((len 0) (nzlist #f) (lis string-list))
+      (if (pair? lis)
+	  (let ((slen (string-length (car lis))))
+	    (lp (+ len slen)
+		(if (or nzlist (zero? slen)) nzlist lis)
+		(cdr lis)))
+
+	  (cond ((zero? len) (substring/cursors final 0 end))
+
+		;; LEN > 0, so NZLIST is non-empty.
+
+		((and (zero? end) (= len (string-length (car nzlist))))
+		 (car nzlist))
+
+		(else (%finish-string-concatenate-reverse len nzlist final end)))))))
+
+(define (%finish-string-concatenate-reverse len string-list final end)
+  (let ((ans (make-string (+ end len))))
+    (%string-copy/cursors! ans len final 0 end)
+    (let lp ((i len) (lis string-list))
+      (if (pair? lis)
+	  (let* ((s   (car lis))
+		 (lis (cdr lis))
+		 (slen (string-length s))
+		 (i (- i slen)))
+	    (%string-copy/cursors! ans i s 0 slen)
+	    (lp i lis))))
+    ans))
+
+
+
+
+;;; string-replace s1 s2 start1 end1 [start2 end2] -> string
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Replace S1[START1,END1) with S2[START2,END2).
+
+(define (string-replace s1 s2 start1 end1 . maybe-start+end)
+  (check-substring-spec string-replace s1 start1 end1)
+  (let-string-start+end (start2 end2) string-replace s2 maybe-start+end
+    (let* ((slen1 (string-length s1))
+	   (sublen2 (- end2 start2))
+	   (alen (+ (- slen1 (- end1 start1)) sublen2))
+	   (ans (make-string alen)))
+      (%string-copy/cursors! ans 0 s1 0 start1)
+      (%string-copy/cursors! ans start1 s2 start2 end2)
+      (%string-copy/cursors! ans (+ start1 sublen2) s1 end1 slen1)
+      ans)))
+
+
+;;; string-split s delimiter [grammar limit start end] -> list
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Returns a list of the words contained in the substring of string from
+;;; start (inclusive) to end (exclusive). Delimiter specifies a string
+;;; whose characters are to be used as the word separator. The returned
+;;; list will then have one more item than the number of non-overlapping
+;;; occurrences of the delimiter in the string. If delimiter is an
+;;; empty string, then the returned list contains a list of strings,
+;;; each of which contains a single character.  Grammar is a symbol with
+;;; the same meaning as in the string-join procedure. If it is infix,
+;;; which is the default, processing is done as described above, except
+;;; that an empty s produces the empty list; if it is strict-infix,
+;;; an empty s signals an error. The values prefix and suffix cause a
+;;; leading/trailing empty string in the result to be suppressed.
+;;;
+;;; If limit is a non-negative exact integer, at most that many splits
+;;; occur, and the remainder of string is returned as the final element
+;;; of the list (thus, the result will have at most limit+1 elements). If
+;;; limit is not specified or is #f, then as many splits as possible
+;;; are made. It is an error if limit is any other value.
+;;;
+;;; Thanks to Shiro Kawai for the following code.
+
+(define (string-split s delimiter . args)
+  ;; The argument checking part might be refactored with other srfi-130
+  ;; routines.
+  (if (not (string? s)) (error "string expected" s))
+  (if (not (string? delimiter)) (error "string expected" delimiter))
+  (let ((slen (string-length s)))
+    (receive (grammar limit no-limit start end)
+        (if (pair? args)
+          (if (pair? (cdr args))
+            (if (pair? (cddr args))
+              (if (pair? (cdddr args))
+                (values (car args) (cadr args) #f (caddr args) (cadddr args))
+                (values (car args) (cadr args) #f (caddr args) slen))
+              (values (car args) (cadr args) #f 0 slen))
+            (values (car args) #f #t 0 slen))
+          (values 'infix #f #t 0 slen))
+      (if (not (memq grammar '(infix strict-infix prefix suffix)))
+        (error "grammar must be one of (infix strict-infix prefix suffix)" grammar))
+      (if (not limit) (set! no-limit #t))
+      (if (not (or no-limit
+                  (and (integer? limit) (exact? limit) (>= limit 0))))
+        (error "limit must be exact nonnegative integer or #f" limit))
+      (if (not (and (integer? start) (exact? start)))
+        (error "start argument must be exact integer" start))
+      (if (not (<= 0 start slen))
+        (error "start argument out of range" start))
+      (if (not (<= 0 end slen))
+        (error "end argument out of range" end))
+      (if (not (<= start end))
+        (error "start argument is greater than end argument" (list start end)))
+
+      (cond ((string-cursor=? start end)
+             (if (eq? grammar 'strict-infix)
+               (error "empty string cannot be spilt with strict-infix grammar")
+               '()))
+            ((string-null? delimiter)
+             (%string-split-chars s start end limit))
+            (else (%string-split s start end delimiter grammar limit))))))
+
+(define (%string-split-chars s start end limit)
+  (if (not limit)
+    (map string (string->list/cursors s start end))
+    (let loop ((r '()) (c start) (n 0))
+      (cond ((string-cursor=? c end) (reverse r))
+            ((>= n limit) (reverse (cons (substring s c end) r)))
+            (else (loop (cons (string (string-ref s c)) r)
+                        (string-cursor-next s c)
+                        (+ n 1)))))))
+
+(define (%string-split s start end delimiter grammar limit)
+  (let ((dlen (string-length delimiter)))
+    (define (finish r c)
+      (let ((rest (substring/cursors s c end)))
+        (if (and (eq? grammar 'suffix) (string-null? rest))
+          (reverse r)
+          (reverse (cons rest r)))))
+    (define (scan r c n)
+      (if (and limit (>= n limit))
+        (finish r c)
+        (let ((i (string-contains s delimiter c end)))
+          (if i
+            (let ((fragment (substring/cursors s c i)))
+              (if (and (= n 0) (eq? grammar 'prefix) (string-null? fragment))
+                (scan r (+ i dlen) (+ n 1))
+                (scan (cons fragment r)
+                      (+ i dlen)
+                      (+ n 1))))
+            (finish r c)))))
+    (scan '() start 0)))
+
+
+
+;;; string-replicate s from [to start end] -> string
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; S is a string; START and END are optional arguments that demarcate
+;;; a substring of S, defaulting to 0 and the length of S (e.g., the whole
+;;; string). Replicate this substring up and down index space, in both the
+;;  positive and negative directions. For example, if S = "abcdefg", START=3,
+;;; and END=6, then we have the conceptual bidirectionally-infinite string
+;;;     ...  d  e  f  d  e  f  d  e  f  d  e  f  d  e  f  d  e  f  d  e  f ...
+;;;     ... -9 -8 -7 -6 -5 -4 -3 -2 -1  0  1  2  3  4  5  6  7  8  9 ...
+;;; XSUBSTRING returns the substring of this string beginning at index FROM,
+;;; and ending at TO (which defaults to FROM+(END-START)).
+;;;
+;;; You can use XSUBSTRING in many ways:
+;;; - To rotate a string left:  (string-replicate "abcdef" 2)  => "cdefab"
+;;; - To rotate a string right: (string-replicate "abcdef" -2) => "efabcd"
+;;; - To replicate a string:    (string-replicate "abc" 0 7) => "abcabca"
+;;;
+;;; Note that
+;;;   - The FROM/TO indices give a half-open range -- the characters from
+;;;     index FROM up to, but not including index TO.
+;;;   - The FROM/TO indices are not in terms of the index space for string S.
+;;;     They are in terms of the replicated index space of the substring
+;;;     defined by S, START, and END.
+;;;
+;;; It is an error if START=END -- although this is allowed by special
+;;; dispensation when FROM=TO.
+
+(define (string-replicate s from . maybe-to+start+end)
+  (check-arg (lambda (val) (and (integer? val) (exact? val)))
+	     from string-replicate)
+  (receive (to start end)
+           (if (pair? maybe-to+start+end)
+	       (let-string-start+end (start end) string-replicate s (cdr maybe-to+start+end)
+		 (let ((to (car maybe-to+start+end)))
+		   (check-arg (lambda (val) (and (integer? val)
+						 (exact? val)
+						 (<= from val)))
+			      to string-replicate)
+		   (values to start end)))
+	       (let ((slen (string-length (check-arg string? s string-replicate))))
+		 (values (+ from slen) 0 slen)))
+    (let ((slen   (- end start))
+	  (anslen (- to  from)))
+      (cond ((zero? anslen) "")
+	    ((zero? slen) (error "Cannot replicate empty (sub)string"
+				  string-replicate s from to start end))
+
+	    ((= 1 slen)		; Fast path for 1-char replication.
+	     (make-string anslen (string-ref s start)))
+
+	    ;; Selected text falls entirely within one span.
+	    ((= (floor (/ from slen)) (floor (/ to slen)))
+	     (substring s (+ start (modulo from slen))
+			  (+ start (modulo to   slen))))
+
+	    ;; Selected text requires multiple spans.
+	    (else (let ((ans (make-string anslen)))
+		    (%multispan-repcopy! ans 0 s from to start end)
+		    ans))))))
+
+
+;;; This is the core copying loop for XSUBSTRING and STRING-XCOPY!
+;;; Internal -- not exported, no careful arg checking.
+(define (%multispan-repcopy! target tstart s sfrom sto start end)
+  (let* ((slen (- end start))
+	 (i0 (+ start (modulo sfrom slen)))
+	 (total-chars (- sto sfrom)))
+
+    ;; Copy the partial span ! the beginning
+    (%string-copy/cursors! target tstart s i0 end)
+
+    (let* ((ncopied (- end i0))			; We've copied this many.
+	   (nleft (- total-chars ncopied))	; # chars left to copy.
+	   (nspans (quotient nleft slen)))	; # whole spans to copy
+
+      ;; Copy the whole spans in the middle.
+      (do ((i (+ tstart ncopied) (+ i slen))	; Current target index.
+	   (nspans nspans (- nspans 1)))	; # spans to copy
+	  ((zero? nspans)
+	   ;; Copy the partial-span ! the end & we're done.
+	   (%string-copy/cursors! target i s start (+ start (- total-chars (- i tstart)))))
+
+	(%string-copy/cursors! target i s start end))))); Copy a whole span.
+
+
+
+;;; (string-join string-list [delimiter grammar]) => string
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Paste strings together using the delimiter string.
+;;;
+;;; (join-strings '("foo" "bar" "baz") ":") => "foo:bar:baz"
+;;;
+;;; DELIMITER defaults to a single space " "
+;;; GRAMMAR is one of the symbols {prefix, infix, strict-infix, suffix}
+;;; and defaults to 'infix.
+;;;
+;;; I could rewrite this more efficiently -- precompute the length of the
+;;; answer string, then allocate & fill it in iteratively. Using
+;;; STRING-CONCATENATE is less efficient.
+
+(define (string-join strings . delim+grammar)
+  (let-optionals* delim+grammar ((delim " " (string? delim))
+				 (grammar 'infix))
+    (let ((buildit (lambda (lis final)
+		     (let recur ((lis lis))
+		       (if (pair? lis)
+			   (cons delim (cons (car lis) (recur (cdr lis))))
+			   final)))))
+
+      (cond ((pair? strings)
+	     (string-concatenate
+	      (case grammar
+
+		((infix strict-infix)
+		 (cons (car strings) (buildit (cdr strings) '())))
+
+		((prefix) (buildit strings '()))
+
+		((suffix)
+		 (cons (car strings) (buildit (cdr strings) (list delim))))
+
+		(else (error "Illegal join grammar"
+			     grammar string-join)))))
+
+	     ((not (null? strings))
+	      (error "STRINGS parameter not list." strings string-join))
+
+	     ;; STRINGS is ()
+
+	     ((eq? grammar 'strict-infix)
+	      (error "Empty list cannot be joined with STRICT-INFIX grammar."
+		     string-join))
+
+	     (else "")))))		; Special-cased for infix grammar.
+
+(define string-ref/cursor string-ref)
+
+
+;;; Porting & performance-tuning notes
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; See the section at the beginning of this file on external dependencies.
+;;;
+;;; The biggest issue with respect to porting is the LET-OPTIONALS* macro.
+;;; There are many, many optional arguments in this library; the complexity
+;;; of parsing, defaulting & type-testing these parameters is handled with the
+;;; aid of this macro. There are about 15 uses of LET-OPTIONALS*. You can
+;;; rewrite the uses, port the hairy macro definition (which is implemented
+;;; using a Clinger-Rees low-level explicit-renaming macro system), or port
+;;; the simple, high-level definition, which is less efficient.
+;;;
+;;; There is a fair amount of argument checking. This is, strictly speaking,
+;;; unnecessary -- the actual body of the procedures will blow up if, say, a
+;;; START/END index is improper. However, the error message will not be as
+;;; good as if the error were caught at the "higher level." Also, a very, very
+;;; smart Scheme compiler may be able to exploit having the type checks done
+;;; early, so that the actual body of the procedures can assume proper values.
+;;; This isn't likely; this kind of compiler technology isn't common any
+;;; longer.
+;;;
+;;; The overhead of optional-argument parsing is irritating. The optional
+;;; arguments must be consed into a rest list on entry, and then parsed out.
+;;; Function call should be a matter of a few register moves and a jump; it
+;;; should not involve heap allocation! Your Scheme system may have a superior
+;;; non-R5RS optional-argument system that can eliminate this overhead. If so,
+;;; then this is a prime candidate for optimising these procedures,
+;;; *especially* the many optional START/END index parameters.
+;;;
+;;; Note that optional arguments are also a barrier to procedure integration.
+;;; If your Scheme system permits you to specify alternate entry points
+;;; for a call when the number of optional arguments is known in a manner
+;;; that enables inlining/integration, this can provide performance
+;;; improvements.
+;;;
+;;; There is enough *explicit* error checking that *all* string-index
+;;; operations should *never* produce a bounds error. Period. Feel like
+;;; living dangerously? *Big* performance win to be had by replacing
+;;; STRING-REF's and STRING-SET!'s with unsafe equivalents in the loops.
+;;; Similarly, fixnum-specific operators can speed up the arithmetic done on
+;;; the index values in the inner loops. The only arguments that are not
+;;; completely error checked are
+;;;   - string lists (complete checking requires time proportional to the
+;;;     length of the list)
+;;;   - procedure arguments, such as char->char maps & predicates.
+;;;     There is no way to check the range & domain of procedures in Scheme.
+;;; Procedures that take these parameters cannot fully check their
+;;; arguments. But all other types to all other procedures are fully
+;;; checked.
+;;;
+;;; This does open up the alternate possibility of simply *removing* these
+;;; checks, and letting the safe primitives raise the errors. On a dumb
+;;; Scheme system, this would provide speed (by eliminating the redundant
+;;; error checks) at the cost of error-message clarity.
+;;;
+;;; See the comments preceding the hash function code for notes on tuning
+;;; the default bound so that the code never overflows your implementation's
+;;; fixnum size into bignum calculation.
+;;;
+;;; In an interpreted Scheme, some of these procedures, or the internal
+;;; routines with % prefixes, are excellent candidates for being rewritten
+;;; in C. Consider STRING-HASH, %STRING-COMPARE, the
+;;; %STRING-{SUF,PRE}FIX-LENGTH routines, STRING-COPY!, STRING-INDEX &
+;;; STRING-SKIP (char case), SUBSTRING and SUBSTRING/CURSORS,
+;;; %KMP-SEARCH, and %MULTISPAN-REPCOPY!.
+;;;
+;;; It would also be nice to have the ability to mark some of these
+;;; routines as candidates for inlining/integration.
+;;;
+;;; All the %-prefixed routines in this source code are written
+;;; to be called internally to this library. They do *not* perform
+;;; friendly error checks on the inputs; they assume everything is
+;;; proper. They also do not take optional arguments. These two properties
+;;; save calling overhead and enable procedure integration -- but they
+;;; are not appropriate for exported routines.
+
+
+;;; Copyright details
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; The prefix/suffix and comparison routines in this code had (extremely
+;;; distant) origins in MIT Scheme's string lib, and was substantially
+;;; reworked by Olin Shivers (shivers@ai.mit.edu) 9/98. As such, it is
+;;; covered by MIT Scheme's open source copyright. See below for details.
+;;;
+;;; The KMP string-search code was influenced by implementations written
+;;; by Stephen Bevan, Brian Dehneyer and Will Fitzgerald. However, this
+;;; version was written from scratch by myself.
+;;;
+;;; The remainder of this code was written from scratch by myself for scsh.
+;;; The scsh copyright is a BSD-style open source copyright. See below for
+;;; details.
+;;;     -Olin Shivers
+
+;;; MIT Scheme copyright terms
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; This material was developed by the Scheme project at the Massachusetts
+;;; Institute of Technology, Department of Electrical Engineering and
+;;; Computer Science.  Permission to copy and modify this software, to
+;;; redistribute either the original software or a modified version, and
+;;; to use this software for any purpose is granted, subject to the
+;;; following restrictions and understandings.
+;;;
+;;; 1. Any copy made of this software must include this copyright notice
+;;; in full.
+;;;
+;;; 2. Users of this software agree to make their best efforts (a) to
+;;; return to the MIT Scheme project any improvements or extensions that
+;;; they make, so that these may be included in future releases; and (b)
+;;; to inform MIT of noteworthy uses of this software.
+;;;
+;;; 3. All materials developed as a consequence of the use of this
+;;; software shall duly acknowledge such use, in accordance with the usual
+;;; standards of acknowledging credit in academic research.
+;;;
+;;; 4. MIT has made no warrantee or representation that the operation of
+;;; this software will be error-free, and MIT is under no obligation to
+;;; provide any services, by way of maintenance, update, or otherwise.
+;;;
+;;; 5. In conjunction with products arising from the use of this material,
+;;; there shall be no use of the name of the Massachusetts Institute of
+;;; Technology nor of any adaptation thereof in any advertising,
+;;; promotional, or sales literature without prior written consent from
+;;; MIT in each case.
+
+;;; Scsh copyright terms
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;; 1. Redistributions of source code must retain the above copyright
+;;;    notice, this list of conditions and the following disclaimer.
+;;; 2. Redistributions in binary form must reproduce the above copyright
+;;;    notice, this list of conditions and the following disclaimer in the
+;;;    documentation and/or other materials provided with the distribution.
+;;; 3. The name of the authors may not be used to endorse or promote products
+;;;    derived from this software without specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+;;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;;; IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+;;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(define srfi-13:string-index string-index)
+(define srfi-13:string-index-right string-index-right)
+(define srfi-13:string-split string-split)
+(define srfi-13:string-skip string-skip)
+(define srfi-13:string-skip-right string-skip)
+
+(import SRFI-130)
+
+(define string-index (in-module SRFI-130 string-index))
+(define string-index-right (in-module SRFI-130 string-index-right))
+(define string-split (in-module SRFI-130 string-split))
+(define string-skip (in-module SRFI-130 string-skip))
+(define string-skip-right (in-module SRFI-130 string-skip-right))
+
+(provide "srfi-130")

--- a/tests/test-srfi-130.stk
+++ b/tests/test-srfi-130.stk
@@ -1,0 +1,4778 @@
+;;;;
+;;;; srfi-130.stk		-- Implementation of SRFI-130
+;;;;
+;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; the tests for this SRFI by William Clinger, it is copyrighted as:
+;;;;
+;;;;;;  Copyright (c) William Clinger (2016).
+;;;;;;  Permission is hereby granted, free of charge, to any person
+;;;;;;  obtaining a copy of this software and associated documentation
+;;;;;;  files (the "Software"), to deal in the Software without
+;;;;;;  restriction, including without limitation the rights to use,
+;;;;;;  copy, modify, merge, publish, distribute, sublicense, and/or
+;;;;;;  sell copies of the Software, and to permit persons to whom the
+;;;;;;  Software is furnished to do so, subject to the following
+;;;;;;  conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;;;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;;;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;;;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;;;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;;;;; OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 13-Nov-2020 21:00 (jpellegrini)
+;;;; Last file update: 14-Nov-2020 00:01 (jpellegrini)
+;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Tests for SRFI 130.
+;;;
+;;; To run in Larceny or Sagittarius, cd to the directory containing
+;;; this file and incant:
+;;;
+;;;     larceny --r7rs --path . --program srfi-130-test.scm
+;;;     sagittarius -r7 -L . srfi-130-test.scm
+;;;
+;;; Both Larceny and Sagittarius will look for the (srfi 130) library
+;;; in the srfi subdirectory.  The implementations contained within
+;;; the foof and srfi-130 directories can be tested by renaming those
+;;; directories to srfi.
+;;;
+;;; FIXME: These tests are incomplete because there's  a combinatorial
+;;; explosion of possibilities for optional arguments that could be
+;;; either indexes or cursors.  Consider string-prefix-length, for
+;;; example.  For each test that calls that procedure with all four
+;;; optional arguments, there are 16 possible combinations of indexes
+;;; and cursors.  Beginning with string-take, the optional arguments
+;;; tested are indexes rather than cursors.
+
+
+;;; Unicode is the main motivation for string cursors, so we ought
+;;; to use at least some non-ASCII strings for testing.
+;;; Some systems would blow up if this file were to contain non-ASCII
+;;; characters, however, so we have to be careful here.
+
+(cond-expand (full-unicode
+              (define ABC
+                (list->string (map integer->char
+                                   '(#x3b1 #x3b2 #x3b3))))
+              (define ABCDEF
+                (list->string (map integer->char
+                                   '(#x0c0 #x062 #x0c7 #x064 #x0c9 #x066)))))
+             (else
+              (define ABC "abc")
+              (define ABCDEF "abcdef")))
+
+;;; Cursor operations
+
+(test "(fail 'string-cursor?)"
+      #t
+      (string-cursor? (string-index->cursor "" 0)))
+
+
+(test "(fail 'string-cursor?)-2"
+      #t
+      (not (string-cursor? #f)))
+
+
+(test "'string-cursor?-3"
+      #t
+      (string-cursor? (string-index->cursor (make-string 10000) 9999)))
+
+
+(test "string-cursor-start-4"
+      #t
+      (= 0
+         (string-cursor->index "" (string-cursor-start ""))))
+
+
+(test "string-cursor-start-5"
+      #t
+      (= 0
+         (string-cursor->index ABC (string-cursor-start ABC))))
+
+
+(test "string-cursor-end-6"
+      #t
+      (= 0
+         (string-cursor->index "" (string-cursor-end ""))))
+
+
+(test "string-cursor-end-7"
+      #t
+      (= 3
+         (string-cursor->index ABC (string-cursor-end ABC))))
+
+
+(test "string-cursor-next-8"
+      #t
+      (= 1
+         (string-cursor->index ABC (string-cursor-next ABC 0))))
+
+
+(test "string-cursor-next-9"
+      #t
+      (= 2
+         (string-cursor->index ABC (string-cursor-next ABC 1))))
+
+
+(test "string-cursor-next-10"
+      #t
+      (= 3
+         (string-cursor->index ABC (string-cursor-next ABC 2))))
+
+
+(test "string-cursor-prev-11"
+      #t
+      (= 0
+         (string-cursor->index ABC (string-cursor-prev ABC 1))))
+
+
+(test "string-cursor-prev-12"
+      #t
+      (= 1
+         (string-cursor->index ABC (string-cursor-prev ABC 2))))
+
+
+(test "string-cursor-prev-13"
+      #t
+      (= 2
+         (string-cursor->index ABC (string-cursor-prev ABC 3))))
+
+
+(test "string-cursor-forward-14"
+      #t
+      (= 0
+         (string-cursor->index ABC (string-cursor-forward ABC 0 0))))
+
+
+(test "string-cursor-forward-15"
+      #t
+      (= 2
+         (string-cursor->index ABC (string-cursor-forward ABC 0 2))))
+
+
+(test "string-cursor-forward-16"
+      #t
+      (= 3
+         (string-cursor->index ABC (string-cursor-forward ABC 1 2))))
+
+
+(test "string-cursor-forward-17"
+      #t
+      (= 3
+         (string-cursor->index ABC (string-cursor-forward ABC 3 0))))
+
+
+(test "string-cursor-back-18"
+      #t
+      (= 0
+         (string-cursor->index ABC (string-cursor-back ABC 0 0))))
+
+
+(test "string-cursor-back-19"
+      #t
+      (= 0
+         (string-cursor->index ABC (string-cursor-back ABC 2 2))))
+
+
+(test "string-cursor-back-20"
+      #t
+      (= 1
+         (string-cursor->index ABC (string-cursor-back ABC 3 2))))
+
+
+(test "string-cursor-back-21"
+      #t
+      (= 3
+         (string-cursor->index ABC (string-cursor-back ABC 3 0))))
+
+
+
+;;; These are supposed to work on both indexes and cursors.
+
+(test "string-cursor=?-22"
+      #t
+      (string-cursor=? 0 0))
+
+
+(test "string-cursor=?-23"
+      #t
+      (not (string-cursor=? 0 1)))
+
+
+(test "string-cursor=?-24"
+      #t
+      (not (string-cursor=? 0 2)))
+
+
+(test "string-cursor=?-25"
+      #t
+      (not (string-cursor=? 0 3)))
+
+
+(test "string-cursor=?-26"
+      #t
+      (not (string-cursor=? 1 0)))
+
+
+(test "string-cursor=?-27"
+      #t
+      (string-cursor=? 1 1))
+
+
+(test "string-cursor=?-28"
+      #t
+      (not (string-cursor=? 1 2)))
+
+
+(test "string-cursor=?-29"
+      #t
+      (not (string-cursor=? 1 3)))
+
+
+(test "string-cursor=?-30"
+      #t
+      (not (string-cursor=? 2 0)))
+
+
+(test "string-cursor=?-31"
+      #t
+      (not (string-cursor=? 2 1)))
+
+
+(test "string-cursor=?-32"
+      #t
+      (string-cursor=? 2 2))
+
+
+(test "string-cursor=?-33"
+      #t
+      (not (string-cursor=? 2 3)))
+
+
+(test "string-cursor=?-34"
+      #t
+      (not (string-cursor=? 3 0)))
+
+
+(test "string-cursor=?-35"
+      #t
+      (not (string-cursor=? 3 1)))
+
+
+(test "string-cursor=?-36"
+      #t
+      (not (string-cursor=? 3 2)))
+
+
+(test "string-cursor=?-37"
+      #t
+      (string-cursor=? 3 3))
+
+
+
+(test "string-cursor<?-38"
+      #t
+      (not (string-cursor<? 0 0)))
+
+
+(test "string-cursor<?-39"
+      #t
+      (string-cursor<? 0 1))
+
+
+(test "string-cursor<?-40"
+      #t
+      (string-cursor<? 0 2))
+
+
+(test "string-cursor<?-41"
+      #t
+      (string-cursor<? 0 3))
+
+
+(test "string-cursor<?-42"
+      #t
+      (not (string-cursor<? 1 0)))
+
+
+(test "string-cursor<?-43"
+      #t
+      (not (string-cursor<? 1 1)))
+
+
+(test "string-cursor<?-44"
+      #t
+      (string-cursor<? 1 2))
+
+
+(test "string-cursor<?-45"
+      #t
+      (string-cursor<? 1 3))
+
+
+(test "string-cursor<?-46"
+      #t
+      (not (string-cursor<? 2 0)))
+
+
+(test "string-cursor<?-47"
+      #t
+      (not (string-cursor<? 2 1)))
+
+
+(test "string-cursor<?-48"
+      #t
+      (not (string-cursor<? 2 2)))
+
+
+(test "string-cursor<?-49"
+      #t
+      (string-cursor<? 2 3))
+
+
+(test "string-cursor<?-50"
+      #t
+      (not (string-cursor<? 3 0)))
+
+
+(test "string-cursor<?-51"
+      #t
+      (not (string-cursor<? 3 1)))
+
+
+(test "string-cursor<?-52"
+      #t
+      (not (string-cursor<? 3 2)))
+
+
+(test "string-cursor<?-53"
+      #t
+      (not (string-cursor<? 3 3)))
+
+
+
+(test "string-cursor>?-54"
+      #t
+      (not (string-cursor>? 0 0)))
+
+
+(test "string-cursor>?-55"
+      #t
+      (not (string-cursor>? 0 1)))
+
+
+(test "string-cursor>?-56"
+      #t
+      (not (string-cursor>? 0 2)))
+
+
+(test "string-cursor>?-57"
+      #t
+      (not (string-cursor>? 0 3)))
+
+
+(test "string-cursor>?-58"
+      #t
+      (string-cursor>? 1 0))
+
+
+(test "string-cursor>?-59"
+      #t
+      (not (string-cursor>? 1 1)))
+
+
+(test "string-cursor>?-60"
+      #t
+      (not (string-cursor>? 1 2)))
+
+
+(test "string-cursor>?-61"
+      #t
+      (not (string-cursor>? 1 3)))
+
+
+(test "string-cursor>?-62"
+      #t
+      (string-cursor>? 2 0))
+
+
+(test "string-cursor>?-63"
+      #t
+      (string-cursor>? 2 1))
+
+
+(test "string-cursor>?-64"
+      #t
+      (not (string-cursor>? 2 2)))
+
+
+(test "string-cursor>?-65"
+      #t
+      (not (string-cursor>? 2 3)))
+
+
+(test "string-cursor>?-66"
+      #t
+      (string-cursor>? 3 0))
+
+
+(test "string-cursor>?-67"
+      #t
+      (string-cursor>? 3 1))
+
+
+(test "string-cursor>?-68"
+      #t
+      (string-cursor>? 3 2))
+
+
+(test "string-cursor>?-69"
+      #t
+      (not (string-cursor>? 3 3)))
+
+
+
+(test "string-cursor<=?-70"
+      #t
+      (string-cursor<=? 0 0))
+
+
+(test "string-cursor<=?-71"
+      #t
+      (string-cursor<=? 0 1))
+
+
+(test "string-cursor<=?-72"
+      #t
+      (string-cursor<=? 0 2))
+
+
+(test "string-cursor<=?-73"
+      #t
+      (string-cursor<=? 0 3))
+
+
+(test "string-cursor<=?-74"
+      #t
+      (not (string-cursor<=? 1 0)))
+
+
+(test "string-cursor<=?-75"
+      #t
+      (string-cursor<=? 1 1))
+
+
+(test "string-cursor<=?-76"
+      #t
+      (string-cursor<=? 1 2))
+
+
+(test "string-cursor<=?-77"
+      #t
+      (string-cursor<=? 1 3))
+
+
+(test "string-cursor<=?-78"
+      #t
+      (not (string-cursor<=? 2 0)))
+
+
+(test "string-cursor<=?-79"
+      #t
+      (not (string-cursor<=? 2 1)))
+
+
+(test "string-cursor<=?-80"
+      #t
+      (string-cursor<=? 2 2))
+
+
+(test "string-cursor<=?-81"
+      #t
+      (string-cursor<=? 2 3))
+
+
+(test "string-cursor<=?-82"
+      #t
+      (not (string-cursor<=? 3 0)))
+
+
+(test "string-cursor<=?-83"
+      #t
+      (not (string-cursor<=? 3 1)))
+
+
+(test "string-cursor<=?-84"
+      #t
+      (not (string-cursor<=? 3 2)))
+
+
+(test "string-cursor<=?-85"
+      #t
+      (string-cursor<=? 3 3))
+
+
+
+(test "string-cursor>=?-86"
+      #t
+      (string-cursor>=? 0 0))
+
+
+(test "string-cursor>=?-87"
+      #t
+      (not (string-cursor>=? 0 1)))
+
+
+(test "string-cursor>=?-88"
+      #t
+      (not (string-cursor>=? 0 2)))
+
+
+(test "string-cursor>=?-89"
+      #t
+      (not (string-cursor>=? 0 3)))
+
+
+(test "string-cursor>=?-90"
+      #t
+      (string-cursor>=? 1 0))
+
+
+(test "string-cursor>=?-91"
+      #t
+      (string-cursor>=? 1 1))
+
+
+(test "string-cursor>=?-92"
+      #t
+      (not (string-cursor>=? 1 2)))
+
+
+(test "string-cursor>=?-93"
+      #t
+      (not (string-cursor>=? 1 3)))
+
+
+(test "string-cursor>=?-94"
+      #t
+      (string-cursor>=? 2 0))
+
+
+(test "string-cursor>=?-95"
+      #t
+      (string-cursor>=? 2 1))
+
+
+(test "string-cursor>=?-96"
+      #t
+      (string-cursor>=? 2 2))
+
+
+(test "string-cursor>=?-97"
+      #t
+      (not (string-cursor>=? 2 3)))
+
+
+(test "string-cursor>=?-98"
+      #t
+      (string-cursor>=? 3 0))
+
+
+(test "string-cursor>=?-99"
+      #t
+      (string-cursor>=? 3 1))
+
+
+(test "string-cursor>=?-100"
+      #t
+      (string-cursor>=? 3 2))
+
+
+(test "string-cursor>=?-101"
+      #t
+      (string-cursor>=? 3 3))
+
+
+
+(test "string-cursor=?-102"
+      #t
+      (string-cursor=? (string-index->cursor ABC 0)
+                       (string-index->cursor ABC 0)))
+
+
+(test "string-cursor=?-103"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor=?-104"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor=?-105"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 3))))
+
+
+(test "string-cursor=?-106"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor=?-107"
+      #t
+      (string-cursor=? (string-index->cursor ABC 1)
+                       (string-index->cursor ABC 1)))
+
+
+(test "string-cursor=?-108"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor=?-109"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 3))))
+
+
+(test "string-cursor=?-110"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor=?-111"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor=?-112"
+      #t
+      (string-cursor=? (string-index->cursor ABC 2)
+                       (string-index->cursor ABC 2)))
+
+
+(test "string-cursor=?-113"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 3))))
+
+
+(test "string-cursor=?-114"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor=?-115"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor=?-116"
+      #t
+      (not (string-cursor=? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor=?-117"
+      #t
+      (string-cursor=? (string-index->cursor ABC 3)
+                       (string-index->cursor ABC 3)))
+
+
+
+(test "string-cursor<?-118"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<?-119"
+      #t
+      (string-cursor<? (string-index->cursor ABC 0)
+                       (string-index->cursor ABC 1)))
+
+
+(test "string-cursor<?-120"
+      #t
+      (string-cursor<? (string-index->cursor ABC 0)
+                       (string-index->cursor ABC 2)))
+
+
+(test "string-cursor<?-121"
+      #t
+      (string-cursor<? (string-index->cursor ABC 0)
+                       (string-index->cursor ABC 3)))
+
+
+(test "string-cursor<?-122"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<?-123"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor<?-124"
+      #t
+      (string-cursor<? (string-index->cursor ABC 1)
+                       (string-index->cursor ABC 2)))
+
+
+(test "string-cursor<?-125"
+      #t
+      (string-cursor<? (string-index->cursor ABC 1)
+                       (string-index->cursor ABC 3)))
+
+
+(test "string-cursor<?-126"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<?-127"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor<?-128"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor<?-129"
+      #t
+      (string-cursor<? (string-index->cursor ABC 2)
+                       (string-index->cursor ABC 3)))
+
+
+(test "string-cursor<?-130"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<?-131"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor<?-132"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor<?-133"
+      #t
+      (not (string-cursor<? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 3))))
+
+
+
+(test "string-cursor>?-134"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 0))))
+
+
+(test "string-cursor>?-135"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor>?-136"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor>?-137"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 0)
+                            (string-index->cursor ABC 3))))
+
+
+(test "string-cursor>?-138"
+      #t
+      (string-cursor>? (string-index->cursor ABC 1)
+                       (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>?-139"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 1))))
+
+
+(test "string-cursor>?-140"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor>?-141"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 1)
+                            (string-index->cursor ABC 3))))
+
+
+(test "string-cursor>?-142"
+      #t
+      (string-cursor>? (string-index->cursor ABC 2)
+                       (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>?-143"
+      #t
+      (string-cursor>? (string-index->cursor ABC 2)
+                       (string-index->cursor ABC 1)))
+
+
+(test "string-cursor>?-144"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 2))))
+
+
+(test "string-cursor>?-145"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 2)
+                            (string-index->cursor ABC 3))))
+
+
+(test "string-cursor>?-146"
+      #t
+      (string-cursor>? (string-index->cursor ABC 3)
+                       (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>?-147"
+      #t
+      (string-cursor>? (string-index->cursor ABC 3)
+                       (string-index->cursor ABC 1)))
+
+
+(test "string-cursor>?-148"
+      #t
+      (string-cursor>? (string-index->cursor ABC 3)
+                       (string-index->cursor ABC 2)))
+
+
+(test "string-cursor>?-149"
+      #t
+      (not (string-cursor>? (string-index->cursor ABC 3)
+                            (string-index->cursor ABC 3))))
+
+
+
+(test "string-cursor<=?-150"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 0)
+                        (string-index->cursor ABC 0)))
+
+
+(test "string-cursor<=?-151"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 0)
+                        (string-index->cursor ABC 1)))
+
+
+(test "string-cursor<=?-152"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 0)
+                        (string-index->cursor ABC 2)))
+
+
+(test "string-cursor<=?-153"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 0)
+                        (string-index->cursor ABC 3)))
+
+
+(test "string-cursor<=?-154"
+      #t
+      (not (string-cursor<=? (string-index->cursor ABC 1)
+                             (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<=?-155"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 1)
+                        (string-index->cursor ABC 1)))
+
+
+(test "string-cursor<=?-156"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 1)
+                        (string-index->cursor ABC 2)))
+
+
+(test "string-cursor<=?-157"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 1)
+                        (string-index->cursor ABC 3)))
+
+
+(test "string-cursor<=?-158"
+      #t
+      (not (string-cursor<=? (string-index->cursor ABC 2)
+                             (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<=?-159"
+      #t
+      (not (string-cursor<=? (string-index->cursor ABC 2)
+                             (string-index->cursor ABC 1))))
+
+
+(test "string-cursor<=?-160"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 2)
+                        (string-index->cursor ABC 2)))
+
+
+(test "string-cursor<=?-161"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 2)
+                        (string-index->cursor ABC 3)))
+
+
+(test "string-cursor<=?-162"
+      #t
+      (not (string-cursor<=? (string-index->cursor ABC 3)
+                             (string-index->cursor ABC 0))))
+
+
+(test "string-cursor<=?-163"
+      #t
+      (not (string-cursor<=? (string-index->cursor ABC 3)
+                             (string-index->cursor ABC 1))))
+
+
+(test "string-cursor<=?-164"
+      #t
+      (not (string-cursor<=? (string-index->cursor ABC 3)
+                             (string-index->cursor ABC 2))))
+
+
+(test "string-cursor<=?-165"
+      #t
+      (string-cursor<=? (string-index->cursor ABC 3)
+                        (string-index->cursor ABC 3)))
+
+
+
+(test "string-cursor>=?-166"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 0)
+                        (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>=?-167"
+      #t
+      (not (string-cursor>=? (string-index->cursor ABC 0)
+                             (string-index->cursor ABC 1))))
+
+
+(test "string-cursor>=?-168"
+      #t
+      (not (string-cursor>=? (string-index->cursor ABC 0)
+                             (string-index->cursor ABC 2))))
+
+
+(test "string-cursor>=?-169"
+      #t
+      (not (string-cursor>=? (string-index->cursor ABC 0)
+                             (string-index->cursor ABC 3))))
+
+
+(test "string-cursor>=?-170"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 1)
+                        (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>=?-171"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 1)
+                        (string-index->cursor ABC 1)))
+
+
+(test "string-cursor>=?-172"
+      #t
+      (not (string-cursor>=? (string-index->cursor ABC 1)
+                             (string-index->cursor ABC 2))))
+
+
+(test "string-cursor>=?-173"
+      #t
+      (not (string-cursor>=? (string-index->cursor ABC 1)
+                             (string-index->cursor ABC 3))))
+
+
+(test "string-cursor>=?-174"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 2)
+                        (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>=?-175"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 2)
+                        (string-index->cursor ABC 1)))
+
+
+(test "string-cursor>=?-176"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 2)
+                        (string-index->cursor ABC 2)))
+
+
+(test "string-cursor>=?-177"
+      #t
+      (not (string-cursor>=? (string-index->cursor ABC 2)
+                             (string-index->cursor ABC 3))))
+
+
+(test "string-cursor>=?-178"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 3)
+                        (string-index->cursor ABC 0)))
+
+
+(test "string-cursor>=?-179"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 3)
+                        (string-index->cursor ABC 1)))
+
+
+(test "string-cursor>=?-180"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 3)
+                        (string-index->cursor ABC 2)))
+
+
+(test "string-cursor>=?-181"
+      #t
+      (string-cursor>=? (string-index->cursor ABC 3)
+                        (string-index->cursor ABC 3)))
+
+
+
+(test "string-cursor-diff-182"
+      #t
+      (= 0 (string-cursor-diff ""
+                               (string-index->cursor ABC 0)
+                               (string-index->cursor ABC 0))))
+
+
+(test "string-cursor-diff-183"
+      #t
+      (= 3 (string-cursor-diff ABC
+                               (string-index->cursor ABC 0)
+                               (string-index->cursor ABC 3))))
+
+
+(test "string-cursor->index-184"
+      #t
+      (= 0 (string-cursor->index "" (string-index->cursor "" 0))))
+
+
+(test "string-cursor->index-185"
+      #t
+      (= 3 (string-cursor->index ABC (string-index->cursor ABC 3))))
+
+
+(test "string-index->cursor-186"
+      #t
+      (= 0 (string-index->cursor "" (string-index->cursor "" 0))))
+
+
+(test "string-index->cursor-187"
+      #t
+      (= 3 (string-index->cursor ABC (string-index->cursor ABC 3))))
+
+
+;;; Predicates
+
+(test "string-null-188"
+      #t
+      (string-null? ""))
+
+
+(test "string-null-189"
+      #t
+      (not (string-null? "abc")))
+
+
+(test "string-every-190"
+      #t
+      (eqv? #t (string-every (lambda (c) (if (char? c) c #f)) "")))
+
+
+(test "string-every-191"
+      #t
+      (eqv? #\c (string-every (lambda (c) (if (char? c) c #f)) "abc")))
+
+
+(test "string-every-192"
+      #t
+      (eqv? #f (string-every (lambda (c) (if (char>? c #\b) c #f)) "abc")))
+
+
+(test "string-every-193"
+      #t
+      (eqv? #\c (string-every (lambda (c) (if (char>? c #\b) c #f)) "abc" 2)))
+
+
+(test "string-every-194"
+      #t
+      (eqv? #t (string-every (lambda (c) (if (char>? c #\b) c #f)) "abc" 1 1)))
+
+
+(test "string-any-195"
+      #t
+      (eqv? #f (string-any (lambda (c) (if (char? c) c #f)) "")))
+
+
+(test "string-any-196"
+      #t
+      (eqv? #\a (string-any (lambda (c) (if (char? c) c #f)) "abc")))
+
+
+(test "string-any-197"
+      #t
+      (eqv? #\c (string-any (lambda (c) (if (char>? c #\b) c #f)) "abc")))
+
+
+(test "string-any-198"
+      #t
+      (eqv? #\c (string-any (lambda (c) (if (char>? c #\b) c #f)) "abc" 2)))
+
+
+(test "string-any-199"
+      #t
+      (eqv? #f (string-any (lambda (c) (if (char>? c #\b) c #f)) "abc" 0 2)))
+
+
+;;; Constructors
+
+(test "string-tabulate-200"
+      #t
+      (equal? ""
+              (string-tabulate (lambda (i)
+                                 (integer->char (+ i (char->integer #\a))))
+                               0)))
+
+
+(test "string-tabulate-201"
+      #t
+      (equal? "abc"
+              (string-tabulate (lambda (i)
+                                 (integer->char (+ i (char->integer #\a))))
+                               3)))
+
+
+(test "string-unfold-202"
+      #t
+      (equal? "abc"
+              (let ((p (open-input-string "abc")))
+                (string-unfold eof-object?
+                               values
+                               (lambda (x) (read-char p))
+                               (read-char p)))))
+
+
+(test "string-unfold-203"
+      #t
+      (equal? "" (string-unfold null? car cdr '())))
+
+
+(test "string-unfold-204"
+      #t
+      (equal? "abc" (string-unfold null? car cdr (string->list "abc"))))
+
+
+(test "string-unfold-205"
+      #t
+      (equal? "def" (string-unfold null? car cdr '() "def")))
+
+
+(test "string-unfold-206"
+      #t
+      (equal? "defabcG"
+              (string-unfold null?
+                             car
+                             cdr
+                             (string->list "abc")
+                             "def"
+                             (lambda (x) (and (null? x) "G")))))
+
+
+(test "string-unfold-right-207"
+      #t
+      (equal? "" (string-unfold-right null? car cdr '())))
+
+
+(test "string-unfold-right-208"
+      #t
+      (equal? "cba" (string-unfold-right null? car cdr (string->list "abc"))))
+
+
+(test "string-unfold-right-209"
+      #t
+      (equal? "def" (string-unfold-right null? car cdr '() "def")))
+
+
+(test "string-unfold-right-210"
+      #t
+      (equal? "Gcbadef"
+              (string-unfold-right null?
+                                   car
+                                   cdr
+                                   (string->list "abc")
+                                   "def"
+                                   (lambda (x) (and (null? x) "G")))))
+
+
+;;; Conversion
+
+(test "string->list/cursors-211"
+      #t
+      (equal? '() (string->list/cursors "")))
+
+
+(test "string->list/cursors-212"
+      #t
+      (equal? '() (string->list/cursors "" 0)))
+
+
+(test "string->list/cursors-213"
+      #t
+      (equal? '() (string->list/cursors "" 0 0)))
+
+
+(test "string->list/cursors-214"
+      #t
+      (equal? '(#\a #\b #\c) (string->list/cursors "abc")))
+
+
+(test "string->list/cursors-215"
+      #t
+      (equal? '() (string->list/cursors "abc" 3)))
+
+
+(test "string->list/cursors-216"
+      #t
+      (equal? '(#\b #\c) (string->list/cursors "abc" 1 3)))
+
+
+(test "string->list/cursors-217"
+      #t
+      (equal? '(#\b #\c)
+              (string->list/cursors "abc"
+                                    (string-index->cursor "abc" 1)
+                                    (string-index->cursor "abc" 3))))
+
+
+(test "string->vector/cursors-218"
+      #t
+      (equal? '#() (string->vector/cursors "")))
+
+
+(test "string->vector/cursors-219"
+      #t
+      (equal? '#() (string->vector/cursors "" 0)))
+
+
+(test "string->vector/cursors-220"
+      #t
+      (equal? '#() (string->vector/cursors "" 0 0)))
+
+
+(test "string->vector/cursors-221"
+      #t
+      (equal? '#(#\a #\b #\c) (string->vector/cursors "abc")))
+
+
+(test "string->vector/cursors-222"
+      #t
+      (equal? '#() (string->vector/cursors "abc" 3)))
+
+
+(test "string->vector/cursors-223"
+      #t
+      (equal? '#(#\b #\c) (string->vector/cursors "abc" 1 3)))
+
+
+(test "string->vector/cursors-224"
+      #t
+      (equal? '#(#\b #\c)
+              (string->vector/cursors "abc"
+                                      (string-index->cursor "abc" 1)
+                                      (string-index->cursor "abc" 3))))
+
+
+(test "reverse-list->string-225"
+      #t
+      (equal? "" (reverse-list->string '())))
+
+
+(test "reverse-list->string-226"
+      #t
+      (equal? "cba" (reverse-list->string '(#\a #\b #\c))))
+
+
+(test "string-join-227"
+      #t
+      (equal? "" (string-join '())))
+
+
+(test "string-join-228"
+      #t
+      (equal? " ab cd  e f "
+              (string-join '("" "ab" "cd" "" "e" "f" ""))))
+
+
+(test "string-join-229"
+      #t
+      (equal? "" (string-join '() "")))
+
+
+(test "string-join-230"
+      #t
+      (equal? "abcdef"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "")))
+
+
+(test "string-join-231"
+      #t
+      (equal? "" (string-join '() "xyz")))
+
+
+(test "string-join-232"
+      #t
+      (equal? "xyzabxyzcdxyzxyzexyzfxyz"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "xyz")))
+
+
+(test "string-join-233"
+      #t
+      (equal? "" (string-join '() "" 'infix)))
+
+
+(test "string-join-234"
+      #t
+      (equal? "abcdef"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "" 'infix)))
+
+
+(test "string-join-235"
+      #t
+      (equal? "" (string-join '() "xyz" 'infix)))
+
+
+(test "string-join-236"
+      #t
+      (equal? "xyzabxyzcdxyzxyzexyzfxyz"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "xyz" 'infix)))
+
+
+(test "string-join-237"
+      #t
+      (equal? 'horror
+              (guard (exn (#t 'horror))
+                (string-join '() "" 'strict-infix))))
+
+
+(test "string-join-238"
+      #t
+      (equal? "abcdef"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "" 'strict-infix)))
+
+
+(test "string-join-239"
+      #t
+      (equal? 'wham
+              (guard (exn (else 'wham))
+                (string-join '() "xyz" 'strict-infix))))
+
+
+(test "string-join-240"
+      #t
+      (equal? "xyzabxyzcdxyzxyzexyzfxyz"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "xyz" 'strict-infix)))
+
+
+(test "string-join-241"
+      #t
+      (equal? "" (string-join '() "" 'suffix)))
+
+
+(test "string-join-242"
+      #t
+      (equal? "abcdef"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "" 'suffix)))
+
+
+(test "string-join-243"
+      #t
+      (equal? "" (string-join '() "xyz" 'suffix)))
+
+
+(test "string-join-244"
+      #t
+      (equal? "xyzabxyzcdxyzxyzexyzfxyzxyz"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "xyz" 'suffix)))
+
+
+(test "string-join-245"
+      #t
+      (equal? "" (string-join '() "" 'prefix)))
+
+
+(test "string-join-246"
+      #t
+      (equal? "abcdef"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "" 'prefix)))
+
+
+(test "string-join-247"
+      #t
+      (equal? "" (string-join '() "xyz" 'prefix)))
+
+
+(test "string-join-248"
+      #t
+      (equal? "xyzxyzabxyzcdxyzxyzexyzfxyz"
+              (string-join '("" "ab" "cd" "" "e" "f" "") "xyz" 'prefix)))
+
+
+;;; Selection
+
+(test "string-ref/cursor-249"
+      #t
+      (char=? #\a (string-ref/cursor "abc" 0)))
+
+
+(test "string-ref/cursor-250"
+      #t
+      (char=? #\c (string-ref/cursor "abc" 2)))
+
+
+(test "string-ref/cursor-251"
+      #t
+      (char=? #\a (string-ref/cursor "abc" (string-index->cursor "abc" 0))))
+
+
+(test "string-ref/cursor-252"
+      #t
+      (char=? #\c (string-ref/cursor "abc" (string-index->cursor "abc" 2))))
+
+
+(test "substring/cursors-253"
+      #t
+      (string=? "" (substring/cursors "" 0 0)))
+
+
+(test "substring/cursors-254"
+      #t
+      (string=? "" (substring/cursors "abc" 0 0)))
+
+
+(test "substring/cursors-255"
+      #t
+      (string=? "" (substring/cursors "abc" 3 3)))
+
+
+(test "substring/cursors-256"
+      #t
+      (string=? ABC (substring/cursors ABC 0 3)))
+
+
+(test "substring/cursors-257"
+      #t
+      (string=? ABC
+                (substring/cursors ABC
+                                   (string-index->cursor "abc" 0)
+                                   (string-index->cursor "abc" 3))))
+
+
+(test "substring/cursors-258"
+      #t
+      (string=? "b" (substring/cursors "abc" 1 2)))
+
+
+(test "string-copy/cursors-259"
+      #t
+      (string=? "" (string-copy/cursors "")))
+
+
+(test "string-copy/cursors-260"
+      #t
+      (string=? "abc" (string-copy/cursors "abc")))
+
+
+(test "string-copy/cursors-261"
+      #t
+      (string=? "" (string-copy/cursors "abc" 3)))
+
+
+(test "string-copy/cursors-262"
+      #t
+      (string=? "c" (string-copy/cursors "abc" 2)))
+
+
+(test "string-copy/cursors-263"
+      #t
+      (string=? "abc" (string-copy/cursors "abc" 0)))
+
+
+(test "string-copy/cursors-264"
+      #t
+      (string=? "b" (string-copy/cursors "abc" 1 2)))
+
+
+(test "string-copy/cursors-265"
+      #t
+      (string=? "" (string-copy/cursors "" 0 0)))
+
+
+(test "string-copy/cursors-266"
+      #t
+      (string=? "" (string-copy/cursors "abc" 0 0)))
+
+
+(test "string-copy/cursors-267"
+      #t
+      (string=? "" (string-copy/cursors "abc" 3 3)))
+
+
+(test "string-copy/cursors-268"
+      #t
+      (string=? "abc" (string-copy/cursors "abc" 0 3)))
+
+
+(test "string-copy/cursors-269"
+      #t
+      (string=? "b" (string-copy/cursors "abc" 1 2)))
+
+
+(test "string-copy/cursors-270"
+      #t
+      (string=? (substring ABC 1 2)
+                (string-copy/cursors ABC
+                                     (string-index->cursor "abc" 1)
+                                     (string-index->cursor "abc" 2))))
+
+
+(test "string-take-271"
+      #t
+      (string=? "" (string-take "" 0)))
+
+
+(test "string-take-272"
+      #t
+      (string=? "" (string-take "abcdef" 0)))
+
+
+(test "string-take-273"
+      #t
+      (string=? "ab" (string-take "abcdef" 2)))
+
+
+(test "string-drop-274"
+      #t
+      (string=? "" (string-drop "" 0)))
+
+
+(test "string-drop-275"
+      #t
+      (string=? "abcdef" (string-drop "abcdef" 0)))
+
+
+(test "string-drop-276"
+      #t
+      (string=? "cdef" (string-drop "abcdef" 2)))
+
+
+(test "string-take-right-277"
+      #t
+      (string=? "" (string-take-right "" 0)))
+
+
+(test "string-take-right-278"
+      #t
+      (string=? "" (string-take-right "abcdef" 0)))
+
+
+(test "string-take-right-279"
+      #t
+      (string=? "ef" (string-take-right "abcdef" 2)))
+
+
+(test "string-drop-right-280"
+      #t
+      (string=? "" (string-drop-right "" 0)))
+
+
+(test "string-drop-right-281"
+      #t
+      (string=? "abcdef" (string-drop-right "abcdef" 0)))
+
+
+(test "string-drop-right-282"
+      #t
+      (string=? "abcd" (string-drop-right "abcdef" 2)))
+
+
+(test "string-pad-283"
+      #t
+      (string=? "" (string-pad "" 0)))
+
+
+(test "string-pad-284"
+      #t
+      (string=? "     " (string-pad "" 5)))
+
+
+(test "string-pad-285"
+      #t
+      (string=? "  325" (string-pad "325" 5)))
+
+
+(test "string-pad-286"
+      #t
+      (string=? "71325" (string-pad "71325" 5)))
+
+
+(test "string-pad-287"
+      #t
+      (string=? "71325" (string-pad "8871325" 5)))
+
+
+(test "string-pad-288"
+      #t
+      (string=? "" (string-pad "" 0 #\*)))
+
+
+(test "string-pad-289"
+      #t
+      (string=? "*****" (string-pad "" 5 #\*)))
+
+
+(test "string-pad-290"
+      #t
+      (string=? "**325" (string-pad "325" 5 #\*)))
+
+
+(test "string-pad-291"
+      #t
+      (string=? "71325" (string-pad "71325" 5 #\*)))
+
+
+(test "string-pad-292"
+      #t
+      (string=? "71325" (string-pad "8871325" 5 #\*)))
+
+
+(test "string-pad-293"
+      #t
+      (string=? "" (string-pad "" 0 #\* 0)))
+
+
+(test "string-pad-294"
+      #t
+      (string=? "*****" (string-pad "" 5 #\* 0)))
+
+
+(test "string-pad-295"
+      #t
+      (string=? "**325" (string-pad "325" 5 #\* 0)))
+
+
+(test "string-pad-296"
+      #t
+      (string=? "71325" (string-pad "71325" 5 #\* 0)))
+
+
+(test "string-pad-297"
+      #t
+      (string=? "71325" (string-pad "8871325" 5 #\* 0)))
+
+
+(test "string-pad-298"
+      #t
+      (string=? "***25" (string-pad "325" 5 #\* 1)))
+
+
+(test "string-pad-299"
+      #t
+      (string=? "*1325" (string-pad "71325" 5 #\* 1)))
+
+
+(test "string-pad-300"
+      #t
+      (string=? "71325" (string-pad "8871325" 5 #\* 1)))
+
+
+(test "string-pad-301"
+      #t
+      (string=? "" (string-pad "" 0 #\* 0 0)))
+
+
+(test "string-pad-302"
+      #t
+      (string=? "*****" (string-pad "" 5 #\* 0 0)))
+
+
+(test "string-pad-303"
+      #t
+      (string=? "**325" (string-pad "325" 5 #\* 0 3)))
+
+
+(test "string-pad-304"
+      #t
+      (string=? "**713" (string-pad "71325" 5 #\* 0 3)))
+
+
+(test "string-pad-305"
+      #t
+      (string=? "**887" (string-pad "8871325" 5 #\* 0 3)))
+
+
+(test "string-pad-306"
+      #t
+      (string=? "***25" (string-pad "325" 5 #\* 1 3)))
+
+
+(test "string-pad-307"
+      #t
+      (string=? "**132" (string-pad "71325" 5 #\* 1 4)))
+
+
+(test "string-pad-308"
+      #t
+      (string=? "*8713" (string-pad "8871325" 5 #\* 1 5)))
+
+
+(test "string-pad-right-309"
+      #t
+      (string=? "" (string-pad-right "" 0)))
+
+
+(test "string-pad-right-310"
+      #t
+      (string=? "     " (string-pad-right "" 5)))
+
+
+(test "string-pad-right-311"
+      #t
+      (string=? "325  " (string-pad-right "325" 5)))
+
+
+(test "string-pad-right-312"
+      #t
+      (string=? "71325" (string-pad-right "71325" 5)))
+
+
+(test "string-pad-right-313"
+      #t
+      (string=? "88713" (string-pad-right "8871325" 5)))
+
+
+(test "string-pad-right-314"
+      #t
+      (string=? "" (string-pad-right "" 0 #\*)))
+
+
+(test "string-pad-right-315"
+      #t
+      (string=? "*****" (string-pad-right "" 5 #\*)))
+
+
+(test "string-pad-right-316"
+      #t
+      (string=? "325**" (string-pad-right "325" 5 #\*)))
+
+
+(test "string-pad-right-317"
+      #t
+      (string=? "71325" (string-pad-right "71325" 5 #\*)))
+
+
+(test "string-pad-right-318"
+      #t
+      (string=? "88713" (string-pad-right "8871325" 5 #\*)))
+
+
+(test "string-pad-right-319"
+      #t
+      (string=? "" (string-pad-right "" 0 #\* 0)))
+
+
+(test "string-pad-right-320"
+      #t
+      (string=? "*****" (string-pad-right "" 5 #\* 0)))
+
+
+(test "string-pad-right-321"
+      #t
+      (string=? "325**" (string-pad-right "325" 5 #\* 0)))
+
+
+(test "string-pad-right-322"
+      #t
+      (string=? "71325" (string-pad-right "71325" 5 #\* 0)))
+
+
+(test "string-pad-right-323"
+      #t
+      (string=? "88713" (string-pad-right "8871325" 5 #\* 0)))
+
+
+(test "string-pad-right-324"
+      #t
+      (string=? "25***" (string-pad-right "325" 5 #\* 1)))
+
+
+(test "string-pad-right-325"
+      #t
+      (string=? "1325*" (string-pad-right "71325" 5 #\* 1)))
+
+
+(test "string-pad-right-326"
+      #t
+      (string=? "87132" (string-pad-right "8871325" 5 #\* 1)))
+
+
+(test "string-pad-right-327"
+      #t
+      (string=? "" (string-pad-right "" 0 #\* 0 0)))
+
+
+(test "string-pad-right-328"
+      #t
+      (string=? "*****" (string-pad-right "" 5 #\* 0 0)))
+
+
+(test "string-pad-right-329"
+      #t
+      (string=? "325**" (string-pad-right "325" 5 #\* 0 3)))
+
+
+(test "string-pad-right-330"
+      #t
+      (string=? "713**" (string-pad-right "71325" 5 #\* 0 3)))
+
+
+(test "string-pad-right-331"
+      #t
+      (string=? "887**" (string-pad-right "8871325" 5 #\* 0 3)))
+
+
+(test "string-pad-right-332"
+      #t
+      (string=? "25***" (string-pad-right "325" 5 #\* 1 3)))
+
+
+(test "string-pad-right-333"
+      #t
+      (string=? "132**" (string-pad-right "71325" 5 #\* 1 4)))
+
+
+(test "string-pad-right-334"
+      #t
+      (string=? "8713*" (string-pad-right "8871325" 5 #\* 1 5)))
+
+
+
+(test "string-trim-335"
+      #t
+      (string=? "" (string-trim "")))
+
+
+(test "string-trim-336"
+      #t
+      (string=? "a  b  c  " (string-trim "  a  b  c  ")))
+
+
+(test "string-trim-337"
+      #t
+      (string=? "" (string-trim "" char-whitespace?)))
+
+
+(test "string-trim-338"
+      #t
+      (string=? "a  b  c  " (string-trim "  a  b  c  " char-whitespace?)))
+
+
+(test "string-trim-339"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char?)))
+
+
+(test "string-trim-340"
+      #t
+      (string=? "" (string-trim "" char-whitespace? 0)))
+
+
+(test "string-trim-341"
+      #t
+      (string=? "a  b  c  " (string-trim "  a  b  c  " char-whitespace? 0)))
+
+
+(test "string-trim-342"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char? 0)))
+
+
+(test "string-trim-343"
+      #t
+      (string=? "b  c  " (string-trim "  a  b  c  " char-whitespace? 3)))
+
+
+(test "string-trim-344"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char? 3)))
+
+
+(test "string-trim-345"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char? 0 11)))
+
+
+(test "string-trim-346"
+      #t
+      (string=? "b  c  " (string-trim "  a  b  c  " char-whitespace? 3 11)))
+
+
+(test "string-trim-347"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char? 3 11)))
+
+
+(test "string-trim-348"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char? 0 8)))
+
+
+(test "string-trim-349"
+      #t
+      (string=? "b  " (string-trim "  a  b  c  " char-whitespace? 3 8)))
+
+
+(test "string-trim-350"
+      #t
+      (string=? "" (string-trim "  a  b  c  " char? 3 8)))
+
+
+
+(test "string-trim-right-351"
+      #t
+      (string=? "" (string-trim-right "")))
+
+
+(test "string-trim-right-352"
+      #t
+      (string=? "  a  b  c" (string-trim-right "  a  b  c  ")))
+
+
+(test "string-trim-right-353"
+      #t
+      (string=? "" (string-trim-right "" char-whitespace?)))
+
+
+(test "string-trim-right-354"
+      #t
+      (string=? "  a  b  c" (string-trim-right "  a  b  c  " char-whitespace?)))
+
+
+(test "string-trim-right-355"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char?)))
+
+
+(test "string-trim-right-356"
+      #t
+      (string=? "" (string-trim-right "" char-whitespace? 0)))
+
+
+(test "string-trim-right-357"
+      #t
+      (string=? "  a  b  c" (string-trim-right "  a  b  c  " char-whitespace? 0)))
+
+
+(test "string-trim-right-358"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char? 0)))
+
+
+(test "string-trim-right-359"
+      #t
+      (string=? "  b  c" (string-trim-right "  a  b  c  " char-whitespace? 3)))
+
+
+(test "string-trim-right-360"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char? 3)))
+
+
+(test "string-trim-right-361"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char? 0 11)))
+
+
+(test "string-trim-right-362"
+      #t
+      (string=? "  b  c" (string-trim-right "  a  b  c  " char-whitespace? 3 11)))
+
+
+(test "string-trim-right-363"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char? 3 11)))
+
+
+(test "string-trim-right-364"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char? 0 8)))
+
+
+(test "string-trim-right-365"
+      #t
+      (string=? "  b" (string-trim-right "  a  b  c  " char-whitespace? 3 8)))
+
+
+(test "string-trim-right-366"
+      #t
+      (string=? "" (string-trim-right "  a  b  c  " char? 3 8)))
+
+
+
+(test "string-trim-both-367"
+      #t
+      (string=? "" (string-trim-both "")))
+
+
+(test "string-trim-both-368"
+      #t
+      (string=? "a  b  c" (string-trim-both "  a  b  c  ")))
+
+
+(test "string-trim-both-369"
+      #t
+      (string=? "" (string-trim-both "" char-whitespace?)))
+
+
+(test "string-trim-both-370"
+      #t
+      (string=? "a  b  c" (string-trim-both "  a  b  c  " char-whitespace?)))
+
+
+(test "string-trim-both-371"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char?)))
+
+
+(test "string-trim-both-372"
+      #t
+      (string=? "" (string-trim-both "" char-whitespace? 0)))
+
+
+(test "string-trim-both-373"
+      #t
+      (string=? "a  b  c" (string-trim-both "  a  b  c  " char-whitespace? 0)))
+
+
+(test "string-trim-both-374"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char? 0)))
+
+
+(test "string-trim-both-375"
+      #t
+      (string=? "b  c" (string-trim-both "  a  b  c  " char-whitespace? 3)))
+
+
+(test "string-trim-both-376"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char? 3)))
+
+
+(test "string-trim-both-377"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char? 0 11)))
+
+
+(test "string-trim-both-378"
+      #t
+      (string=? "b  c" (string-trim-both "  a  b  c  " char-whitespace? 3 11)))
+
+
+(test "string-trim-both-379"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char? 3 11)))
+
+
+(test "string-trim-both-380"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char? 0 8)))
+
+
+(test "string-trim-both-381"
+      #t
+      (string=? "b" (string-trim-both "  a  b  c  " char-whitespace? 3 8)))
+
+
+(test "string-trim-both-382"
+      #t
+      (string=? "" (string-trim-both "  a  b  c  " char? 3 8)))
+
+
+
+(test "string-prefix-length-383"
+      #t
+      (= 0 (string-prefix-length "" "")))
+
+
+(test "string-prefix-length-384"
+      #t
+      (= 0 (string-prefix-length "" "aabbccddee")))
+
+
+(test "string-prefix-length-385"
+      #t
+      (= 0 (string-prefix-length "aisle" "")))
+
+
+(test "string-prefix-length-386"
+      #t
+      (= 0 (string-prefix-length "" "aabbccddee")))
+
+
+(test "string-prefix-length-387"
+      #t
+      (= 1 (string-prefix-length "aisle" "aabbccddee")))
+
+
+(test "string-prefix-length-388"
+      #t
+      (= 0 (string-prefix-length "bail" "aabbccddee")))
+
+
+(test "string-prefix-length-389"
+      #t
+      (= 4 (string-prefix-length "prefix" "preface")))
+
+
+(test "string-prefix-length-390"
+      #t
+      (= 0 (string-prefix-length "" "" 0)))
+
+
+(test "string-prefix-length-391"
+      #t
+      (= 0 (string-prefix-length "" "aabbccddee" 0)))
+
+
+(test "string-prefix-length-392"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 0)))
+
+
+(test "string-prefix-length-393"
+      #t
+      (= 1 (string-prefix-length "aisle" "aabbccddee" 0)))
+
+
+(test "string-prefix-length-394"
+      #t
+      (= 0 (string-prefix-length "bail" "aabbccddee" 0)))
+
+
+(test "string-prefix-length-395"
+      #t
+      (= 4 (string-prefix-length "prefix" "preface" 0)))
+
+
+(test "string-prefix-length-396"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 1)))
+
+
+(test "string-prefix-length-397"
+      #t
+      (= 0 (string-prefix-length "aisle" "aabbccddee" 1)))
+
+
+(test "string-prefix-length-398"
+      #t
+      (= 1 (string-prefix-length "bail" "aabbccddee" 1)))
+
+
+(test "string-prefix-length-399"
+      #t
+      (= 0 (string-prefix-length "prefix" "preface" 1)))
+
+
+(test "string-prefix-length-400"
+      #t
+      (= 0 (string-prefix-length "" "" 0 0)))
+
+
+(test "string-prefix-length-401"
+      #t
+      (= 0 (string-prefix-length "" "aabbccddee" 0 0)))
+
+
+(test "string-prefix-length-402"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 0 4)))
+
+
+(test "string-prefix-length-403"
+      #t
+      (= 1 (string-prefix-length "aisle" "aabbccddee" 0 4)))
+
+
+(test "string-prefix-length-404"
+      #t
+      (= 0 (string-prefix-length "bail" "aabbccddee" 0 1)))
+
+
+(test "string-prefix-length-405"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 1 4)))
+
+
+(test "string-prefix-length-406"
+      #t
+      (= 0 (string-prefix-length "aisle" "aabbccddee" 1 4)))
+
+
+(test "string-prefix-length-407"
+      #t
+      (= 1 (string-prefix-length "bail" "aabbccddee" 1 4)))
+
+
+(test "string-prefix-length-408"
+      #t
+      (= 0 (string-prefix-length "prefix" "preface" 1 5)))
+
+
+(test "string-prefix-length-409"
+      #t
+      (= 0 (string-prefix-length "" "" 0 0 0)))
+
+
+(test "string-prefix-length-410"
+      #t
+      (= 0 (string-prefix-length "" "aabbccddee" 0 0 0)))
+
+
+(test "string-prefix-length-411"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 0 4 0)))
+
+
+(test "string-prefix-length-412"
+      #t
+      (= 0 (string-prefix-length "aisle" "aabbccddee" 0 4 2)))
+
+
+(test "string-prefix-length-413"
+      #t
+      (= 1 (string-prefix-length "bail" "aabbccddee" 0 1 2)))
+
+
+(test "string-prefix-length-414"
+      #t
+      (= 0 (string-prefix-length "prefix" "preface" 0 5 1)))
+
+
+(test "string-prefix-length-415"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 1 4 0)))
+
+
+(test "string-prefix-length-416"
+      #t
+      (= 0 (string-prefix-length "aisle" "aabbccddee" 1 4 3)))
+
+
+(test "string-prefix-length-417"
+      #t
+      (= 0 (string-prefix-length "bail" "aabbccddee" 1 4 3)))
+
+
+(test "string-prefix-length-418"
+      #t
+      (= 3 (string-prefix-length "prefix" "preface" 1 5 1)))
+
+
+(test "string-prefix-length-419"
+      #t
+      (= 0 (string-prefix-length "" "" 0 0 0 0)))
+
+
+(test "string-prefix-length-420"
+      #t
+      (= 0 (string-prefix-length "" "aabbccddee" 0 0 0 0)))
+
+
+(test "string-prefix-length-421"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 0 4 0 0)))
+
+
+(test "string-prefix-length-422"
+      #t
+      (= 0 (string-prefix-length "aisle" "aabbccddee" 0 4 2 10)))
+
+
+(test "string-prefix-length-423"
+      #t
+      (= 1 (string-prefix-length "bail" "aabbccddee" 0 1 2 10)))
+
+
+(test "string-prefix-length-424"
+      #t
+      (= 0 (string-prefix-length "prefix" "preface" 0 5 1 6)))
+
+
+(test "string-prefix-length-425"
+      #t
+      (= 0 (string-prefix-length "aisle" "" 1 4 0 0)))
+
+
+(test "string-prefix-length-426"
+      #t
+      (= 0 (string-prefix-length "aisle" "aabbccddee" 1 4 3 3)))
+
+
+(test "string-prefix-length-427"
+      #t
+      (= 0 (string-prefix-length "bail" "aabbccddee" 1 4 3 6)))
+
+
+(test "string-prefix-length-428"
+      #t
+      (= 3 (string-prefix-length "prefix" "preface" 1 5 1 7)))
+
+
+
+(test "string-suffix-length-429"
+      #t
+      (= 0 (string-suffix-length "" "")))
+
+
+(test "string-suffix-length-430"
+      #t
+      (= 0 (string-suffix-length "" "aabbccddee")))
+
+
+(test "string-suffix-length-431"
+      #t
+      (= 0 (string-suffix-length "aisle" "")))
+
+
+(test "string-suffix-length-432"
+      #t
+      (= 0 (string-suffix-length "" "aabbccddee")))
+
+
+(test "string-suffix-length-433"
+      #t
+      (= 1 (string-suffix-length "aisle" "aabbccddee")))
+
+
+(test "string-suffix-length-434"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee")))
+
+
+(test "string-suffix-length-435"
+      #t
+      (= 3 (string-suffix-length "place" "preface")))
+
+
+(test "string-suffix-length-436"
+      #t
+      (= 0 (string-suffix-length "" "" 0)))
+
+
+(test "string-suffix-length-437"
+      #t
+      (= 0 (string-suffix-length "" "aabbccddee" 0)))
+
+
+(test "string-suffix-length-438"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 0)))
+
+
+(test "string-suffix-length-439"
+      #t
+      (= 1 (string-suffix-length "aisle" "aabbccddee" 0)))
+
+
+(test "string-suffix-length-440"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 0)))
+
+
+(test "string-suffix-length-441"
+      #t
+      (= 3 (string-suffix-length "place" "preface" 0)))
+
+
+(test "string-suffix-length-442"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 1)))
+
+
+(test "string-suffix-length-443"
+      #t
+      (= 1 (string-suffix-length "aisle" "aabbccddee" 1)))
+
+
+(test "string-suffix-length-444"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 1)))
+
+
+(test "string-suffix-length-445"
+      #t
+      (= 3 (string-suffix-length "place" "preface" 1)))
+
+
+(test "string-suffix-length-446"
+      #t
+      (= 0 (string-suffix-length "" "" 0 0)))
+
+
+(test "string-suffix-length-447"
+      #t
+      (= 0 (string-suffix-length "" "aabbccddee" 0 0)))
+
+
+(test "string-suffix-length-448"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 0 4)))
+
+
+(test "string-suffix-length-449"
+      #t
+      (= 0 (string-suffix-length "aisle" "aabbccddee" 0 4)))
+
+
+(test "string-suffix-length-450"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 0 1)))
+
+
+(test "string-suffix-length-451"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 1 4)))
+
+
+(test "string-suffix-length-452"
+      #t
+      (= 0 (string-suffix-length "aisle" "aabbccddee" 1 4)))
+
+
+(test "string-suffix-length-453"
+      #t
+      (= 1 (string-suffix-length "aisle" "aabbccddee" 1 5)))
+
+
+(test "string-suffix-length-454"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 1 4)))
+
+
+(test "string-suffix-length-455"
+      #t
+      (= 3 (string-suffix-length "place" "preface" 1 5)))
+
+
+(test "string-suffix-length-456"
+      #t
+      (= 0 (string-suffix-length "" "" 0 0 0)))
+
+
+(test "string-suffix-length-457"
+      #t
+      (= 0 (string-suffix-length "" "aabbccddee" 0 0 0)))
+
+
+(test "string-suffix-length-458"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 0 4 0)))
+
+
+(test "string-suffix-length-459"
+      #t
+      (= 0 (string-suffix-length "aisle" "aabbccddee" 0 4 2)))
+
+
+(test "string-suffix-length-460"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 0 1 2)))
+
+
+(test "string-suffix-length-461"
+      #t
+      (= 3 (string-suffix-length "place" "preface" 0 5 1)))
+
+
+(test "string-suffix-length-462"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 1 4 0)))
+
+
+(test "string-suffix-length-463"
+      #t
+      (= 0 (string-suffix-length "aisle" "aabbccddee" 1 4 3)))
+
+
+(test "string-suffix-length-464"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 1 4 3)))
+
+
+(test "string-suffix-length-465"
+      #t
+      (= 3 (string-suffix-length "place" "preface" 1 5 1)))
+
+
+(test "string-suffix-length-466"
+      #t
+      (= 0 (string-suffix-length "" "" 0 0 0 0)))
+
+
+(test "string-suffix-length-467"
+      #t
+      (= 0 (string-suffix-length "" "aabbccddee" 0 0 0 0)))
+
+
+(test "string-suffix-length-468"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 0 4 0 0)))
+
+
+(test "string-suffix-length-469"
+      #t
+      (= 1 (string-suffix-length "aisle" "aabbccddee" 0 5 2 10)))
+
+
+(test "string-suffix-length-470"
+      #t
+      (= 1 (string-suffix-length "bail" "aabbccddee" 0 1 2 4)))
+
+
+(test "string-suffix-length-471"
+      #t
+      (= 0 (string-suffix-length "place" "preface" 0 5 1 6)))
+
+
+(test "string-suffix-length-472"
+      #t
+      (= 2 (string-suffix-length "place" "preface" 0 4 1 6)))
+
+
+(test "string-suffix-length-473"
+      #t
+      (= 0 (string-suffix-length "aisle" "" 1 4 0 0)))
+
+
+(test "string-suffix-length-474"
+      #t
+      (= 0 (string-suffix-length "aisle" "aabbccddee" 1 4 3 3)))
+
+
+(test "string-suffix-length-475"
+      #t
+      (= 0 (string-suffix-length "bail" "aabbccddee" 1 4 3 6)))
+
+
+(test "string-suffix-length-476"
+      #t
+      (= 3 (string-suffix-length "place" "preface" 1 5 1 7)))
+
+
+
+(test "string-prefix?-477"
+      #t
+      (eq? #t (string-prefix? "" "")))
+
+
+(test "string-prefix?-478"
+      #t
+      (eq? #t (string-prefix? "" "abc")))
+
+
+(test "string-prefix?-479"
+      #t
+      (eq? #t (string-prefix? "a" "abc")))
+
+
+(test "string-prefix?-480"
+      #t
+      (eq? #f (string-prefix? "c" "abc")))
+
+
+(test "string-prefix?-481"
+      #t
+      (eq? #t (string-prefix? "ab" "abc")))
+
+
+(test "string-prefix?-482"
+      #t
+      (eq? #f (string-prefix? "ac" "abc")))
+
+
+(test "string-prefix?-483"
+      #t
+      (eq? #t (string-prefix? "abc" "abc")))
+
+
+(test "string-suffix?-484"
+      #t
+      (eq? #t (string-suffix? "" "")))
+
+
+(test "string-suffix?-485"
+      #t
+      (eq? #t (string-suffix? "" "abc")))
+
+
+(test "string-suffix?-486"
+      #t
+      (eq? #f (string-suffix? "a" "abc")))
+
+
+(test "string-suffix?-487"
+      #t
+      (eq? #t (string-suffix? "c" "abc")))
+
+
+(test "string-suffix?-488"
+      #t
+      (eq? #f (string-suffix? "ac" "abc")))
+
+
+(test "string-suffix?-489"
+      #t
+      (eq? #t (string-suffix? "bc" "abc")))
+
+
+(test "string-suffix?-490"
+      #t
+      (eq? #t (string-suffix? "abc" "abc")))
+
+
+(test "string-prefix?-491"
+      #t
+      (eq? #t (string-prefix? "" "" 0)))
+
+
+(test "string-prefix?-492"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0)))
+
+
+(test "string-prefix?-493"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0)))
+
+
+(test "string-prefix?-494"
+      #t
+      (eq? #f (string-prefix? "c" "abc" 0)))
+
+
+(test "string-prefix?-495"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0)))
+
+
+(test "string-prefix?-496"
+      #t
+      (eq? #f (string-prefix? "ac" "abc" 0)))
+
+
+(test "string-prefix?-497"
+      #t
+      (eq? #t (string-prefix? "abc" "abc" 0)))
+
+
+(test "string-suffix?-498"
+      #t
+      (eq? #t (string-suffix? "" "" 0)))
+
+
+(test "string-suffix?-499"
+      #t
+      (eq? #t (string-suffix? "" "abc" 0)))
+
+
+(test "string-suffix?-500"
+      #t
+      (eq? #f (string-suffix? "a" "abc" 0)))
+
+
+(test "string-suffix?-501"
+      #t
+      (eq? #t (string-suffix? "c" "abc" 0)))
+
+
+(test "string-suffix?-502"
+      #t
+      (eq? #f (string-suffix? "ac" "abc" 0)))
+
+
+(test "string-suffix?-503"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 0)))
+
+
+(test "string-suffix?-504"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 0)))
+
+
+(test "string-prefix?-505"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 2)))
+
+
+(test "string-prefix?-506"
+      #t
+      (eq? #t (string-prefix? "ac" "abc" 2)))
+
+
+(test "string-prefix?-507"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 2)))
+
+
+(test "string-suffix?-508"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 2)))
+
+
+(test "string-suffix?-509"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 2)))
+
+
+(test "string-suffix?-510"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 2)))
+
+
+
+(test "string-prefix?-511"
+      #t
+      (eq? #t (string-prefix? "" "" 0 0)))
+
+
+(test "string-prefix?-512"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0 0)))
+
+
+(test "string-prefix?-513"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0 0)))
+
+
+(test "string-prefix?-514"
+      #t
+      (eq? #f (string-prefix? "c" "abc" 0 1)))
+
+
+(test "string-prefix?-515"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 1)))
+
+
+(test "string-prefix?-516"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 2)))
+
+
+(test "string-prefix?-517"
+      #t
+      (eq? #f (string-prefix? "ac" "abc" 0 2)))
+
+
+(test "string-prefix?-518"
+      #t
+      (eq? #t (string-prefix? "abc" "abc" 0 3)))
+
+
+(test "string-suffix?-519"
+      #t
+      (eq? #t (string-suffix? "" "" 0 0)))
+
+
+(test "string-suffix?-520"
+      #t
+      (eq? #t (string-suffix? "" "abc" 0 0)))
+
+
+(test "string-suffix?-521"
+      #t
+      (eq? #f (string-suffix? "a" "abc" 0 1)))
+
+
+(test "string-suffix?-522"
+      #t
+      (eq? #t (string-suffix? "c" "abc" 0 1)))
+
+
+(test "string-suffix?-523"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 1 2)))
+
+
+(test "string-suffix?-524"
+      #t
+      (eq? #f (string-suffix? "ac" "abc" 0 2)))
+
+
+(test "string-suffix?-525"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 0 2)))
+
+
+(test "string-suffix?-526"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 0 3)))
+
+
+(test "string-prefix?-527"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 2 2)))
+
+
+(test "string-prefix?-528"
+      #t
+      (eq? #t (string-prefix? "ac" "abc" 2 2)))
+
+
+(test "string-prefix?-529"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 2 3)))
+
+
+(test "string-suffix?-530"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 2 2)))
+
+
+(test "string-suffix?-531"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 2 2)))
+
+
+(test "string-suffix?-532"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 2 3)))
+
+
+
+(test "string-prefix?-533"
+      #t
+      (eq? #t (string-prefix? "" "" 0 0 0)))
+
+
+(test "string-prefix?-534"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0 0 0)))
+
+
+(test "string-prefix?-535"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0 0 0)))
+
+
+(test "string-prefix?-536"
+      #t
+      (eq? #f (string-prefix? "c" "abc" 0 1 0)))
+
+
+(test "string-prefix?-537"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 1 0)))
+
+
+(test "string-prefix?-538"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 2 0)))
+
+
+(test "string-prefix?-539"
+      #t
+      (eq? #f (string-prefix? "ac" "abc" 0 2 0)))
+
+
+(test "string-prefix?-540"
+      #t
+      (eq? #t (string-prefix? "abc" "abc" 0 3 0)))
+
+
+(test "string-suffix?-541"
+      #t
+      (eq? #t (string-suffix? "" "" 0 0 0)))
+
+
+(test "string-suffix?-542"
+      #t
+      (eq? #t (string-suffix? "" "abc" 0 0 0)))
+
+
+(test "string-suffix?-543"
+      #t
+      (eq? #f (string-suffix? "a" "abc" 0 1 0)))
+
+
+(test "string-suffix?-544"
+      #t
+      (eq? #t (string-suffix? "c" "abc" 0 1 0)))
+
+
+(test "string-suffix?-545"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 1 2 0)))
+
+
+(test "string-suffix?-546"
+      #t
+      (eq? #f (string-suffix? "ac" "abc" 0 2 0)))
+
+
+(test "string-suffix?-547"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 0 2 0)))
+
+
+(test "string-suffix?-548"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 0 3 0)))
+
+
+(test "string-prefix?-549"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 2 2 0)))
+
+
+(test "string-prefix?-550"
+      #t
+      (eq? #t (string-prefix? "ac" "abc" 2 2 0)))
+
+
+(test "string-prefix?-551"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 2 3 0)))
+
+
+(test "string-suffix?-552"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 2 2 0)))
+
+
+(test "string-suffix?-553"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 2 2 0)))
+
+
+(test "string-suffix?-554"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 2 3 0)))
+
+
+(test "string-prefix?-555"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0 0 1)))
+
+
+(test "string-prefix?-556"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0 0 1)))
+
+
+(test "string-prefix?-557"
+      #t
+      (eq? #t (string-prefix? "c" "abc" 0 1 2)))
+
+
+(test "string-prefix?-558"
+      #t
+      (eq? #f (string-prefix? "ab" "abc" 0 1 2)))
+
+
+(test "string-prefix?-559"
+      #t
+      (eq? #f (string-prefix? "ab" "abc" 0 2 1)))
+
+
+(test "string-prefix?-560"
+      #t
+      (eq? #f (string-prefix? "ac" "abc" 0 2 1)))
+
+
+(test "string-prefix?-561"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 0 3 1)))
+
+
+(test "string-suffix?-562"
+      #t
+      (eq? #f (string-suffix? "a" "abc" 0 1 2)))
+
+
+(test "string-suffix?-563"
+      #t
+      (eq? #t (string-suffix? "c" "abc" 0 1 1)))
+
+
+(test "string-suffix?-564"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 1 2 2)))
+
+
+(test "string-suffix?-565"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 0 2 1)))
+
+
+(test "string-suffix?-566"
+      #t
+      (eq? #f (string-suffix? "bc" "abc" 0 2 2)))
+
+
+
+(test "string-prefix?-567"
+      #t
+      (eq? #t (string-prefix? "" "" 0 0 0 0)))
+
+
+(test "string-prefix?-568"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0 0 0 3)))
+
+
+(test "string-prefix?-569"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0 0 0 3)))
+
+
+(test "string-prefix?-570"
+      #t
+      (eq? #f (string-prefix? "c" "abc" 0 1 0 3)))
+
+
+(test "string-prefix?-571"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 1 0 3)))
+
+
+(test "string-prefix?-572"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 2 0 3)))
+
+
+(test "string-prefix?-573"
+      #t
+      (eq? #f (string-prefix? "ac" "abc" 0 2 0 3)))
+
+
+(test "string-prefix?-574"
+      #t
+      (eq? #t (string-prefix? "abc" "abc" 0 3 0 3)))
+
+
+(test "string-suffix?-575"
+      #t
+      (eq? #t (string-suffix? "" "abc" 0 0 0 3)))
+
+
+(test "string-suffix?-576"
+      #t
+      (eq? #f (string-suffix? "a" "abc" 0 1 0 3)))
+
+
+(test "string-suffix?-577"
+      #t
+      (eq? #t (string-suffix? "c" "abc" 0 1 0 3)))
+
+
+(test "string-suffix?-578"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 1 2 0 3)))
+
+
+(test "string-suffix?-579"
+      #t
+      (eq? #f (string-suffix? "ac" "abc" 0 2 0 3)))
+
+
+(test "string-suffix?-580"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 0 2 0 3)))
+
+
+(test "string-suffix?-581"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 0 3 0 3)))
+
+
+(test "string-prefix?-582"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 2 2 0 3)))
+
+
+(test "string-prefix?-583"
+      #t
+      (eq? #t (string-prefix? "ac" "abc" 2 2 0 3)))
+
+
+(test "string-prefix?-584"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 2 3 0 3)))
+
+
+(test "string-suffix?-585"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 2 2 0 3)))
+
+
+(test "string-suffix?-586"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 2 2 0 3)))
+
+
+(test "string-suffix?-587"
+      #t
+      (eq? #t (string-suffix? "abc" "abc" 2 3 0 3)))
+
+
+(test "string-prefix?-588"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0 0 1 3)))
+
+
+(test "string-prefix?-589"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0 0 1 3)))
+
+
+(test "string-prefix?-590"
+      #t
+      (eq? #t (string-prefix? "c" "abc" 0 1 2 3)))
+
+
+(test "string-prefix?-591"
+      #t
+      (eq? #f (string-prefix? "ab" "abc" 0 1 2 3)))
+
+
+(test "string-prefix?-592"
+      #t
+      (eq? #f (string-prefix? "ab" "abc" 0 2 1 3)))
+
+
+(test "string-prefix?-593"
+      #t
+      (eq? #f (string-prefix? "ac" "abc" 0 2 1 3)))
+
+
+(test "string-prefix?-594"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 0 3 1 3)))
+
+
+(test "string-suffix?-595"
+      #t
+      (eq? #f (string-suffix? "a" "abc" 0 1 2 3)))
+
+
+(test "string-suffix?-596"
+      #t
+      (eq? #t (string-suffix? "c" "abc" 0 1 1 3)))
+
+
+(test "string-suffix?-597"
+      #t
+      (eq? #t (string-suffix? "ac" "abc" 1 2 2 3)))
+
+
+(test "string-suffix?-598"
+      #t
+      (eq? #t (string-suffix? "bc" "abc" 0 2 1 3)))
+
+
+(test "string-suffix?-599"
+      #t
+      (eq? #f (string-suffix? "bc" "abc" 0 2 2 3)))
+
+
+
+(test "string-prefix?-600"
+      #t
+      (eq? #t (string-prefix? "" "abc" 0 0 0 2)))
+
+
+(test "string-prefix?-601"
+      #t
+      (eq? #t (string-prefix? "a" "abc" 0 0 0 2)))
+
+
+(test "string-prefix?-602"
+      #t
+      (eq? #f (string-prefix? "c" "abc" 0 1 0 2)))
+
+
+(test "string-prefix?-603"
+      #t
+      (eq? #t (string-prefix? "ab" "abc" 0 1 0 2)))
+
+
+(test "string-prefix?-604"
+      #t
+      (eq? #f (string-prefix? "abc" "abc" 0 3 0 2)))
+
+
+(test "string-suffix?-605"
+      #t
+      (eq? #t (string-suffix? "" "abc" 0 0 0 2)))
+
+
+(test "string-suffix?-606"
+      #t
+      (eq? #f (string-suffix? "c" "abc" 0 1 0 2)))
+
+
+(test "string-suffix?-607"
+      #t
+      (eq? #f (string-suffix? "ac" "abc" 1 2 0 2)))
+
+
+;;; Searching
+
+(test "string-index-608"
+      #t
+      (= 0
+         (string-cursor->index ""
+                               (string-index "" char?))))
+
+
+(test "string-index-609"
+      #t
+      (= 0
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef" char?))))
+
+
+(test "string-index-610"
+      #t
+      (= 4
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef"
+                                             (lambda (c) (char>? c #\d))))))
+
+
+(test "string-index-611"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef" char-whitespace?))))
+
+
+(test "string-index-right-612"
+      #t
+      (= 0
+         (string-cursor->index "abcdef"
+                               (string-index-right "" char?))))
+
+
+(test "string-index-right-613"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef" char?))))
+
+
+(test "string-index-right-614"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef"
+                                                   (lambda (c) (char>? c #\d))))))
+
+
+(test "string-index-right-615"
+      #t
+      (= 0
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef" char-whitespace?))))
+
+
+(test "string-skip-616"
+      #t
+      (= 0
+         (string-cursor->index "" (string-skip "" string?))))
+
+
+(test "string-skip-617"
+      #t
+      (= 0
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef" string?))))
+
+
+(test "string-skip-618"
+      #t
+      (= 4
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef"
+                                            (lambda (c) (char<=? c #\d))))))
+
+
+(test "string-skip-619"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef" char?))))
+
+
+(test "string-skip-right-620"
+      #t
+      (= 0
+         (string-cursor->index "" (string-skip-right "" string?))))
+
+
+(test "string-skip-right-621"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef" string?))))
+
+
+(test "string-skip-right-622"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef"
+                                                  (lambda (c) (char<=? c #\d))))))
+
+
+(test "string-skip-right-623"
+      #t
+      (= 0
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef" char?))))
+
+
+
+(test "string-index-624"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef" char? 2))))
+
+
+(test "string-index-625"
+      #t
+      (= 4
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef"
+                                             (lambda (c) (char>? c #\d)) 2))))
+
+
+(test "string-index-626"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef" char-whitespace? 2))))
+
+
+(test "string-index-right-627"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef" char? 2))))
+
+
+(test "string-index-right-628"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef"
+                                                   (lambda (c)
+                                                     (char>? c #\d)) 2))))
+
+
+(test "string-index-right-629"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef" char-whitespace? 2))))
+
+
+(test "string-skip-630"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef" string? 2))))
+
+
+(test "string-skip-631"
+      #t
+      (= 4
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef"
+                                            (lambda (c)
+                                              (char<=? c #\d)) 2))))
+
+
+(test "string-skip-632"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef" char? 2))))
+
+
+(test "string-skip-right-633"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef" string? 2))))
+
+
+(test "string-skip-right-634"
+      #t
+      (= 6
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef"
+                                                  (lambda (c)
+                                                    (char<=? c #\d)) 2))))
+
+
+(test "string-skip-right-635"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef" char? 2))))
+
+
+
+(test "string-index-636"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef" char? 2 5))))
+
+
+(test "string-index-637"
+      #t
+      (= 4
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef"
+                                             (lambda (c) (char>? c #\d)) 2 5))))
+
+
+(test "string-index-638"
+      #t
+      (= 5
+         (string-cursor->index "abcdef"
+                               (string-index "abcdef" char-whitespace? 2 5))))
+
+
+(test "string-index-right-639"
+      #t
+      (= 5
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef" char? 2 5))))
+
+
+(test "string-index-right-640"
+      #t
+      (= 5
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef"
+                                                   (lambda (c)
+                                                     (char>? c #\d)) 2 5))))
+
+
+(test "string-index-right-641"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-index-right "abcdef"
+                                                   char-whitespace? 2 5))))
+
+
+(test "string-skip-642"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef" string? 2 5))))
+
+
+(test "string-skip-643"
+      #t
+      (= 4
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef"
+                                            (lambda (c) (char<=? c #\d)) 2 5))))
+
+
+(test "string-skip-644"
+      #t
+      (= 5
+         (string-cursor->index "abcdef"
+                               (string-skip "abcdef" char? 2 5))))
+
+
+(test "string-skip-right-645"
+      #t
+      (= 5
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef" string? 2 5))))
+
+
+(test "string-skip-right-646"
+      #t
+      (= 5
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef"
+                                                  (lambda (c)
+                                                    (char<=? c #\d)) 2 5))))
+
+
+(test "string-skip-right-647"
+      #t
+      (= 2
+         (string-cursor->index "abcdef"
+                               (string-skip-right "abcdef" char? 2 5))))
+
+
+
+(test "string-contains-648"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains "" ""))))
+
+
+(test "string-contains-649"
+      #t
+      (eqv? 0
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" ""))))
+
+
+(test "string-contains-650"
+      #t
+      (eqv? 0
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "a"))))
+
+
+(test "string-contains-651"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "ff"))))
+
+
+(test "string-contains-652"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "eff"))))
+
+
+(test "string-contains-653"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "foo"))))
+
+
+(test "string-contains-654"
+      #t
+      (not (string-contains "abcdeffffoo" "efffoo")))
+
+
+(test "string-contains-right-655"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains-right "" ""))))
+
+
+(test "string-contains-right-656"
+      #t
+      (eqv? 11
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo" ""))))
+
+
+(test "string-contains-right-657"
+      #t
+      (eqv? 0
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo" "a"))))
+
+
+(test "string-contains-right-658"
+      #t
+      (eqv? 7
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo" "ff"))))
+
+
+(test "string-contains-right-659"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo" "eff"))))
+
+
+(test "string-contains-right-660"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo" "foo"))))
+
+
+(test "string-contains-right-661"
+      #t
+      (not (string-contains-right "abcdeffffoo" "efffoo")))
+
+
+
+(test "string-contains-662"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains "" "" 0))))
+
+
+(test "string-contains-663"
+      #t
+      (eqv? 2
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "" 2))))
+
+
+(test "string-contains-664"
+      #t
+      (not (string-contains "abcdeffffoo" "a" 2)))
+
+
+(test "string-contains-665"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "ff" 2))))
+
+
+(test "string-contains-666"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "eff" 2))))
+
+
+(test "string-contains-667"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo" "foo" 2))))
+
+
+(test "string-contains-668"
+      #t
+      (not (string-contains "abcdeffffoo" "efffoo" 2)))
+
+
+(test "string-contains-right-669"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains-right "" "" 0))))
+
+
+(test "string-contains-right-670"
+      #t
+      (eqv? 11
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "" 2))))
+
+
+(test "string-contains-right-671"
+      #t
+      (not (string-contains-right "abcdeffffoo" "a" 2)))
+
+
+(test "string-contains-right-672"
+      #t
+      (eqv? 7
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "ff" 2))))
+
+
+(test "string-contains-right-673"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "eff" 2))))
+
+
+(test "string-contains-right-674"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "foo" 2))))
+
+
+(test "string-contains-right-675"
+      #t
+      (not (string-contains-right "abcdeffffoo" "efffoo" 2)))
+
+
+
+(test "string-contains-676"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains "" "" 0 0))))
+
+
+(test "string-contains-677"
+      #t
+      (eqv? 2
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "" 2 10))))
+
+
+(test "string-contains-678"
+      #t
+      (not (string-contains "abcdeffffoo" "a" 2 10)))
+
+
+(test "string-contains-679"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "ff" 2 10))))
+
+
+(test "string-contains-680"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "eff" 2 10))))
+
+
+(test "string-contains-681"
+      #t
+      (not (string-contains "abcdeffffoo" "foo" 2 10)))
+
+
+(test "string-contains-682"
+      #t
+      (not (string-contains "abcdeffffoo" "efffoo" 2 10)))
+
+
+(test "string-contains-right-683"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains-right "" "" 0 0))))
+
+
+(test "string-contains-right-684"
+      #t
+      (eqv? 10
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "" 2 10))))
+
+
+(test "string-contains-right-685"
+      #t
+      (not (string-contains-right "abcdeffffoo" "a" 2 10)))
+
+
+(test "string-contains-right-686"
+      #t
+      (eqv? 7
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "ff" 2 10))))
+
+
+(test "string-contains-right-687"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "eff" 2 10))))
+
+
+(test "string-contains-right-688"
+      #t
+      (not (string-contains-right "abcdeffffoo" "foo" 2 10)))
+
+
+(test "string-contains-right-689"
+      #t
+      (not (string-contains-right "abcdeffffoo" "efffoo" 2 10)))
+
+
+
+(test "string-contains-690"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains "" "" 0 0 0))))
+
+
+(test "string-contains-691"
+      #t
+      (eqv? 2
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "" 2 10 0))))
+
+
+(test "string-contains-692"
+      #t
+      (eqv? 2
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "a" 2 10 1))))
+
+
+(test "string-contains-693"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "ff" 2 10 1))))
+
+
+(test "string-contains-694"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "eff" 2 10 1))))
+
+
+(test "string-contains-695"
+      #t
+      (not (string-contains "abcdeffffoo" "foo" 2 10 1)))
+
+
+(test "string-contains-696"
+      #t
+      (not (string-contains "abcdeffffoo" "efffoo" 2 10 1)))
+
+
+(test "string-contains-right-697"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains-right "" "" 0 0 0))))
+
+
+(test "string-contains-right-698"
+      #t
+      (eqv? 10
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "" 2 10 0))))
+
+
+(test "string-contains-right-699"
+      #t
+      (eqv? 10
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "a" 2 10 1))))
+
+
+(test "string-contains-right-700"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "ff" 2 10 1))))
+
+
+(test "string-contains-right-701"
+      #t
+      (eqv? 7
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "eff" 2 10 1))))
+
+
+(test "string-contains-right-702"
+      #t
+      (not (string-contains-right "abcdeffffoo" "foo" 2 10 1)))
+
+
+(test "string-contains-right-703"
+      #t
+      (not (string-contains-right "abcdeffffoo" "efffoo" 2 10 1)))
+
+
+
+(test "string-contains-704"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains "" "" 0 0 0 0))))
+
+
+(test "string-contains-705"
+      #t
+      (eqv? 2
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "" 2 10 0 0))))
+
+
+(test "string-contains-706"
+      #t
+      (eqv? 2
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "a" 2 10 1 1))))
+
+
+(test "string-contains-707"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "ff" 2 10 1 2))))
+
+
+(test "string-contains-708"
+      #t
+      (eqv? 5
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "eff" 2 10 1 2))))
+
+
+(test "string-contains-709"
+      #t
+      (eqv? 9
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "foo" 2 10 1 2))))
+
+
+(test "string-contains-710"
+      #t
+      (eqv? 4
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains "abcdeffffoo"
+                                                   "efffoo" 2 10 0 2))))
+
+
+(test "string-contains-right-711"
+      #t
+      (eqv? 0
+            (string-cursor->index ""
+                                  (string-contains-right "" "" 0 0 0 0))))
+
+
+(test "string-contains-right-712"
+      #t
+      (eqv? 10
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "" 2 10 0 0))))
+
+
+(test "string-contains-right-713"
+      #t
+      (eqv? 10
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "a" 2 10 1 1))))
+
+
+(test "string-contains-right-714"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "ff" 2 10 1 2))))
+
+
+(test "string-contains-right-715"
+      #t
+      (eqv? 8
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "eff" 2 10 1 2))))
+
+
+(test "string-contains-right-716"
+      #t
+      (eqv? 9
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "foo" 2 10 1 2))))
+
+
+(test "string-contains-right-717"
+      #t
+      (eqv? 7
+            (string-cursor->index "abcdeffffoo"
+                                  (string-contains-right "abcdeffffoo"
+                                                         "efffoo" 2 10 1 3))))
+
+
+;;; The whole string
+
+(test "string-reverse-718"
+      #t
+      (string=? "" (string-reverse "")))
+
+
+(test "string-reverse-719"
+      #t
+      (string=? "fedcba" (string-reverse "abcdef")))
+
+
+(test "string-reverse-720"
+      #t
+      (string=? "" (string-reverse "" 0)))
+
+
+(test "string-reverse-721"
+      #t
+      (string=? "fedcba" (string-reverse "abcdef" 0)))
+
+
+(test "string-reverse-722"
+      #t
+      (string=? "fedc" (string-reverse "abcdef" 2)))
+
+
+(test "string-reverse-723"
+      #t
+      (string=? "" (string-reverse "" 0 0)))
+
+
+(test "string-reverse-724"
+      #t
+      (string=? "fedcba" (string-reverse "abcdef" 0 6)))
+
+
+(test "string-reverse-725"
+      #t
+      (string=? "edc" (string-reverse "abcdef" 2 5)))
+
+
+
+(test "string-concatenate-726"
+      #t
+      (string=? "" (string-concatenate '())))
+
+
+(test "string-concatenate-727"
+      #t
+      (string=? "abcdef" (string-concatenate '("" "a" "bcd" "" "ef" "" ""))))
+
+
+(test "string-concatenate-reverse-728"
+      #t
+      (string=? "" (string-concatenate-reverse '())))
+
+
+(test "string-concatenate-reverse-729"
+      #t
+      (string=? "efbcda"
+                (string-concatenate-reverse '("" "a" "bcd" "" "ef" "" ""))))
+
+
+(test "string-concatenate-reverse-730"
+      #t
+      (string=? "huh?" (string-concatenate-reverse '() "huh?")))
+
+
+(test "string-concatenate-reverse-731"
+      #t
+      (string=? "efbcdaxy"
+                (string-concatenate-reverse '("" "a" "bcd" "" "ef" "" "") "xy")))
+
+
+(test "string-concatenate-reverse-732"
+      #t
+      (string=? "huh" (string-concatenate-reverse '() "huh?" 3)))
+
+
+(test "string-concatenate-reverse-733"
+      #t
+      (string=? "efbcdax"
+                (string-concatenate-reverse '("" "a" "bcd" "" "ef" "" "") "x" 1)))
+
+
+
+(test "string-fold-734"
+      #t
+      (= 8
+         (string-fold (lambda (c count)
+                        (if (char-whitespace? c)
+                            (+ count 1)
+                            count))
+                      0
+                      " ...a couple of spaces in this one... ")))
+
+
+(test "string-fold-735"
+      #t
+      (= 7
+         (string-fold (lambda (c count)
+                        (if (char-whitespace? c)
+                            (+ count 1)
+                            count))
+                      0
+                      " ...a couple of spaces in this one... "
+                      1)))
+
+
+(test "string-fold-736"
+      #t
+      (= 6
+         (string-fold (lambda (c count)
+                        (if (char-whitespace? c)
+                            (+ count 1)
+                            count))
+                      0
+                      " ...a couple of spaces in this one... "
+                      1
+                      32)))
+
+
+(test "string-fold-right-737"
+      #t
+      (equal? (string->list "abcdef")
+              (string-fold-right cons '() "abcdef")))
+
+
+(test "string-fold-right-738"
+      #t
+      (equal? (string->list "def")
+              (string-fold-right cons '() "abcdef" 3)))
+
+
+(test "string-fold-right-739"
+      #t
+      (equal? (string->list "cde")
+              (string-fold-right cons '() "abcdef" 2 5)))
+
+
+(test "string-fold-740"
+      #t
+      (string=? "aabraacaadaabraa"
+                (let* ((s "abracadabra")
+                       (ans-len (string-fold (lambda (c sum)
+                                               (+ sum (if (char=? c #\a) 2 1)))
+                                             0 s))
+                       (ans (make-string ans-len)))
+                  (string-fold (lambda (c i)
+                                 (let ((i (if (char=? c #\a)
+                                              (begin (string-set! ans i #\a)
+                                                     (+ i 1))
+                                              i)))
+                                   (string-set! ans i c)
+                                   (+ i 1)))
+                               0 s)
+                  ans)))
+
+
+
+(test "string-for-each-cursor-741"
+      #t
+      (equal? '(101 100 99 98 97)
+              (let ((s "abcde") (v '()))
+                (string-for-each-cursor
+                 (lambda (cur)
+                   (set! v (cons (char->integer (string-ref/cursor s cur)) v)))
+                 s)
+                v)))
+
+
+
+(test "string-replicate-742"
+      #t
+      (string=? "cdefabcdefabcd"
+                (string-replicate "abcdef" -4 10)))
+
+
+(test "string-replicate-743"
+      #t
+      (string=? "bcdefbcdefbcd"
+                (string-replicate "abcdef" 90 103 1)))
+
+
+(test "string-replicate-744"
+      #t
+      (string=? "ecdecdecde"
+                (string-replicate "abcdef" -13 -3 2 5)))
+
+
+
+(test "string-count-745"
+      #t
+      (= 6 (string-count "abcdef" char?)))
+
+
+(test "string-count-746"
+      #t
+      (= 4 (string-count "counting  whitespace, again " char-whitespace? 5)))
+
+
+(test "string-count-747"
+      #t
+      (= 3 (string-count "abcdefwxyz"
+                         (lambda (c) (odd? (char->integer c)))
+                         2 8)))
+
+
+
+(test "string-replace-748"
+      #t
+      (string=? "It's lots of fun to code it up in Scheme."
+                (string-replace "It's easy to code it up in Scheme."
+                                "lots of fun"
+                                5 9)))
+
+
+(test "string-replace-749"
+      #t
+      (string=? "The miserable perl programmer endured daily ridicule."
+                (string-replace "The TCL programmer endured daily ridicule."
+                                "another miserable perl drone"
+                                4 7 8 22)))
+
+
+(test "string-replace-750"
+      #t
+      (string=? "It's really easy to code it up in Scheme."
+                (string-replace "It's easy to code it up in Scheme."
+                                "really "
+                                5 5)))
+
+
+
+(test "string-split-751"
+      #t
+      (equal? '() (string-split "" "")))
+
+
+(test "string-split-752"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "")))
+
+
+(test "string-split-753"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " ")))
+
+
+(test "string-split-754"
+      #t
+      (equal? '("" "there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***")))
+
+
+(test "string-split-755"
+      #t
+      (equal? '() (string-split "" "" 'infix)))
+
+
+(test "string-split-756"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'infix)))
+
+
+(test "string-split-757"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'infix)))
+
+
+(test "string-split-758"
+      #t
+      (equal? '("" "there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'infix)))
+
+
+(test "string-split-759"
+      #t
+      (equal? 'error
+              (guard (exn (else 'error))
+                (string-split "" "" 'strict-infix))))
+
+
+(test "string-split-760"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'strict-infix)))
+
+
+(test "string-split-761"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'strict-infix)))
+
+
+(test "string-split-762"
+      #t
+      (equal? '("" "there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'strict-infix)))
+
+
+(test "string-split-763"
+      #t
+      (equal? '() (string-split "" "" 'prefix)))
+
+
+(test "string-split-764"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'prefix)))
+
+
+(test "string-split-765"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'prefix)))
+
+
+(test "string-split-766"
+      #t
+      (equal? '("there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'prefix)))
+
+
+(test "string-split-767"
+      #t
+      (equal? '() (string-split "" "" 'suffix)))
+
+
+(test "string-split-768"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'suffix)))
+
+
+(test "string-split-769"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'suffix)))
+
+
+(test "string-split-770"
+      #t
+      (equal? '("" "there" "ya" "go")
+              (string-split "***there***ya***go***" "***" 'suffix)))
+
+
+
+(test "string-split-771"
+      #t
+      (equal? '() (string-split "" "" 'infix #f)))
+
+
+(test "string-split-772"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'infix #f)))
+
+
+(test "string-split-773"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'infix #f)))
+
+
+(test "string-split-774"
+      #t
+      (equal? '("" "there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'infix #f)))
+
+
+(test "string-split-775"
+      #t
+      (equal? 'error
+              (guard (exn (else 'error))
+                (string-split "" "" 'strict-infix #f))))
+
+
+(test "string-split-776"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'strict-infix #f)))
+
+
+(test "string-split-777"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'strict-infix #f)))
+
+
+(test "string-split-778"
+      #t
+      (equal? '("" "there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'strict-infix #f)))
+
+
+(test "string-split-779"
+      #t
+      (equal? '() (string-split "" "" 'prefix #f)))
+
+
+(test "string-split-780"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'prefix #f)))
+
+
+(test "string-split-781"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'prefix #f)))
+
+
+(test "string-split-782"
+      #t
+      (equal? '("there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'prefix #f)))
+
+
+(test "string-split-783"
+      #t
+      (equal? '() (string-split "" "" 'suffix #f)))
+
+
+(test "string-split-784"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'suffix #f)))
+
+
+(test "string-split-785"
+      #t
+      (equal? '("too" "" "much" "" "data")
+              (string-split "too  much  data" " " 'suffix #f)))
+
+
+(test "string-split-786"
+      #t
+      (equal? '("" "there" "ya" "go")
+              (string-split "***there***ya***go***" "***" 'suffix #f)))
+
+
+
+(test "string-split-787"
+      #t
+      (equal? 'error
+              (guard (exn (else 'error))
+                (string-split "" "" 'strict-infix 3))))
+
+
+(test "string-split-788"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'strict-infix 3)))
+
+
+(test "string-split-789"
+      #t
+      (equal? '("too" "" "much" " data")
+              (string-split "too  much  data" " " 'strict-infix 3)))
+
+
+(test "string-split-790"
+      #t
+      (equal? '("" "there" "ya" "go***")
+              (string-split "***there***ya***go***" "***" 'strict-infix 3)))
+
+
+(test "string-split-791"
+      #t
+      (equal? '() (string-split "" "" 'prefix 3)))
+
+
+(test "string-split-792"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'prefix 3)))
+
+
+(test "string-split-793"
+      #t
+      (equal? '("too" "" "much" " data")
+              (string-split "too  much  data" " " 'prefix 3)))
+
+
+(test "string-split-794"
+      #t
+      (equal? '("there" "ya" "go***")
+              (string-split "***there***ya***go***" "***" 'prefix 3)))
+
+
+(test "string-split-795"
+      #t
+      (equal? '() (string-split "" "" 'suffix 3)))
+
+
+(test "string-split-796"
+      #t
+      (equal? '("a" "b" "c") (string-split "abc" "" 'suffix 3)))
+
+
+(test "string-split-797"
+      #t
+      (equal? '("too" "" "much" " data")
+              (string-split "too  much  data" " " 'suffix 3)))
+
+
+(test "string-split-798"
+      #t
+      (equal? '("" "there" "ya" "go***")
+              (string-split "***there***ya***go***" "***" 'suffix 3)))
+
+
+
+(test "string-split-799"
+      #t
+      (equal? 'error
+              (guard (exn (else 'error))
+                (string-split "" "" 'strict-infix 3 0))))
+
+
+(test "string-split-800"
+      #t
+      (equal? '("b" "c") (string-split "abc" "" 'strict-infix 3 1)))
+
+
+(test "string-split-801"
+      #t
+      (equal? '("oo" "" "much" " data")
+              (string-split "too  much  data" " " 'strict-infix 3 1)))
+
+
+(test "string-split-802"
+      #t
+      (equal? '("**there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'strict-infix 3 1)))
+
+
+(test "string-split-803"
+      #t
+      (equal? '() (string-split "" "" 'prefix 3 0)))
+
+
+(test "string-split-804"
+      #t
+      (equal? '("b" "c") (string-split "abc" "" 'prefix 3 1)))
+
+
+(test "string-split-805"
+      #t
+      (equal? '("oo" "" "much" " data")
+              (string-split "too  much  data" " " 'prefix 3 1)))
+
+
+(test "string-split-806"
+      #t
+      (equal? '("**there" "ya" "go" "")
+              (string-split "***there***ya***go***" "***" 'prefix 3 1)))
+
+
+(test "string-split-807"
+      #t
+      (equal? '() (string-split "" "" 'suffix 3 0)))
+
+
+(test "string-split-808"
+      #t
+      (equal? '("b" "c") (string-split "abc" "" 'suffix 3 1)))
+
+
+(test "string-split-809"
+      #t
+      (equal? '("oo" "" "much" " data")
+              (string-split "too  much  data" " " 'suffix 3 1)))
+
+
+(test "string-split-810"
+      #t
+      (equal? '("**there" "ya" "go")
+              (string-split "***there***ya***go***" "***" 'suffix 3 1)))
+
+
+
+(test "string-split-811"
+      #t
+      (equal? 'error
+              (guard (exn (else 'error))
+                (string-split "" "" 'strict-infix 3 0 0))))
+
+
+(test "string-split-812"
+      #t
+      (equal? '("b") (string-split "abc" "" 'strict-infix 3 1 2)))
+
+
+(test "string-split-813"
+      #t
+      (equal? '("oo" "" "much" " ")
+              (string-split "too  much  data" " " 'strict-infix 3 1 11)))
+
+
+(test "string-split-814"
+      #t
+      (equal? '() (string-split "" "" 'prefix 3 0 0)))
+
+
+(test "string-split-815"
+      #t
+      (equal? '("b") (string-split "abc" "" 'prefix 3 1 2)))
+
+
+(test "string-split-816"
+      #t
+      (equal? '("oo" "" "much" " ")
+              (string-split "too  much  data" " " 'prefix 3 1 11)))
+
+
+(test "string-split-817"
+      #t
+      (equal? '() (string-split "" "" 'suffix 3 0 0)))
+
+
+(test "string-split-818"
+      #t
+      (equal? '("b") (string-split "abc" "" 'suffix 3 1 2)))
+
+
+(test "string-split-819"
+      #t
+      (equal? '("oo" "" "much" " ")
+              (string-split "too  much  data" " " 'suffix 3 1 11)))
+
+
+
+(test "string-filter-820"
+      #t
+      (string=? "aiueaaaoi"
+                (string-filter (lambda (c) (memv c (string->list "aeiou")))
+                               "What is number, that man may know it?")))
+
+
+(test "string-remove-821"
+      #t
+      (string=? "And wmn, tht sh my knw nmbr?"
+                (string-remove (lambda (c) (memv c (string->list "aeiou")))
+                               "And woman, that she may know number?")))
+
+
+(test "string-filter-822"
+      #t
+      (string=? "iueaaaoi"
+                (string-filter (lambda (c) (memv c (string->list "aeiou")))
+                               "What is number, that man may know it?"
+                               4)))
+
+
+(test "string-remove-823"
+      #t
+      (string=? "mn, tht sh my knw nmbr?"
+                (string-remove (lambda (c) (memv c (string->list "aeiou")))
+                               "And woman, that she may know number?"
+                               6)))
+
+
+(test "string-filter-824"
+      #t
+      (string=? "aaao"
+                (string-filter (lambda (c) (memv c (string->list "aeiou")))
+                               "What is number, that man may know it?"
+                               16 32)))
+
+
+(test "string-remove-825"
+      #t
+      (string=? "And woman, that sh may know"
+                (string-remove (lambda (c) (memv c (string->list "eiu")))
+                               "And woman, that she may know number?"
+                               0 28)))
+
+

--- a/tests/test-srfi.stk
+++ b/tests/test-srfi.stk
@@ -4791,6 +4791,15 @@
 (test "string-append! constant 3" "abcdef" (string-append! (string-copy str1) str2)) ;  second arg may be constant
 (test "string-append! constant 3" "xdef" (string-append! (string-copy "x") str2)) ;  second arg may be constant
 
+;; ----------------------------------------------------------------------
+;;  SRFI 141 ...
+;; ----------------------------------------------------------------------
+(test-subsection "SRFI 130 - Cursor-based string library")
+
+(require "srfi-130")
+
+(load "test-srfi-130.stk")
+
 
 ;; ----------------------------------------------------------------------
 ;;  SRFI 141 ...


### PR DESCRIPTION
Hello @egallesio !

The tests are huge, so I put them in a separate file.

SRFI-130 redefines some procedures from SRFI-13. I am not sure if those are supposed to  be different, but the tests fail unless I force the use of the new ones, so I did this:

```
(require "srfi-13")

(define-module SRFI-130

;;;;;;;;; code goes here

) ;; END OF DEFINE-MODULE
;;;; ======================================================================
(select-module STklos)

(define srfi-13:string-index string-index)
(define srfi-13:string-index-right string-index-right)
(define srfi-13:string-split string-split)
(define srfi-13:string-skip string-skip)
(define srfi-13:string-skip-right string-skip)

(import SRFI-130)

(define string-index (in-module SRFI-130 string-index))
(define string-index-right (in-module SRFI-130 string-index-right))
(define string-split (in-module SRFI-130 string-split))
(define string-skip (in-module SRFI-130 string-skip))
(define string-skip-right (in-module SRFI-130 string-skip-right))

(provide "srfi-130")
```

Is this ok?