### PR TITLE
Add SRFI-207: String-notated bytevectors

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -132,6 +132,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-189.stk        \
           srfi-190.stk        \
           srfi-196.stk        \
+          srfi-207.stk        \
           tar.stk             \
           trace.stk
 
@@ -203,6 +204,7 @@ scheme_OBJS = compfile.ostk    \
           srfi-189.ostk        \
           srfi-190.ostk        \
           srfi-196.ostk        \
+          srfi-207.ostk        \
           tar.ostk             \
           trace.ostk
 

--- a/lib/srfi-207.stk
+++ b/lib/srfi-207.stk
@@ -1,0 +1,858 @@
+(require "srfi-9")
+(require "srfi-1")
+(require "srfi-13")
+(require "srfi-151")
+(require "srfi-158")
+
+(define-module SRFI-207
+  (import SRFI-1)
+  (import SRFI-13)
+  (import SRFI-151)
+  (import SRFI-158)
+  (export bytestring bytevector->hex-string bytestring->list
+          make-bytestring make-bytestring!
+          hex-string->bytevector bytevector->base64 base64->bytevector
+          make-bytestring-generator
+          bytestring-pad bytestring-pad-right bytestring-trim
+          bytestring-trim-right bytestring-trim-both bytestring-replace
+          bytestring-index bytestring-index-right bytestring-break
+          bytestring-span
+          bytestring>? bytestring<? bytestring<=? bytestring>=?
+          bytestring-error? bytestring-error-message bytestring-error-irritants
+          bytestring-join bytestring-split
+          read-textual-bytestring write-textual-bytestring
+          write-binary-bytestring)
+
+
+(define (vector-unfold f len)
+  (let ((res (make-vector len)))
+    (let lp ((i 0))
+      (cond ((= i len) res)
+            (else (vector-set! res i (f i))
+                  (lp (+ i 1)))))))
+
+(define (u8vector-for-each proc bvec)
+  (assume (procedure? proc))
+  (assume (bytevector? bvec))
+  (let ((len (bytevector-length bvec)))
+    (let lp ((i 0))
+      (cond ((= i len) (if #f #f))
+            (else
+             (proc (bytevector-u8-ref bvec i))
+             (lp (+ i 1)))))))
+
+(define (u8vector-unfold f len seed)
+  (let ((u8vec (make-bytevector len)))
+    (let lp ((i 0) (seed seed))
+      (unless (= i len)
+        (let-values (((b seed*) (f i seed)))
+          (bytevector-u8-set! u8vec i b)
+          (lp (+ i 1) seed*))))
+    u8vec))
+
+(define (u8-list->bytevector lis)
+  (let* ((len (length lis))
+         (bvec (make-bytevector len)))
+    (let lp ((i 0) (lis lis))
+      (cond ((null? lis) bvec)
+            (else (bytevector-u8-set! bvec i (car lis))
+                  (lp (+ i 1) (cdr lis)))))))
+
+(define (bytevector->u8-list bvec)
+  (list-tabulate (bytevector-length bvec)
+                 (lambda (i)
+                   (bytevector-u8-ref bvec i))))
+
+                     
+ 
+;; (define-record-type <bytestring-error>
+;;   (raw-bytestring-error message irritants)
+;;   bytestring-error?
+;;   (message bytestring-error-message)
+;;   (irritants bytestring-error-irritants))
+
+;; (define (bytestring-error message . irritants)
+;;   (raise (raw-bytestring-error message irritants)))
+
+
+
+
+(define &bytestring-error
+  (make-condition-type 'bytestring-error
+                       &condition
+                       '(message irritants)))
+
+(define (bytestring-error message . irritants)
+  (raise (make-condition &bytestring-error
+                         'message message
+                         'irritants irritants)))
+
+(define (bytestring-error? obj)
+  (and (condition? obj)
+       (condition-has-type? obj &bytestring-error))) 
+
+(define (bytestring-error-message c)
+  (condition-ref c 'messsage))
+
+(define (bytestring-error-irritants c)
+  (condition-ref c 'irritants))
+
+
+
+
+
+
+
+
+
+
+;;; Simple parser for string-notated bytevectors.
+
+(define (parse prefix)
+  (when prefix (consume-prefix))
+  (consume-quote)
+  (let lp ((c (read-char)))
+    (cond ((eof-object? c) (bytestring-error "unexpected EOF"))
+          ((char=? c #\") (if #f #f))  ; terminating quote
+          ((char=? c #\\)
+           (let ((c* (read-char)))
+             (cond ((eof-object? c*)
+                    (bytestring-error "incomplete escape sequence"))
+                   ((escape c*) =>
+                    (lambda (b)
+                      (write-u8 b)
+                      (lp (read-char))))
+                   (else (lp (read-char))))))
+          ((and (char>=? c #\space) (char<=? c #\~))
+           (write-u8 (char->integer c))
+           (lp (read-char)))
+          (else (bytestring-error "invalid character" c)))))
+
+(define (consume-quote)
+  (let ((c (read-char)))
+    (cond ((eof-object? c) (bytestring-error "unexpected EOF"))
+          ((char=? c #\") #t)
+          (else
+           (bytestring-error "invalid character (expected #\\\")" c)))))
+
+(define (consume-prefix)
+  (let ((s (read-string 3)))
+    (cond ((eof-object? s) (bytestring-error "unexpected EOF"))
+          ((string=? s "#u8") #t)
+          (else (bytestring-error "invalid bytestring prefix" s)))))
+
+(define (escape c)
+  (case c
+    ((#\a) 7)
+    ((#\b) 8)
+    ((#\t) 9)
+    ((#\n) 10)
+    ((#\r) 13)
+    ((#\") 34)
+    ((#\\) 92)
+    ((#\|) 124)
+    ((#\x) (parse-hex))
+    ((#\newline)
+     (skip-horizontal-whitespace)
+     #f)                              ; skip
+    (else
+     (cond ((char-whitespace? c)
+            (skip-horizontal-whitespace)
+            (skip-line-break)
+            #f)
+           (else (bytestring-error "invalid escaped character" c))))))
+
+(define (parse-hex)
+  (let* ((hex1 (read-char))
+         (hex2 (read-char)))
+    (when (or (eof-object? hex1) (eof-object? hex2))
+      (bytestring-error "incomplete hexadecimal sequence"))
+    (if (char=? hex2 #\;)
+        (or (string->number (string hex1) 16)
+            (bytestring-error "invalid hexadecimal sequence"))
+        (let ((term (read-char)))
+          (if (eqv? term #\;)
+              (or (string->number (string hex1 hex2) 16)
+                  (bytestring-error "invalid hexadecimal sequence"))
+              (bytestring-error
+               "overlong or unterminated hexadecimal sequence"))))))
+
+(define (skip-line-break)
+  (let ((c (read-char)))
+    (unless (eqv? #\newline c)
+      (bytestring-error "expected newline" c)))
+  (skip-horizontal-whitespace))
+
+(define (skip-horizontal-whitespace)
+  (let lp ((c (peek-char)))
+    (when (and (char-whitespace? c) (not (char=? c #\newline)))
+      (read-char)
+      (lp (peek-char)))))
+
+(define read-textual-bytestring
+  (case-lambda
+   ((prefix) (read-textual-bytestring prefix (current-input-port)))
+   ((prefix in)
+    (assume (boolean? prefix))
+    (call-with-port
+     (open-output-bytevector)
+     (lambda (out)
+       (parameterize ((current-input-port in)
+                      (current-output-port out))
+         (parse prefix)
+         (get-output-bytevector out)))))))
+
+
+
+
+;;;
+
+
+
+
+
+
+(define outside-char 99) ; luft-balloons
+(define pad-char 101)    ; dalmations
+
+(define (outside-char? x) (eqv? x outside-char))
+(define (pad-char? x) (eqv? x pad-char))
+
+(define (make-base64-decode-table digits)
+  (let ((extra-1 (char->integer (string-ref digits 0)))
+        (extra-2 (char->integer (string-ref digits 1))))
+    (vector-unfold
+     (lambda (i)
+       (cond ((and (>= i 48) (< i 58)) (+ i 4))   ; numbers
+             ((and (>= i 65) (< i 91)) (- i 65))  ; upper case letters
+             ((and (>= i 97) (< i 123)) (- i 71)) ; lower case letters
+             ((= i extra-1) 62)
+             ((= i extra-2) 63)
+             ((= i 61) pad-char)                  ; '='
+             (else outside-char)))
+     #x100)))
+
+(define (base64-decode-u8 table u8)
+  (vector-ref table u8))
+
+(define (make-base64-encode-table digits)
+  (vector-unfold
+   (lambda (i)
+     (cond ((< i 26) (+ i 65))  ; upper-case letters
+           ((< i 52) (+ i 71))  ; lower-case letters
+           ((< i 62) (- i 4))   ; numbers
+           ((= i 62) (char->integer (string-ref digits 0)))
+           ((= i 63) (char->integer (string-ref digits 1)))
+           (else (error "out of range"))))
+   64))
+
+;;;; Decoding
+
+(define (decode-base64-string src digits)
+  (let ((table (make-base64-decode-table digits)))
+    (call-with-port
+     (open-output-bytevector)
+     (lambda (out)
+       (decode-base64-to-port src out table)
+       (get-output-bytevector out)))))
+
+;; Loop through src, writing decoded base64 data to port in chunks
+;; of up to three bytes.
+(define (decode-base64-to-port src port table)
+  (let ((len (string-length src)))
+    (let lp ((i 0) (b1 outside-char) (b2 outside-char) (b3 outside-char))
+      (if (= i len)
+          (decode-base64-trailing port b1 b2 b3)
+          (let* ((c (string-ref src i))
+                 (b (base64-decode-u8 table (char->integer c))))
+            (cond ((pad-char? b) (decode-base64-trailing port b1 b2 b3))
+                  ((char-whitespace? c) (lp (+ i 1) b1 b2 b3))
+                  ((outside-char? b)
+                   (bytestring-error "invalid character in base64 string"
+                                     c
+                                     src))
+                  ((outside-char? b1) (lp (+ i 1) b b2 b3))
+                  ((outside-char? b2) (lp (+ i 1) b1 b b3))
+                  ((outside-char? b3) (lp (+ i 1) b1 b2 b))
+                  (else
+                   (write-u8 (bitwise-ior (arithmetic-shift b1 2)
+                                          (bit-field b2 4 6))
+                             port)
+                   (write-u8 (bitwise-ior
+                              (arithmetic-shift (bit-field b2 0 4) 4)
+                              (bit-field b3 2 6))
+                             port)
+                   (write-u8 (bitwise-ior
+                              (arithmetic-shift (bit-field b3 0 2) 6)
+                              b)
+                             port)
+                   (lp (+ i 1) outside-char outside-char outside-char))))))))
+
+;; Flush any trailing bits accumulated in the decode loop to the
+;; bytevector port `out', then return the finalized bytestring.
+(define (decode-base64-trailing out b1 b2 b3)
+  (cond ((outside-char? b1) #t)
+        ((outside-char? b2) (write-u8 (arithmetic-shift b1 2) out))
+        (else
+         (write-u8 (bitwise-ior (arithmetic-shift b1 2) (bit-field b2 4 6))
+                   out)
+         (unless (outside-char? b3)
+           (write-u8 (bitwise-ior (arithmetic-shift (bit-field b2 0 4) 4)
+                                  (bit-field b3 2 6))
+                     out)))))
+
+;;;; Encoding
+
+(define (base64-encode-bytevector bv digits)
+  (let* ((len (bytevector-length bv))
+         (quot (quotient len 3))
+         (rem (- len (* quot 3)))
+         (res-len (arithmetic-shift (+ quot (if (zero? rem) 0 1)) 2))
+         (res (make-bytevector res-len))
+         (table (make-base64-encode-table digits)))
+    (base64-encode-bytevector! bv 0 len res table)
+    res))
+
+(define (base64-encode-bytevector! bv start end res table)
+  (let ((limit (- end 2))
+        (enc (lambda (i) (vector-ref table i))))
+    (let lp ((i start) (j 0))
+      (if (>= i limit)
+          (case (- end i)
+            ((1)
+             (let ((b1 (bytevector-u8-ref bv i)))
+               (bytevector-u8-set! res j (enc (arithmetic-shift b1 -2)))
+               (bytevector-u8-set!
+                res
+                (+ j 1)
+                (enc (arithmetic-shift (bitwise-and #b11 b1) 4)))
+               (bytevector-u8-set! res (+ j 2) (char->integer #\=))
+               (bytevector-u8-set! res (+ j 3) (char->integer #\=))
+               (+ j 4)))
+            ((2)
+             (let ((b1 (bytevector-u8-ref bv i))
+                   (b2 (bytevector-u8-ref bv (+ i 1))))
+               (bytevector-u8-set! res j (enc (arithmetic-shift b1 -2)))
+               (bytevector-u8-set!
+                res
+                (+ j 1)
+                (enc (bitwise-ior
+                      (arithmetic-shift (bitwise-and #b11 b1) 4)
+                      (bit-field b2 4 8))))
+               (bytevector-u8-set!
+                res
+                (+ j 2)
+                (enc (arithmetic-shift (bit-field b2 0 4) 2)))
+               (bytevector-u8-set! res (+ j 3) (char->integer #\=))
+               (+ j 4)))
+            (else
+             j))
+          (let ((b1 (bytevector-u8-ref bv i))
+                (b2 (bytevector-u8-ref bv (+ i 1)))
+                (b3 (bytevector-u8-ref bv (+ i 2))))
+            (bytevector-u8-set! res j (enc (arithmetic-shift b1 -2)))
+            (bytevector-u8-set!
+             res
+             (+ j 1)
+             (enc (bitwise-ior
+                   (arithmetic-shift (bitwise-and #b11 b1) 4)
+                   (bit-field b2 4 8))))
+            (bytevector-u8-set!
+             res
+             (+ j 2)
+             (enc (bitwise-ior
+                   (arithmetic-shift (bit-field b2 0 4) 2)
+                   (bit-field b3 6 8))))
+            (bytevector-u8-set! res (+ j 3) (enc (bitwise-and #b111111 b3)))
+            (lp (+ i 3) (+ j 4)))))))
+
+
+
+
+
+;;;; Utility
+
+(define (exact-natural? x)
+  (and (integer? x) (exact-integer? x) (not (negative? x))))
+
+(define (u8-or-ascii-char? obj)
+  (or (and (char? obj) (char<=? obj #\delete))
+      (and (exact-natural? obj) (< obj 256))))
+
+(define (string-ascii? obj)
+  (and (string? obj)
+       (string-every (lambda (c) (char<=? c #\delete)) obj)
+       #t))
+
+(define (valid-bytestring-segment? obj)
+  (or (bytevector? obj)
+      (u8-or-ascii-char? obj)
+      (string-ascii? obj)))
+
+(define (%bytestring-null? bstring)
+  (zero? (bytevector-length bstring)))
+
+(define (%bytestring-last bstring)
+  (assume (not (%bytestring-null? bstring)) "empty bytestring")
+  (bytevector-u8-ref bstring (- (bytevector-length bstring) 1)))
+
+(define (negate pred)
+  (lambda (obj)
+    (not (pred obj))))
+
+;;;; Constructors
+
+(define (make-bytestring lis)
+  (assume (or (pair? lis) (null? lis)))
+  (call-with-port
+   (open-output-bytevector)
+   (lambda (out)
+     (for-each (lambda (seg) (%write-bytestring-segment seg out)) lis)
+     (get-output-bytevector out))))
+
+(define (make-bytestring! bvec at lis)
+  (assume (bytevector? bvec))
+  (assume (and (exact-natural? at)
+               (< at (bytevector-length bvec))))
+  (bytevector-copy! bvec at (make-bytestring lis)))
+
+(define (%write-bytestring-segment obj port)
+  ((cond ((and (exact-natural? obj) (< obj 256)) write-u8)
+         ((and (char? obj) (char<=? obj #\delete)) write-char-binary)
+         ((bytevector? obj) write-bytevector)
+         ((string-ascii? obj) write-string-binary)
+         (else
+          (bytestring-error "invalid bytestring element" obj)))
+   obj
+   port))
+
+;; If your Scheme allows binary ports to function as textual ports,
+;; get rid of this dance.
+(define (write-char-binary c port)
+  (write-u8 (char->integer c) port))
+
+(define (write-string-binary s port)
+  (string-for-each (lambda (c)
+                     (write-char-binary c port))
+                   s))
+
+(define (bytestring . args)
+  (if (null? args) (bytevector) (make-bytestring args)))
+
+;;;; Conversion
+
+;;; Hex string conversion
+
+;; Convert an unsigned integer n to a bytevector representing
+;; the base-256 big-endian form (the zero index holds the MSB).
+(define (integer->bytevector n)
+  (assume (and (integer? n) (not (negative? n))))
+  (if (zero? n)
+      (make-bytevector 1 0)
+      (u8-list->bytevector
+       (unfold-right zero?
+                     (lambda (n) (truncate-remainder n 256))
+                     (lambda (n) (truncate-quotient n 256))
+                     n))))
+
+(define (integer->hex-string n)
+  (cond ((number->string n 16) =>
+         (lambda (res)
+           (if (even? (string-length res))
+               res
+               (string-append "0" res))))
+        (else (bytestring-error "not an integer" n))))
+
+(define (bytevector->hex-string bv)
+  (assume (bytevector? bv))
+  (string-concatenate
+   (list-tabulate (bytevector-length bv)
+                  (lambda (i)
+                    (integer->hex-string (bytevector-u8-ref bv i))))))
+
+(define (hex-string->bytevector hex-str)
+  (assume (string? hex-str))
+  (let ((len (string-length hex-str)))
+    (unless (even? len)
+      (bytestring-error "incomplete hexadecimal string" hex-str))
+    (u8vector-unfold
+     (lambda (_ i)
+       (let* ((end (+ i 2))
+              (s (substring hex-str i end))
+              (n (string->number s 16)))
+         (if n
+             (values n end)
+             (bytestring-error "invalid hexadecimal sequence" s))))
+     (truncate-quotient len 2)
+     0)))
+
+(define bytevector->base64
+  (case-lambda
+    ((bvec) (bytevector->base64 bvec "+/"))
+    ((bvec digits)
+     (assume (bytevector? bvec))
+     (assume (string? digits))
+     (utf8->string (base64-encode-bytevector bvec digits)))))
+
+(define base64->bytevector
+  (case-lambda
+    ((base64-string) (base64->bytevector base64-string "+/"))
+    ((base64-string digits)
+     (assume (string? base64-string))
+     (assume (string? digits))
+     (decode-base64-string base64-string digits))))
+
+(define bytestring->list
+  (case-lambda
+    ((bstring) (bytestring->list bstring 0 (bytevector-length bstring)))
+    ((bstring start)
+     (bytestring->list bstring start (bytevector-length bstring)))
+    ((bstring start end)
+     (assume (bytevector? bstring))
+     (assume (and (exact-natural? start) (>= start 0))
+             "invalid start index"
+             start
+             bstring)
+     (assume (and (exact-natural? end) (<= end (bytevector-length bstring)))
+             "invalid end index"
+             end
+             bstring)
+     (assume (>= end start) "invalid indices" start end)
+     (unfold (lambda (i) (= i end))
+             (lambda (i)
+               (let ((b (bytevector-u8-ref bstring i)))
+                 (if (and (>= b #x20) (< b #x7f))
+                     (integer->char b)
+                     b)))
+             (lambda (i) (+ i 1))
+             start))))
+
+;; Lazily generate the bytestring constructed from objs.
+(define (make-bytestring-generator . objs)
+  (list->generator (flatten-bytestring-segments objs)))
+
+;; Convert and flatten chars and strings, and flatten bytevectors
+;; to yield a flat list of bytes.
+(define (flatten-bytestring-segments objs)
+  (fold-right
+   (lambda (x res)
+     (cond ((and (exact-natural? x) (< x 256)) (cons x res))
+           ((and (char? x) (char<=? x #\delete))
+            (cons (char->integer x) res))
+           ((bytevector? x)
+            (append (bytevector->u8-list x) res))
+           ((string-ascii? x)
+            (append (map char->integer (string->list x)) res))
+           (else
+            (bytestring-error "invalid bytestring segment" x))))
+   '()
+   objs))
+
+;;;; Selection
+
+(define (%bytestring-pad-left-or-right bstring len char-or-u8 right)
+  (assume (bytevector? bstring))
+  (assume (exact-natural? len))
+  (assume (u8-or-ascii-char? char-or-u8))
+  (let ((pad-len (- len (bytevector-length bstring)))
+        (pad-byte (if (char? char-or-u8)
+                      (char->integer char-or-u8)
+                      char-or-u8)))
+    (if (<= pad-len 0)
+        (bytevector-copy bstring)
+        (let ((padded (make-bytevector len pad-byte)))
+          (bytevector-copy! padded (if right 0 pad-len) bstring)
+          padded))))
+
+(define (bytestring-pad bstring len char-or-u8)
+  (%bytestring-pad-left-or-right bstring len char-or-u8 #f))
+
+(define (bytestring-pad-right bstring len char-or-u8)
+  (%bytestring-pad-left-or-right bstring len char-or-u8 #t))
+
+(define (bytestring-trim bstring pred)
+  (assume (bytevector? bstring))
+  (assume (procedure? pred))
+  (let ((new-start (bytestring-index bstring (negate pred))))
+    (if new-start
+        (bytevector-copy bstring new-start)
+        (bytevector))))
+
+(define (bytestring-trim-right bstring pred)
+  (assume (bytevector? bstring))
+  (assume (procedure? pred))
+  (cond ((bytestring-index-right bstring (negate pred)) =>
+         (lambda (end-1)
+           (bytevector-copy bstring 0 (+ 1 end-1))))
+        (else (bytevector))))
+
+(define (bytestring-trim-both bstring pred)
+  (assume (bytevector? bstring))
+  (assume (procedure? pred))
+  (let ((neg-pred (negate pred)))
+    (cond ((bytestring-index bstring neg-pred) =>
+           (lambda (start)
+             (bytevector-copy bstring
+                              start
+                              (+ (bytestring-index-right bstring neg-pred)
+                                 1))))
+          (else (bytevector)))))
+
+;;;; Replacement
+
+(define bytestring-replace
+  (case-lambda
+    ((bstring1 bstring2 start end)
+     (bytestring-replace bstring1
+                         bstring2
+                         start
+                         end
+                         0
+                         (bytevector-length bstring2)))
+    ((bstring1 bstring2 start1 end1 start2 end2)
+     (assume (bytevector? bstring1))
+     (assume (bytevector? bstring2))
+     (assume (and (exact-natural? start1) (>= start1 0) (<= start1 end1))
+             "invalid start index"
+             start1)
+     (assume (and (exact-natural? end1)
+                  (<= end1 (bytevector-length bstring1)))
+             "invalid end index"
+             bstring1)
+     (assume (and (exact-natural? start2) (>= start2 0) (<= start2 end2))
+             "invalid start index"
+             start2)
+     (assume (and (exact-natural? end2)
+                  (<= end2 (bytevector-length bstring2)))
+             "invalid end index"
+             bstring2)
+     (if (and (= start1 end1) (= start2 end2))
+         (bytevector-copy bstring1)    ; replace no bits with no bits
+         (let* ((b1-len (bytevector-length bstring1))
+                (sub-len (- end2 start2))
+                (new-len (+ sub-len (- b1-len (- end1 start1))))
+                (bs-new (make-bytevector new-len)))
+           (bytevector-copy! bs-new 0 bstring1 0 start1)
+           (bytevector-copy! bs-new start1 bstring2 start2 end2)
+           (when (< (+ start1 sub-len) new-len)
+             (bytevector-copy! bs-new (+ start1 sub-len) bstring1 end1 b1-len))
+           bs-new)))))
+
+;;;; Comparison
+
+(define (%bytestring-prefix-length bstring1 bstring2)
+  (let ((end (min (bytevector-length bstring1)
+                  (bytevector-length bstring2))))
+    (if (eqv? bstring1 bstring2)  ; fast path
+        end
+        (let lp ((i 0))
+          (if (or (>= i end)
+                  (not (= (bytevector-u8-ref bstring1 i)
+                          (bytevector-u8-ref bstring2 i))))
+              i
+              (lp (+ i 1)))))))
+
+;;; Primitive bytevector comparison functions.
+
+(define (%bytestring-compare bstring1 bstring2 res< res= res>)
+  (let ((len1 (bytevector-length bstring1))
+        (len2 (bytevector-length bstring2)))
+    (let ((match (%bytestring-prefix-length bstring1 bstring2)))
+      (if (= match len1)
+          (if (= match len2) res= res<)
+          (if (= match len2)
+              res>
+              (if (< (bytevector-u8-ref bstring1 match)
+                     (bytevector-u8-ref bstring2 match))
+                  res<
+                  res>))))))
+
+(define (bytestring<? bstring1 bstring2)
+  (assume (bytevector? bstring1))
+  (assume (bytevector? bstring2))
+  (and (not (eqv? bstring1 bstring2))
+       (%bytestring-compare bstring1 bstring2 #t #f #f)))
+
+(define (bytestring>? bstring1 bstring2)
+  (assume (bytevector? bstring1))
+  (assume (bytevector? bstring2))
+  (and (not (eqv? bstring1 bstring2))
+       (%bytestring-compare bstring1 bstring2 #f #f #t)))
+
+(define (bytestring<=? bstring1 bstring2)
+  (assume (bytevector? bstring1))
+  (assume (bytevector? bstring2))
+  (or (eqv? bstring1 bstring2)
+      (%bytestring-compare bstring1 bstring2 #t #t #f)))
+
+(define (bytestring>=? bstring1 bstring2)
+  (assume (bytevector? bstring1))
+  (assume (bytevector? bstring2))
+  (or (eqv? bstring1 bstring2)
+      (%bytestring-compare bstring1 bstring2 #f #t #t)))
+
+;;;; Searching
+
+(define bytestring-index
+  (case-lambda
+    ((bstring pred) (bytestring-index bstring pred 0))
+    ((bstring pred start)
+     (bytestring-index bstring pred start (bytevector-length bstring)))
+    ((bstring pred start end)
+     (assume (bytevector? bstring))
+     (assume (procedure? pred))
+     (assume (exact-natural? start))
+     (assume (exact-natural? end))
+     (let lp ((i start))
+       (and (< i end)
+            (if (pred (bytevector-u8-ref bstring i))
+                i
+                (lp (+ i 1))))))))
+
+(define bytestring-index-right
+  (case-lambda
+    ((bstring pred) (bytestring-index-right bstring pred 0))
+    ((bstring pred start)
+     (bytestring-index-right bstring pred start (bytevector-length bstring)))
+    ((bstring pred start end)
+     (assume (bytevector? bstring))
+     (assume (procedure? pred))
+     (assume (exact-natural? start))
+     (assume (exact-natural? end))
+     (let lp ((i (- end 1)))
+       (and (>= i start)
+            (if (pred (bytevector-u8-ref bstring i))
+                i
+                (lp (- i 1))))))))
+
+(define (bytestring-break bstring pred)
+  (assume (bytevector? bstring))
+  (assume (procedure? pred))
+  (cond ((bytestring-index bstring pred) =>
+         (lambda (len)
+           (values (bytevector-copy bstring 0 len)
+                   (bytevector-copy bstring len))))
+        (else (values (bytevector-copy bstring) (bytevector)))))
+
+(define (bytestring-span bstring pred)
+  (assume (bytevector? bstring))
+  (assume (procedure? pred))
+  (cond ((bytestring-index bstring (negate pred)) =>
+         (lambda (len)
+           (values (bytevector-copy bstring 0 len)
+                   (bytevector-copy bstring len))))
+        (else (values (bytevector-copy bstring) (bytevector)))))
+
+;;;; Joining & Splitting
+
+(define (%bytestring-join-nonempty bstrings delimiter grammar)
+  (call-with-port
+   (open-output-bytevector)
+   (lambda (out)
+     (when (eqv? grammar 'prefix) (write-bytevector delimiter out))
+     (write-bytevector (car bstrings) out)
+     (for-each (lambda (bstr)
+                 (write-bytevector delimiter out)
+                 (write-bytevector bstr out))
+               (cdr bstrings))
+     (when (eqv? grammar 'suffix) (write-bytevector delimiter out))
+     (get-output-bytevector out))))
+
+(define bytestring-join
+  (case-lambda
+    ((bstrings delimiter) (bytestring-join bstrings delimiter 'infix))
+    ((bstrings delimiter grammar)
+     (assume (or (pair? bstrings) (null? bstrings)))
+     (unless (memv grammar '(infix strict-infix prefix suffix))
+       (bytestring-error "invalid grammar" grammar))
+     (let ((delim-bstring (bytestring delimiter)))
+       (if (pair? bstrings)
+           (%bytestring-join-nonempty bstrings delim-bstring grammar)
+           (if (eqv? grammar 'strict-infix)
+               (bytestring-error "empty list with strict-infix grammar")
+               (bytevector)))))))
+
+(define (%find-right bstring byte end)
+  (bytestring-index-right bstring (lambda (b) (= b byte)) 0 end))
+
+(define (%bytestring-infix-split bstring delimiter)
+  (let lp ((token-end (bytevector-length bstring)) (split '()))
+    (cond ((< token-end 0) split)
+          ((%find-right bstring delimiter token-end) =>
+           (lambda (token-start-1)
+             (lp token-start-1
+                 (cons (bytevector-copy bstring (+ 1 token-start-1)
+                                                token-end)
+                       split))))
+          (else (cons (bytevector-copy bstring 0 token-end) split)))))
+
+(define (%trim-byte bstring byte)
+  (bytestring-trim bstring (lambda (b) (= b byte))))
+
+(define (%trim-right-byte bstring byte)
+  (bytestring-trim-right bstring (lambda (b) (= b byte))))
+
+(define (%bytestring-split/trim-outliers bstring delimiter grammar)
+  (let ((trimmed (case grammar
+                  ((infix strict-infix) bstring)
+                  ((prefix) (%trim-byte bstring delimiter))
+                  ((suffix) (%trim-right-byte bstring delimiter)))))
+    (%bytestring-infix-split trimmed delimiter)))
+
+(define bytestring-split
+  (case-lambda
+    ((bstring delimiter) (bytestring-split bstring delimiter 'infix))
+    ((bstring delimiter grammar)
+     (assume (bytevector? bstring))
+     (assume (u8-or-ascii-char? delimiter))
+     (unless (memv grammar '(infix strict-infix prefix suffix))
+       (bytestring-error "invalid grammar" grammar))
+     (if (%bytestring-null? bstring)
+         '()
+         (%bytestring-split/trim-outliers
+          bstring
+          (if (char? delimiter) (char->integer delimiter) delimiter)
+          grammar)))))
+
+;;;; I/O
+
+(define backslash-codepoints
+  '((7 . #\a) (8 . #\b) (9 . #\t) (10 . #\n) (13 . #\r)
+    (34 . #\") (92 . #\\) (124 . #\|)))
+
+(define write-textual-bytestring
+  (case-lambda
+   ((bstring)
+    (write-textual-bytestring bstring (current-output-port)))
+   ((bstring port)
+    (parameterize ((current-output-port port))
+      (write-string "#u8\"")
+      (u8vector-for-each
+       (lambda (b)
+         (cond ((assv b backslash-codepoints) =>
+                (lambda (p)
+                  (write-char #\\)
+                  (write-char (cdr p))))
+               ((and (>= b #x20) (<= b #x7e))
+                (write-char (integer->char b)))
+               (else
+                (write-string "\\x")
+                (write-string (number->string b 16))
+                (write-char #\;))))
+       bstring)
+      (write-char #\")))))
+
+(define (write-binary-bytestring port . args)
+  (assume (binary-port? port))
+  (for-each (lambda (arg)
+              (unless (valid-bytestring-segment? arg)
+                (bytestring-error "invalid bytestring element" arg)))
+            args)
+  (for-each (lambda (seg) (%write-bytestring-segment seg port)) args))
+
+) ;; END OF DEFINE-MODULE
+;;;; ======================================================================
+(select-module STklos)
+
+(import SRFI-207)
+(provide "srfi-207")

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -246,7 +246,7 @@
     ;; 204  Wright-Cartwright-Shinn Pattern Matcher (draft)
     ;; 205  POSIX Terminal Fundamentals (draft)
     ;; 206  Auxiliary Syntax Keywords (draft)
-    ;; 207  String-notated bytevectors
+    (207  "String-notated bytevectors" () "srfi-207")
     ;; 208  NaN procedures (draft)
     ;; 209  Enumerations and Enum Sets (draft)
     ;; 210  Procedures and Syntax for Multiple Values (draft)

--- a/tests/srfis/207.stk
+++ b/tests/srfis/207.stk
@@ -1,0 +1,404 @@
+
+;; ----------------------------------------------------------------------
+;;  SRFI 207 ...
+;; ----------------------------------------------------------------------
+;; (test-subsection "SRFI 207 - String-notated bytevectors")
+
+;; (require "srfi-207")
+
+;; counter for tests, used to generate the test name string
+;; -- jpellegrini
+(define *srfi-207-test-num* 1)
+
+;; Increments the test number and returns a string "srfi-207-num"
+(define (inc-test-num-str)
+  (let ((s (string-append "srfi-207-" (number->string *srfi-207-test-num*))))
+    (set! *srfi-207-test-num*
+          (+ 1 *srfi-207-test-num*))
+    s))
+
+;; Replaced check from the SRFI tests with a wrapper around STklos'
+;; test procedure.
+(define-syntax check
+  (syntax-rules (=>)
+    ((check expr => expected)
+     (test (inc-test-num-str) expected expr))))
+    
+;;;; Utility
+
+;; Changed the print-header procedure from SRFI-207
+;; tests --jpellegrini
+(define (print-header message) #void)
+;;  (newline)
+;;  (display (string-append ";;; " message))
+;;  (newline))
+
+
+
+
+
+
+(define-syntax constantly
+  (syntax-rules ()
+    ((_ obj) (lambda _ obj))))
+
+(define always (constantly #t))
+(define never (constantly #f))
+
+;; Returns a list of the values produced by expr.
+(define-syntax values~>list
+  (syntax-rules ()
+    ((_ expr)
+     (call-with-values (lambda () expr) list))))
+
+;; If expr causes an exception to be raised, return 'bytestring-error
+;; if the raised object satisfies bytestring-error?, and #f otherwise.
+(define-syntax catch-bytestring-error
+  (syntax-rules ()
+   ((_ expr)
+    (guard (condition ((bytestring-error? condition) 'bytestring-error)
+                      ((error? condition) 'bytestring-error)
+                      (else (condition-ref condition 'irritants)))
+      expr))))
+
+;; Testing shorthand for write-binary-bytestring.
+(define (%bytestring/IO . args)
+  (call-with-port (open-output-bytevector)
+                  (lambda (port)
+                    (apply write-binary-bytestring port args)
+                    (get-output-bytevector port))))
+
+;; Testing shorthands for SNB I/O.  Coverage library fans, eat your
+;; hearts out.
+(define (parse-SNB/prefix s)
+  (call-with-port (open-input-string s)
+                  (lambda (p)
+                    (read-textual-bytestring #t p))))
+
+(define (parse-SNB s)
+  (call-with-port (open-input-string s)
+                  (lambda (p)
+                    (read-textual-bytestring #f p))))
+
+(define (%bytestring->SNB bstring)
+  (call-with-port (open-output-string)
+                  (lambda (port)
+                    (write-textual-bytestring bstring port)
+                    (get-output-string port))))
+
+
+(define test-bstring (bytestring "lorem"))
+
+(define homer
+  (bytestring "The Man, O Muse, informe, who many a way / \
+               Wound in his wisedome to his wished stay;"))
+
+(define homer64
+  "VGhlIE1hbiwgTyBNdXNlLCBpbmZvcm1lLCB3aG8gbWFueSBhIHdheSAvIFdvd\
+   W5kIGluIGhpcyB3aXNlZG9tZSB0byBoaXMgd2lzaGVkIHN0YXk7")
+
+(define homer64-w
+  "VGhlIE1hb iwgTyBNdXNlL CBpbmZvcm1lL\nCB3aG8gbWF\tueSBhIH\rdheSAvIFdvd\
+   W5kIGluI   GhpcyB    3aXNlZ\t\t\nG9tZSB0b    yBoaXMgd\t2lzaGVkIHN0YXk7")
+
+;;;; Constructors
+
+(define (check-constructor)
+  (print-header "Running constructor tests...")
+  (check (bytestring "lo" #\r #x65 #u8(#x6d)) => test-bstring)
+  (check (bytestring)                         => (bytevector))
+
+  (check (catch-bytestring-error (bytestring #x100)) => 'bytestring-error)
+  (check (catch-bytestring-error (bytestring "λ"))   => 'bytestring-error))
+
+(define (check-conversion)
+  (print-header "Running conversion tests...")
+
+  (check (bytevector->hex-string test-bstring) => "6c6f72656d")
+  (check (hex-string->bytevector "6c6f72656d") => test-bstring)
+  (check (catch-bytestring-error
+          (hex-string->bytevector "c6f72656d"))
+   => 'bytestring-error)
+  (check (catch-bytestring-error
+          (hex-string->bytevector "6czf72656d"))
+   => 'bytestring-error)
+  (check (equal? (hex-string->bytevector (bytevector->hex-string homer))
+                 homer)
+   => #t)
+
+  (check (hex-string->bytevector (bytevector->hex-string #u8())) => #u8())
+
+  (check (bytevector->base64 test-bstring)             => "bG9yZW0=")
+  (check (bytevector->base64 #u8(#xff #xef #xff))      => "/+//")
+  (check (bytevector->base64 #u8(#xff #xef #xff) "*@") => "@*@@")
+  (check (equal? (bytevector->base64 homer) homer64)   => #t)
+  (check (bytevector->base64 #u8(1))                   => "AQ==")
+  (check (bytevector->base64 #u8())                    => "")
+  (check (base64->bytevector "bG9yZW0=")               => test-bstring)
+  (check (base64->bytevector "/+//")                   => #u8(#xff #xef #xff))
+  (check (base64->bytevector "@*@@" "*@")              => #u8(#xff #xef #xff))
+  (check (equal? (base64->bytevector homer64) homer)   => #t)
+  (check (equal? (base64->bytevector homer64-w) homer) => #t)
+  (check (base64->bytevector "AQ==")                   => #u8(1))
+  (check (base64->bytevector "")                       => #u8())
+  (check (base64->bytevector "\n\n\n==\t\r\n")         => #u8())
+  (check (catch-bytestring-error
+          (base64->bytevector "bG9@frob"))             => 'bytestring-error)
+
+  (check (bytestring->list #u8()) => '())
+  (check (bytestring->list (bytestring 70 82 0 66)) => '(#\F #\R 0 #\B))
+  (check (bytestring->list (bytestring "\a\t\t\n" 200)) => '(7 9 9 10 200))
+  (check (make-bytestring (bytestring->list test-bstring)) => test-bstring)
+  (check (make-bytestring (bytestring->list test-bstring 2))
+   => (bytestring "rem"))
+  (check (make-bytestring (bytestring->list test-bstring 1 3))
+   => (bytestring "or"))
+
+  (let ((bvec (make-bytevector 5)))
+    (check (begin
+            (make-bytestring! bvec 0 '(#x6c #x6f #x72 #x65 #x6d))
+            bvec)
+     => test-bstring))
+  (let ((bvec (make-bytevector 9 #x20)))
+    (check (begin (make-bytestring! bvec 2 '("lo" #\r #x65 #u8(#x6d)))
+                  bvec)
+     => (bytestring "  lorem  ")))
+  (check (catch-bytestring-error (make-bytestring '("λ")))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (make-bytestring '(#x100)))
+   => 'bytestring-error)
+
+  (let ((s (list-tabulate (bytevector-length test-bstring)
+                          (lambda (i)
+                            (bytevector-u8-ref test-bstring i)))))
+    (check (let ((g (make-bytestring-generator "lo" #\r #x65 #u8(#x6d))))
+             (generator->list g))
+     => s))
+  (check (catch-bytestring-error (make-bytestring-generator "λ" #\m #\u))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (make-bytestring-generator 89 90 300))
+   => 'bytestring-error)
+)
+
+(define (check-selection)
+  (print-header "Running selection tests...")
+
+  (check (bytestring-pad test-bstring (bytevector-length test-bstring) #x7a)
+   => test-bstring)
+  (check (utf8->string (bytestring-pad test-bstring 8 #x7a))
+   => "zzzlorem")
+  (check (equal? (bytestring-pad test-bstring 8 #\z)
+                 (bytestring-pad test-bstring 8 (char->integer #\z)))
+   => #t)
+  (check (bytestring-pad-right test-bstring
+                               (bytevector-length test-bstring)
+                               #x7a)
+   => test-bstring)
+  (check (utf8->string (bytestring-pad-right test-bstring 8 #x7a))
+   => "loremzzz")
+  (check (equal? (bytestring-pad-right test-bstring 8 #\z)
+                 (bytestring-pad-right test-bstring 8 (char->integer #\z)))
+   => #t)
+
+  (check (bytestring-trim test-bstring always) => #u8())
+  (check (bytestring-trim test-bstring never)  => test-bstring)
+  (check (bytestring-trim test-bstring (lambda (u8) (< u8 #x70)))
+   => #u8(#x72 #x65 #x6d))
+  (check (bytestring-trim-right test-bstring always) => #u8())
+  (check (bytestring-trim-right test-bstring never)  => test-bstring)
+  (check (bytestring-trim-right test-bstring (lambda (u8) (< u8 #x70)))
+   => #u8(#x6c #x6f #x72))
+  (check (bytestring-trim-both test-bstring always) => #u8())
+  (check (bytestring-trim-both test-bstring never)  => test-bstring)
+  (check (bytestring-trim-both test-bstring (lambda (u8) (< u8 #x70)))
+   => #u8(#x72)))
+
+(define (check-replacement)
+  (print-header "Running bytestring-replace tests...")
+
+  (check (bytestring-replace test-bstring (bytestring "mists") 1 5 1 5)
+   => (bytestring "lists"))
+  (check (bytestring-replace test-bstring (bytestring "faded") 2 5 1 5)
+   => (bytestring "loaded"))
+  (check (bytestring-replace (make-bytevector 5)
+                             test-bstring
+                             0
+                             (bytevector-length test-bstring))
+   => test-bstring)
+
+  (let ((bv1 (bytestring "food")) (bv2 (bytestring "od fo")))
+    (check (bytestring-replace bv1 bv2 2 2 0 5) => (bytestring "food food")))
+  (let ((bv1 (bytestring "food food")))
+    (check (bytestring-replace bv1 (bytevector) 2 7 0 0)
+     => (bytestring "food")))
+)
+
+(define (check-comparison)
+  (define short-bstring (bytestring "lore"))
+  (define long-bstring (bytestring "lorem "))
+  (define mixed-case-bstring (bytestring "loreM"))
+  (print-header "Runnng comparison tests...")
+
+  (check (bytestring<? test-bstring test-bstring)        => #f)
+  (check (bytestring<? short-bstring test-bstring)       => #t)
+  (check (bytestring<? mixed-case-bstring test-bstring)  => #t)
+  (check (bytestring>? test-bstring test-bstring)        => #f)
+  (check (bytestring>? test-bstring short-bstring)       => #t)
+  (check (bytestring>? test-bstring mixed-case-bstring)  => #t)
+  (check (bytestring<=? test-bstring test-bstring)       => #t)
+  (check (bytestring<=? short-bstring test-bstring)      => #t)
+  (check (bytestring<=? mixed-case-bstring test-bstring) => #t)
+  (check (bytestring<=? test-bstring mixed-case-bstring) => #f)
+  (check (bytestring<=? long-bstring test-bstring)       => #f)
+  (check (bytestring>=? test-bstring test-bstring)       => #t)
+  (check (bytestring>=? test-bstring short-bstring)      => #t)
+  (check (bytestring>=? test-bstring mixed-case-bstring) => #t)
+  (check (bytestring>=? mixed-case-bstring test-bstring) => #f)
+  (check (bytestring>=? short-bstring test-bstring)      => #f)
+)
+
+(define (check-searching)
+  (define (eq-r? b) (= b #x72))
+  (define (lt-r? b) (< b #x72))
+  (print-header "Running search tests...")
+
+  (check (bytestring-index test-bstring always)     => 0)
+  (check (bytestring-index test-bstring never)      => #f)
+  (check (bytestring-index test-bstring always 3)   => 3)
+  (check (bytestring-index test-bstring eq-r?) => 2)
+
+  (check (bytestring-index-right test-bstring always)     => 4)
+  (check (bytestring-index-right test-bstring never)      => #f)
+  (check (bytestring-index-right test-bstring always 3)   => 4)
+  (check (bytestring-index-right test-bstring eq-r?) => 2)
+
+  (check (values~>list (bytestring-span test-bstring always))
+   => (list test-bstring (bytevector)))
+  (check (values~>list (bytestring-span test-bstring never))
+   => (list (bytevector) test-bstring))
+  (check (values~>list (bytestring-span test-bstring lt-r?))
+   => (list (bytestring "lo") (bytestring "rem")))
+
+  (check (values~>list (bytestring-break test-bstring always))
+   => (list (bytevector) test-bstring))
+  (check (values~>list (bytestring-break test-bstring never))
+   => (list test-bstring (bytevector)))
+  (check (values~>list (bytestring-break test-bstring eq-r?))
+   => (list (bytestring "lo") (bytestring "rem"))))
+
+(define (check-join-and-split)
+  (define test-segments '(#u8(1) #u8(2) #u8(3)))
+  (print-header "Running joining and splitting tests...")
+
+  (check (bytestring-join test-segments #u8(0))         => #u8(1 0 2 0 3))
+  (check (bytestring-join test-segments #u8(0) 'prefix) => #u8(0 1 0 2 0 3))
+  (check (bytestring-join test-segments #u8(0) 'suffix) => #u8(1 0 2 0 3 0))
+  (check (bytestring-join '() #u8(0))                   => #u8())
+  (check (bytestring-join test-segments #\space)        => #u8(1 32 2 32 3))
+  (check (bytestring-join test-segments 0)              => #u8(1 0 2 0 3))
+  (check (bytestring-join test-segments "AB")
+   => #u8(1 65 66 2 65 66 3))
+  (check (bytestring-join test-segments #u8(7 8))       => #u8(1 7 8 2 7 8 3))
+  (check (catch-bytestring-error
+          (bytestring-join test-segments 300))          => 'bytestring-error)
+  (check (catch-bytestring-error
+          (bytestring-join test-segments "λ"))          => 'bytestring-error)
+  (check (catch-bytestring-error
+           (bytestring-join '() #u8(0) 'strict-infix))  => 'bytestring-error)
+  (check (catch-bytestring-error
+           (bytestring-join '() #u8(0) 'foofix))        => 'bytestring-error)
+
+  (check (bytestring-split #u8(1 0 2 0 3) 0 'infix)    => test-segments)
+  (check (bytestring-split #u8(0 1 0 2 0 3) 0 'prefix) => test-segments)
+  (check (bytestring-split #u8(1 0 2 0 3 0) 0 'suffix) => test-segments)
+  (check (bytestring-split #u8(0 0) 0)                 => '(#u8() #u8() #u8()))
+  (check (bytestring-split #u8() 0)                    => '())
+  (check (catch-bytestring-error
+           (bytestring-split #u8() 0 'foofix))         => 'bytestring-error))
+
+(define (check-io)
+  (print-header "Running I/O tests...")
+
+  (check (%bytestring/IO "lo" #\r #x65 #u8(#x6d)) => test-bstring)
+  (check (%bytestring/IO) => #u8())
+  (check (catch-bytestring-error (%bytestring/IO #x100)) => 'bytestring-error)
+  (check (catch-bytestring-error (%bytestring/IO "λ")) => 'bytestring-error)
+
+  ;;; read-textual-bytestring
+
+  (check (parse-SNB/prefix "#u8\"\"") => #u8())
+  (check (parse-SNB/prefix "#u8\"lorem\"") => test-bstring)
+  (check (parse-SNB/prefix "#u8\"\\xde;\\xad;\\xf0;\\x0d;\"")
+   => (bytevector #xde #xad #xf0 #x0d))
+  (check (parse-SNB/prefix "#u8\"\\\"\\\\\\a\\b\\t\\n\\r\\\|\"")
+   => (bytestring #\" #\\ #\alarm #\backspace #\tab #\newline #\return #\|))
+  (check (parse-SNB/prefix "#u8\"lor\\\n\te\\   \r\n\tm\"")
+   => test-bstring)
+  (check (parse-SNB "\"lorem\"") => test-bstring)
+
+  ;; Invalid SNB detection.
+  (check (catch-bytestring-error (parse-SNB/prefix "#u\"lorem\""))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8lorem\""))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"lorem"))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"lorem"))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"l\\orem\""))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"l\\    orem\""))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"l\\x6frem\""))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"l\\x6z;rem\""))
+   => 'bytestring-error)
+  (check (catch-bytestring-error (parse-SNB/prefix "#u8\"α equivalence\""))
+   => 'bytestring-error)
+
+  ;;; write-textual-bytestring
+
+  (check (%bytestring->SNB #u8()) => "#u8\"\"")
+  (check (%bytestring->SNB test-bstring) => "#u8\"lorem\"")
+  (check (%bytestring->SNB (bytevector #xde #xad #xbe #xef))
+   => "#u8\"\\xde;\\xad;\\xbe;\\xef;\"")
+  (check (%bytestring->SNB
+          (bytestring #\" #\\ #\alarm #\backspace #\tab #\newline #\return #\|))
+   => "#u8\"\\\"\\\\\\a\\b\\t\\n\\r\\\|\"")
+
+  (let ((test-bstrings
+         '(#u8(124 199 173 212 209 232 249 16 198 32 123 111 130 92 64 155)
+           #u8(50 133 193 27 177 105 10 186 61 149 177 105 96 70 223 190)
+           #u8(0 117 226 155 110 0 66 216 27 129 187 81 17 210 71 152)
+           #u8(123 31 159 25 100 135 246 47 249 137 243 241 45 241 240 221)
+           #u8(207 186 70 110 118 231 79 195 153 253 93 101 126 198 70 235)
+           #u8(138 176 92 152 208 107 28 236 198 254 111 37 241 116 191 206)
+           #u8(221 254 214 90 0 155 132 92 157 246 199 224 224 142 91 114)
+           #u8(228 216 233 80 142 15 158 54 5 85 174 101 111 75 126 209)
+           #u8(191 16 83 245 45 98 72 212 148 202 135 19 213 150 141 121)
+           #u8(41 169 182 96 47 184 16 116 196 251 243 93 81 162 175 140)
+           #u8(85 49 218 138 132 11 27 11 182 27 120 71 254 169 132 166)
+           #u8(89 216 175 23 97 10 237 112 208 195 112 80 198 154 241 254)
+           #u8(187 54 6 57 250 137 129 89 188 19 225 217 168 178 174 129)
+           #u8(88 164 89 40 175 194 108 56 12 124 109 96 148 149 119 109)
+           #u8(241 66 32 115 203 71 128 154 240 111 194 137 73 44 146 3)
+           #u8(177 185 177 233 18 14 178 106 110 109 222 147 111 157 216 208))))
+    (check
+     (every (lambda (bvec)
+              (equal? bvec (parse-SNB/prefix (%bytestring->SNB bvec))))
+            test-bstrings)
+    => #t))
+)
+
+(define (check-all-207)
+  (check-constructor)
+  (check-conversion)
+  (check-selection)
+  (check-replacement)
+  (check-comparison)
+  (check-searching)
+  (check-join-and-split)
+  (check-io))
+
+(check-all-207)
+


### PR DESCRIPTION
Hello @egallesio ! Here's SRFI-207...

* Changed read.c:

  - read_hex_sequence accepts a new argument, "use-utf_8",
    because string-notated bytevectors should *not* be read
    as UTF-8.
  - read_string accepts a new argument, "srfi_207".
    When it is true (nonzero), some escapes are forbidden.
    Also, at the end of the function, if it was called for
    reading a SRFI-207 string-notated bytevector, we *must not*
    interpret it as UTF-8, so we do not call STk_makestring,
    but do the same as it (STk_makestring) wold do,
    but without the UTF8 stuff.
  - maybe_read_uniform_vector: accept #u8" for reading SRFI-207
    bytevectors

* Tests from the reference implementation were used: some procedures
were adapted, and a wrapper macro was created, so the tests themselves
did not need to be changed.