### PR TITLE
Fix documentation of (gc) primitive

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -181,7 +181,7 @@ void STk_gc_init(void)
 <doc gc
  * (gc)
  *
- * Returns the address of the object |obj| as an integer.
+ * Force a garbage collection step.
 doc>
 */
 DEFINE_PRIMITIVE("gc", scheme_gc, subr0, (void))


### PR DESCRIPTION
(gc) actually performs a garbage collection step, calling libgc's GC_gcollect() function.