### PR TITLE
Use -q when calling STklos

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -315,7 +315,7 @@ srfi-134.ostk: srfi-158.ostk
 # If ./srfis.stk we must rebuild
 #     - srfis-data.scm (used by SRFI0 and features)
 srfis-data.scm: srfis.stk
-	$(STKLOS_BINARY) -l srfis.stk \
+	$(STKLOS_BINARY) -q -l srfis.stk \
 	                 -f ../utils/update-srfi-list.stk \
                      -- --internal > $@
 	(cd ..; $(MAKE) SUPPORTED-SRFIS)


### PR DESCRIPTION
Otherwise the presence of a `stklosrc` file may break compilation.
This would fix #168 

I have tested and it seems to work...