### PR TITLE
Fix uppercase for "#F"

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -305,7 +305,7 @@ static SCM read_token(SCM port, int c, int case_significant)
       case '#': if (len > 1) {
                   if (len == 2) {
                     if (tok[1] == 't' || tok[1] == 'T') return STk_true;
-                    if (tok[1] == 'f' || tok[1] == 'f') return STk_false;
+                    if (tok[1] == 'f' || tok[1] == 'F') return STk_false;
                   }
                   if (tok[1] == ':')
                     return STk_makekey(tok+1);

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -55,6 +55,33 @@ b|)
 (test "(file-suffix.4" #f  (file-suffix "~/.profile"))
 
 ;;----------------------------------------------------------------------
+(test-subsection "Sharp syntax")
+
+(test "#t #T"
+      #t
+      (eq? #t #T))
+
+(test "#t #true"
+      #t
+      (eq? #t #true))
+
+(test "#f #F"
+      #t
+      (eq? #f #F))
+
+(test "f #false"
+      #t
+      (eq? #f #false))
+
+(test "#eof"
+      #t
+      (eof-object? #eof))
+
+(test "#void"
+      #t
+      (eq? #void (if #f 'WRONG)))
+
+;;----------------------------------------------------------------------
 (test-subsection "Docstrings and signatures")
 
 (import STKLOS-COMPILER)


### PR DESCRIPTION
STklos accepts `#T` and `#t`, but only `#f` (and not the uppercase `#F`); there
was a duplicate test for lowercase `#f`.

Also add tests for sharp syntax.