### PR TITLE
Add SRFI 170 -- POSIX API

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -86,6 +86,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-158: Generators and Accumulators
     - SRFI-161: Unifiable Boxes
     - SRFI-169: Underscores in numbers
+    - SRFI-170: POSIX API
     - SRFI-171: Transducers
     - SRFI-173: Hooks
     - SRFI-174: POSIX Timespecs

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -126,6 +126,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-156.stk        \
           srfi-158.stk        \
           srfi-161.stk        \
+          srfi-170.stk        \
           srfi-171.stk        \
           srfi-173.stk        \
           srfi-174.stk        \
@@ -140,7 +141,7 @@ SRC_STK = bigloo-support.stk  \
           tar.stk             \
           trace.stk
 
-SRC_C = srfi-175-impl.c
+SRC_C = srfi-170-impl.c srfi-175-impl.c
 
 scheme_OBJS = compfile.ostk     \
           bigmatch.ostk         \
@@ -202,6 +203,7 @@ scheme_OBJS = compfile.ostk     \
           srfi-156.ostk         \
           srfi-158.ostk         \
           srfi-161.ostk         \
+          srfi-170.ostk         \
           srfi-171.ostk         \
           srfi-173.ostk         \
           srfi-174.ostk         \
@@ -216,7 +218,7 @@ scheme_OBJS = compfile.ostk     \
           tar.ostk              \
           trace.ostk
 
-scheme_SOLIBS = srfi-175-impl.@SH_SUFFIX@
+scheme_SOLIBS =  srfi-170-impl.@SH_SUFFIX@ srfi-175-impl.@SH_SUFFIX@
 
 DOCDB	    = DOCDB
 

--- a/lib/srfi-170-impl.c
+++ b/lib/srfi-170-impl.c
@@ -1,0 +1,1127 @@
+/*
+ * srfi-170-impl.c   -- C part of SRFI-170: POSIX API
+ *
+ * Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ *
+ *           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+ *    Creation date: 09-Jan-2021 11:54
+ * Last file update: 13-Jan-2021 00:36 (jpellegrini)
+ */
+
+#include <limits.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
+#include <time.h>
+#include <grp.h>
+#include <pwd.h>
+
+#include "stklos.h"
+#include "struct.h"
+#include "fport.h"
+
+static SCM file_info_type, dir_info_type, user_info_type, group_info_type;
+static SCM posix_error;
+
+SCM time_type; /* FIXME */
+
+/* 3.1 Error handling */
+
+
+DEFINE_PRIMITIVE("posix-get-message-for-errno", posix_strerror, subr1, (SCM obj))
+{
+    if (!  ( INTP(obj) ||
+             (CONDP(obj) && 1)))
+        STk_error("bad integer or condition", obj);
+    int no;
+    char *errstr;
+    
+    
+    if (INTP(obj)) errstr = strerror(INT_VAL(obj));
+    else if (CONDP(obj)) {
+        /* don't presume that the message field in obj has been
+           set up properly. get the string from errno */
+        SCM e = STk_int_struct_ref(obj,STk_intern("errno"));
+        errstr = strerror(INT_VAL(e));
+    } else STk_error("impossible error!");
+    
+    return STk_Cstring2string(errstr);
+}
+
+
+DEFINE_PRIMITIVE("%get-posix-error-name", get_posix_error_name,subr1,(SCM n))
+{
+    /* FIXME: make names static, don't call STk_intern
+       every time a condition is rqaised... */
+
+    if (!INTP(n)) STk_error("bad integer ~S", n);
+    
+    SCM errname = STk_false;
+    int err_no = INT_VAL(n);
+    switch (err_no) {
+    case EACCES:
+        errname = STk_intern("EACCES");
+        break;
+    case EBADF:
+        errname = STk_intern("EBADF");
+        break;
+    case EBUSY:
+        errname = STk_intern("EBUSY");
+        break;
+    case EDQUOT:
+        errname = STk_intern("EDQUOT");
+        break;
+    case EEXIST:
+        errname = STk_intern("EEXIST");
+        break;
+    case EFAULT:
+        errname = STk_intern("EFAULT");
+        break;
+    case EINVAL:
+        errname = STk_intern("EINVAL");
+        break;
+    case EINTR:
+        errname = STk_intern("EINTR");
+        break;
+    case EIO:
+        errname = STk_intern("EIO");
+        break;
+    case ELOOP:
+        errname = STk_intern("ELOOP");
+        break;
+    case EMLINK:
+        errname = STk_intern("EMLINK");
+        break;
+    case ENAMETOOLONG:
+        errname = STk_intern("ENAMETOOLONG");
+        break;
+    case ENOENT:
+        errname = STk_intern("ENOENT");
+        break;
+    case ENOMEM:
+        errname = STk_intern("ENOMEM");
+        break;
+    case ENOSPC:
+        errname = STk_intern("ENOSPC");
+        break;
+    case ENOSYS:
+        errname = STk_intern("ENOSYS");
+        break;
+    case ENOTDIR:
+        errname = STk_intern("ENOTDIR");
+        break;
+    case ENOTEMPTY:
+        errname = STk_intern("ENOTEMPTY");
+        break;
+    case ENOTTY:
+        errname = STk_intern("ENOTTY");
+        break;
+    case EOVERFLOW:
+        errname = STk_intern("EOVERFLOW");
+        break;
+    case EPERM:
+        errname = STk_intern("EPERM");
+        break;
+    case EROFS:
+        errname = STk_intern("EROFS");
+        break;
+    case ESRCH:
+        errname = STk_intern("ESRCH");
+        break;
+    case EXDEV:
+        errname = STk_intern("EXDEV");
+        break;
+
+    default:
+        STk_error("POSIX unknown error ~S", n);
+        break;
+    }
+    return errname;
+}
+
+void STk_error_posix(int err,char *proc_name, SCM args)
+{
+    SCM err_no = MAKE_INT(err);
+    SCM errname = STk_get_posix_error_name(err_no);
+    char *msg = strerror(err);
+    SCM message = STk_Cstring2string(msg);
+    SCM procedure = STk_intern(proc_name);
+        
+    STk_raise_exception(STk_make_C_cond(posix_error,
+                                        5,
+                                        procedure,
+                                        args,
+                                        errname,
+                                        message,
+                                        err_no));
+}
+
+
+/* 3.2 I/O */
+
+DEFINE_PRIMITIVE("open-file",posix_open,vsubr, (int argc, SCM *argv))
+{
+    
+    if (argc < 3) STk_error("expects at least three arguments");
+    if (argc > 5) STk_error("expects at most five arguments");
+
+    SCM name  = *argv--;
+    SCM type  = *argv--;
+    SCM flags = *argv--;
+
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+    char *cname = STRING_CHARS(name);
+    
+    if (!INTP(flags)) STk_error("bad integer ~S", flags);
+    int cflags = INT_VAL(flags);
+
+    int cpermbits = 0666;
+    if (argc > 3) {
+        SCM permbits = *argv--;
+        if (!INTP(permbits)) STk_error("bad integer ~S", permbits);
+        cpermbits = INT_VAL(permbits);
+    }
+    
+    if (argc > 4) {
+        // SCM bufmode = *argv--;
+        STk_error("setting buffering mode not supported");
+    }
+    
+    char *mode;
+    int pflags; /* int? */
+    if      (STk_eqv(type, STk_intern("binary-input")) == STk_true)
+    {
+        mode = "r";
+        pflags = PORT_BINARY|PORT_READ;
+        cflags |= O_RDONLY;
+    }
+    else if (STk_eqv(type, STk_intern("textual-input")) == STk_true)
+    {
+        mode = "r";
+        pflags = PORT_TEXTUAL|PORT_READ;
+        cflags |= O_RDONLY;
+    }
+    else if (STk_eqv(type, STk_intern("binary-output")) == STk_true)
+    {
+        mode = "a";
+        pflags = PORT_BINARY|PORT_WRITE;
+        cflags |= O_WRONLY;
+    }
+    else if (STk_eqv(type, STk_intern("textual-output")) == STk_true)
+    {
+        mode = "a";
+        pflags = PORT_TEXTUAL|PORT_WRITE;
+        cflags |= O_WRONLY;
+    }
+    else if (STk_eqv(type, STk_intern("binary-input/output")) == STk_true)
+    {
+        mode = "r+";
+        pflags = PORT_BINARY|PORT_RW;
+        cflags |= O_RDWR;
+    }
+    else
+        STk_error("bad port type ~S", type);
+
+    int fd = open(cname, cflags, cpermbits);
+    if (fd == -1) STk_error_posix(errno,"open-file",STk_argv2list(argc,argv));
+
+
+    FILE *f = fdopen(fd, mode);            
+    SCM port = STk_fd2scheme_port (fd,mode,cname);
+    if (port == NULL) STk_error_posix(errno,"open-file",STk_argv2list(argc,argv));
+    PORT_FLAGS(port) = PORT_IS_FILE | pflags;
+    return port;
+}
+
+DEFINE_PRIMITIVE("fd->port",posix_fd_port,subr23,(SCM fd, SCM type, SCM bufmode))
+{
+    /* FIXME: we ignore bufmode */
+
+
+    if (!bufmode) bufmode = STk_false;
+    
+    char *cname = malloc(25);
+    snprintf(cname,24,"fd->port(%ld)",INT_VAL(fd));
+    
+    char *mode;
+    
+    int flags; /* "int"? */
+    
+    if      (STk_eqv(type, STk_intern("binary-input")) == STk_true)   { mode = "r"; flags = PORT_BINARY|PORT_READ;}
+    else if (STk_eqv(type, STk_intern("textual-input")) == STk_true)  { mode = "r"; flags = PORT_TEXTUAL|PORT_READ;}
+    else if (STk_eqv(type, STk_intern("binary-output")) == STk_true)  { mode = "a"; flags = PORT_BINARY|PORT_WRITE;}
+    else if (STk_eqv(type, STk_intern("textual-output")) == STk_true) { mode = "a"; flags = PORT_TEXTUAL|PORT_WRITE;}
+    else if (STk_eqv(type, STk_intern("binary-input/output")) == STk_true) { mode = "r+"; flags = PORT_BINARY|PORT_RW;}
+    else STk_error("bad port type ~S", type);
+
+    SCM port = STk_fd2scheme_port (INT_VAL(fd),mode,cname);
+    if (port == NULL) STk_error_posix(errno,"fd->port",LIST3(fd,type,bufmode));
+    PORT_FLAGS(port) = flags;
+    return port;
+}
+
+/* 3.3 File System */
+
+
+DEFINE_PRIMITIVE("create-directory", posix_mkdir, subr12, (SCM name, SCM bits))
+{
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+
+    int cbits;
+    if (bits) {
+        if (!INTP(bits)) STk_error("bad integer ~S", bits); /* FIXME: positive? */
+        cbits = INT_VAL(bits);
+    } 
+    else {
+        bits = STk_false; /* to include in error reporting */
+        cbits = 0775;
+    }
+    
+    char *cname = STRING_CHARS(name);
+    int e = mkdir(cname,cbits);
+    
+    if (e != 0) STk_error_posix(errno,"create-directory",LIST2(name,bits));
+    
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("create-fifo", posix_mkfifo, subr12, (SCM name, SCM bits))
+{
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+        int cbits;
+    if (bits) {
+        if (!INTP(bits)) STk_error("bad integer ~S", bits); /* FIXME: positive? */
+    } 
+    else {
+        bits = STk_false; /* to include in error reporting */
+        cbits = 0664;
+    }
+
+    char *cname = STRING_CHARS(name);
+    cbits = INT_VAL(bits);
+
+    int e = mkfifo(cname,cbits);
+    
+    if (e != 0) STk_error_posix(errno,"create-fifo", LIST2(name,bits));
+    
+    return STk_void;
+}
+
+
+
+DEFINE_PRIMITIVE("create-hard-link", posix_link, subr2, (SCM old, SCM new))
+{
+    if (!STRINGP(old)) STk_error("bad string ~S", old);
+    if (!STRINGP(new)) STk_error("bad string ~S", new);
+
+    char *oldname = STRING_CHARS(old);
+    char *newname = STRING_CHARS(new);
+
+    int e = link(oldname,newname);
+    
+    if (e != 0) STk_error_posix(errno,"create-hard-link",LIST2(old,new));
+    
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("create-symlink", posix_symlink, subr2, (SCM old, SCM new))
+{
+    if (!STRINGP(old)) STk_error("bad string ~S", old);
+    if (!STRINGP(new)) STk_error("bad string ~S", new);
+
+    char *oldname = STRING_CHARS(old);
+    char *newname = STRING_CHARS(new);
+
+    int e = symlink(oldname,newname);
+    
+    if (e != 0) STk_error_posix(errno,"create-symlink",LIST2(old,new));
+    
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("read-symlink", posix_readlink, subr1, (SCM name))
+{
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+
+    struct stat sb;
+    char *cname = STRING_CHARS(name);
+
+    int e = lstat(cname, &sb);
+
+    if (e) STk_error_posix(errno,"read-symlink",LIST1(name));
+
+    /* SRFI-170 requires us to error based on errno.
+       When a pathname exists but is not a link, readlink will
+       set errno to EINVAL.
+       The following would be more informative, but we stick to the SRFI.
+       
+      if ((sb.st_mode & S_IFMT) != S_IFLNK) STk_error("bad symlink ~S", name);
+    */
+
+    int bsize = sb.st_size+1;
+
+    /* FROM MANPAGE OF readlink:
+       Some magic symlinks under (for example) /proc and /sys
+       report 'st_size' as zero. In that case, take PATH_MAX as
+       a "good enough" estimate. */
+    if  (sb.st_size == 0)
+        bsize = PATH_MAX;
+
+    char *buf = malloc(bsize);
+    if (buf == NULL) STk_error("cannot allocate memory for symlink resolved name ~S", name);
+
+    e = readlink(cname, buf, bsize);
+    
+    /* if (e == bsize) printf("buffer was truncated\n");fflush(stdout); */
+    if (e == -1) STk_error_posix(errno,"read-symlink",LIST1(name));
+
+    /* readlink does not append the trailing zero! */
+    buf[e]=0;
+    
+    return STk_Cstring2string(buf);
+}
+
+DEFINE_PRIMITIVE("rename-file", posix_rename,subr2, (SCM old, SCM new))
+{
+    if (!STRINGP(old)) STk_error("bad string ~S", old);
+    if (!STRINGP(new)) STk_error("bad string ~S", new);
+    char *cold = STRING_CHARS(old);
+    char *cnew = STRING_CHARS(new);
+    int e = rename(cold,cnew);
+
+    if (e != 0)  STk_error_posix(errno,"rename-file",LIST2(old,new));
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("delete-directory", posix_rmdir,subr1, (SCM dir))
+{
+    if (!STRINGP(dir)) STk_error("bad string ~S", dir);
+    char *cdir = STRING_CHARS(dir);
+    int e = rmdir(cdir);
+    if (e != 0) STk_error_posix(errno,"delete-directory",LIST1(dir));
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("truncate-file", posix_truncate, subr2, (SCM p, SCM length))
+{
+    int e;
+     
+    if (STRINGP(p)) { /* it's a path */
+        e = truncate(STRING_CHARS(p), INT_VAL(length));
+    } else if (FPORTP(p)) { /* it's a port */
+        e = ftruncate(PORT_FD(PORT_STREAM(p)), INT_VAL(length));
+    } else STk_error("bad string or port ~S", p);
+
+    if (e != 0) STk_error_posix(errno,"truncate-file",LIST2(p,length));
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("file-info", posix_stat, subr2, (SCM p, SCM follow))
+{
+    struct stat st;
+    int e;
+
+    errno = 0;
+    if (STRINGP(p)) { /* it's a path */
+        if (!BOOLEANP(follow)) STk_error("bad boolean ~S",follow);
+        if (follow == STk_true)
+            e = stat(STRING_CHARS(p), &st);
+        else
+            e = lstat(STRING_CHARS(p), &st);
+    } else if (FPORTP(p)) { /* it's a port */
+        e = fstat(PORT_FD(PORT_STREAM(p)), &st);
+    } else STk_error("bad string or port ~S", p);
+
+    if (e == -1) STk_error_posix(errno,"file-info",LIST2(p,follow));
+    else {
+        SCM ats[3]; /* atime */
+        ats[2] = time_type;
+        ats[1] = MAKE_INT(st.st_atim.tv_sec);
+        ats[0] = MAKE_INT(st.st_atim.tv_nsec);
+        
+        SCM mts[3]; /* mtime */
+        mts[2] = time_type;
+        mts[1] = MAKE_INT(st.st_mtim.tv_sec);
+        mts[0] = MAKE_INT(st.st_mtim.tv_nsec);
+        
+        SCM cts[3]; /* ctime */
+        cts[2] = time_type;
+        cts[1] = MAKE_INT(st.st_ctim.tv_sec);
+        cts[0] = MAKE_INT(st.st_ctim.tv_nsec);
+
+        SCM argv[17];
+        argv[16] = file_info_type;
+        argv[15] = MAKE_INT(st.st_dev);
+        argv[14] = MAKE_INT(st.st_ino);
+        argv[13] = MAKE_INT(st.st_mode);
+        argv[12] = MAKE_INT(st.st_nlink);
+        argv[11] = MAKE_INT(st.st_uid);
+        argv[10] = MAKE_INT(st.st_gid);
+        argv[9]  = MAKE_INT(st.st_dev);
+        argv[8]  = MAKE_INT(st.st_size);
+        argv[7]  = MAKE_INT(st.st_blksize);
+        argv[6]  = MAKE_INT(st.st_blocks);
+        argv[5]  = MAKE_INT(st.st_atim.tv_sec);
+        argv[4]  = MAKE_INT(st.st_mtim.tv_sec);
+        argv[3]  = MAKE_INT(st.st_ctim.tv_sec);
+        argv[2]  = STk_make_struct(3, &ats[2]);
+        argv[1]  = STk_make_struct(3, &mts[2]);
+        argv[0]  = STk_make_struct(3, &cts[2]);
+        return STk_make_struct(17, &argv[16]);
+    }
+    return STk_false; /* neer reached */
+}
+
+void check_file_info(SCM info) {
+    if (!STRUCTP(info)) STk_error("bad structure", info);
+    if (STRUCT_TYPE(info) != file_info_type)
+        STk_error("bad file-info structure", info);
+}
+
+
+
+DEFINE_PRIMITIVE("file-info-directory?",posix_isdir,subr1,(SCM info, SCM mode))
+{
+    check_file_info(info);
+    if (INTP(mode)) STk_error("bad integer ~S", mode);
+    SCM m = STk_int_struct_ref(info,STk_intern("mode"));
+    return MAKE_BOOLEAN(S_ISDIR(INT_VAL(m)));
+}
+
+DEFINE_PRIMITIVE("file-info-fifo?",posix_isfifo,subr1,(SCM info, SCM mode))
+{
+    check_file_info(info);
+    if (INTP(mode)) STk_error("bad integer ~S", mode);
+    SCM m = STk_int_struct_ref(info,STk_intern("mode"));
+    return MAKE_BOOLEAN(S_ISFIFO(INT_VAL(m)));
+}
+
+DEFINE_PRIMITIVE("file-info-symlink?",posix_issymlink,subr1,(SCM info, SCM mode))
+{
+    check_file_info(info);
+    if (INTP(mode)) STk_error("bad integer ~S", mode);
+    SCM m = STk_int_struct_ref(info,STk_intern("mode"));
+    return MAKE_BOOLEAN(S_ISLNK(INT_VAL(m)));
+}
+
+DEFINE_PRIMITIVE("file-info-regular?",posix_isregular,subr1,(SCM info, SCM mode))
+{
+    check_file_info(info);
+    if (INTP(mode)) STk_error("bad integer ~S", mode);
+    SCM m = STk_int_struct_ref(info,STk_intern("mode"));
+    return MAKE_BOOLEAN(S_ISREG(INT_VAL(m)));
+}
+
+DEFINE_PRIMITIVE("file-info-socket?",posix_issocket,subr1,(SCM info, SCM mode))
+{
+    check_file_info(info);
+    if (INTP(mode)) STk_error("bad integer ~S", mode);
+    SCM m = STk_int_struct_ref(info,STk_intern("mode"));
+    return MAKE_BOOLEAN(S_ISFIFO(INT_VAL(m)));
+}
+DEFINE_PRIMITIVE("file-info-device?",posix_isdevice,subr1,(SCM info, SCM mode))
+{
+    check_file_info(info);
+    if (INTP(mode)) STk_error("bad integer ~S", mode);
+    SCM m = STk_int_struct_ref(info,STk_intern("mode"));
+    int v = INT_VAL(m);
+    return MAKE_BOOLEAN(S_ISCHR(v)||S_ISBLK(v));
+}
+
+
+
+
+DEFINE_PRIMITIVE("set-file-mode", posix_chmod, subr2, (SCM name, SCM bits) )
+{
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+    if (!INTP(bits)) STk_error("bad integer ~S", bits);
+
+    int e = chmod(STRING_CHARS(name), INT_VAL(bits));
+
+    if (e == -1) STk_error_posix(errno,"set-file-mode",LIST2(name,bits));
+    
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("%mkstemp", posix_mkstemp, subr1, (SCM prefix) )
+{
+    if (!STRINGP(prefix)) STk_error("bad string ~S", prefix); /* shouldn't happen */
+
+    /* prefix will be mutated! */
+    int fd = mkstemp(STRING_CHARS(prefix));
+    if (fd == -1) STk_error_posix(errno,"%mkstemp",LIST1(prefix));
+    return prefix;
+}
+
+DEFINE_PRIMITIVE("%set-file-owner", posix_chown, subr3, (SCM name, SCM uid, SCM gid) )
+{
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+    if (!INTP(uid)) STk_error("bad integer (uid) ~S", uid);
+    if (!INTP(gid)) STk_error("bad integer (gid) ~S", gid);
+
+    int e = chown(STRING_CHARS(name),
+                  INT_VAL(uid),
+                  INT_VAL(gid));
+
+    if (e == -1) STk_error_posix(errno,"set-file-owner",LIST3(name,uid,gid));
+    
+    return STk_void;
+}
+
+
+DEFINE_PRIMITIVE("set-file-times",posix_utimensat, vsubr, (int argc, SCM *argv))
+{
+    /* FIXME: this implementation seems overly complicated. There must be easier
+       ways to get it done. */
+    if ((argc == 0) || (argc == 2) || (argc > 3))
+        STk_error("expects exactly one or three arguments", STk_false);
+    SCM name = *argv--;
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+
+    char *cname = STRING_CHARS(name);
+    
+    SCM time1;
+    SCM time2;
+    time_t sec1;
+    long   nsec1;
+    time_t sec2;
+    long   nsec2;
+
+
+    if (argc==1) {
+        nsec1 = UTIME_NOW;
+        nsec2 = UTIME_NOW;
+    } else {
+        SCM time1 = *argv--;
+        SCM time2 = *argv--;
+       
+        if (SYMBOLP(time1)) {
+            if      (STk_eqv(time1, STk_intern("time/now")) == STk_true)       nsec1 = UTIME_NOW;
+            else if (STk_eqv(time1, STk_intern("time/unchanged")) == STk_true) nsec1 = UTIME_OMIT;
+            else STk_error("bad argument ~S",time1);
+        } else {
+            if (!STRUCTP(time1)) STk_error("bad structure ~S",time1);
+            if (STRUCT_TYPE(time1) != time_type) STk_error("bad time structure ~S",time1);
+            sec1  = INT_VAL(STk_int_struct_ref(time1,STk_intern("second")));
+            nsec1 = INT_VAL(STk_int_struct_ref(time1,STk_intern("nanosecond")));
+        }
+        
+        if (SYMBOLP(time2)) {
+            if      (STk_eqv(time2, STk_intern("time/now")) == STk_true)       nsec2 = UTIME_NOW;
+            else if (STk_eqv(time2, STk_intern("time/unchanged")) == STk_true) nsec2 = UTIME_OMIT;
+            else STk_error("bad argument ~S",time2);
+        } else {
+            if (!STRUCTP(time1)) STk_error("bad structure ~S",time2);
+            if (STRUCT_TYPE(time2) != time_type) STk_error("bad time structure ~S",time2);
+            sec2  = INT_VAL(STk_int_struct_ref(time2,STk_intern("second")));
+            nsec2 = INT_VAL(STk_int_struct_ref(time2,STk_intern("nanosecond")));
+        }
+    }
+    
+    struct timespec t[2];
+    t[0].tv_sec  = sec1;
+    t[0].tv_nsec = nsec1;
+    t[1].tv_sec  = sec2;
+    t[1].tv_nsec = nsec2;
+    
+    int e = utimensat(AT_FDCWD,cname, t, 0);
+
+    if (e == -1) STk_error_posix(errno,"set-file-times",STk_argv2list(argc,argv));
+
+    return STk_void;
+}
+
+
+
+DEFINE_PRIMITIVE("open-directory", posix_opendir, subr12, (SCM name, SCM dot) )
+{
+    if (!STRINGP(name)) STk_error("bad string ~S", name);
+    if (!dot) dot = STk_false;
+    else if (!BOOLEANP(dot)) STk_error("bad boolean ~S", dot);
+    
+    DIR *d = opendir(STRING_CHARS(name));
+    if (d == 0) STk_error_posix(errno,"open-directory",LIST2(name,dot));
+
+    SCM obj[3];
+    obj[2] = dir_info_type;
+    obj[1] = d;
+    obj[0] = dot;
+    return STk_make_struct(3,&obj[2]);
+}
+
+DEFINE_PRIMITIVE("read-directory", posix_readdir, subr1, (SCM dir) )
+{
+    if (!STRUCTP(dir)) STk_error("bad structure", STk_false);
+    if (STRUCT_TYPE(dir) != dir_info_type)
+        STk_error("bad directory structure", STk_false);
+    
+    DIR  *d = STk_int_struct_ref(dir,STk_intern("dir-object"));
+    SCM dot = STk_int_struct_ref(dir,STk_intern("dot-files"));
+
+    errno = 0;
+    struct dirent *e = readdir(d);
+    if (e == 0) {
+        if (errno !=0) STk_error_posix(errno,"read-directory",LIST1(dir));
+        else return STk_eof;
+    }
+    while (!strcmp(e->d_name,".")  ||
+           !strcmp(e->d_name,"..") ||
+           (dot == STk_false && !strncmp(e->d_name,".",1))) {
+            e = readdir(d);
+            if (e == 0) {
+                if (errno !=0) STk_error_posix(errno,"read-directory",LIST1(dir));
+                else return STk_eof;
+            }
+        }
+    return STk_Cstring2string(e->d_name);
+}
+
+DEFINE_PRIMITIVE("close-directory", posix_closedir, subr1, (SCM dir) )
+{
+    if (!STRUCTP(dir)) STk_error("bad structure", STk_false);
+    if (STRUCT_TYPE(dir) != dir_info_type)
+        STk_error("bad directory structure", STk_false);
+    DIR  *d = STk_int_struct_ref(dir,STk_intern("dir-object"));
+    int e = closedir(d);
+    if (e != 0) STk_error_posix(errno,"close-directory",LIST1(dir));
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("real-path", posix_realpath, subr1, (SCM p) )
+{
+    char* pa;
+    char* rpath = malloc(PATH_MAX);
+    
+    if (!STRINGP(p)) STk_error("bad string ~S", p);
+    
+    pa = STRING_CHARS(p);
+
+    /* I have tried "rpath = realpath(pa,NULL)", as per the manpage
+       (man 3 realpath) but it would always return NULL and set errno
+       to 22. Giving realpath an allocated buffer seems to work.
+       -- jpellegrini */
+    rpath = realpath(pa, rpath);
+    
+    if (rpath == 0) {
+        STk_error_posix(errno,"real-path",LIST1(p));
+        return STk_void; /* never reached */
+    } else {
+        int len = strlen(rpath);
+        rpath=realloc(rpath,len+1);
+        return STk_makestring(len, rpath);
+    }
+}
+
+DEFINE_PRIMITIVE("file-space", posix_statvfs, subr1, (SCM p))
+{
+    int e;
+    struct statvfs st;
+
+    /* We do not accept non-file ports as aspecial case (as Gauche
+       seems to do, for example). If the behavior of POSIX is to
+       return an EBADF error when passed std{in,out,err}, then we
+       mimic that. */
+    
+    if (STRINGP(p)) { /* it's a path */
+        e = statvfs(STRING_CHARS(p), &st);
+    } else if (FPORTP(p)) { /* it's a port */
+        e = fstatvfs(PORT_FD(PORT_STREAM(p)), &st);
+    } else STk_error("bad string or port ~S", p);
+
+    if (e != 0) STk_error_posix(errno,"file-space",LIST1(p));
+
+    /* We first make Scheme objects, then multiply,
+       in order to avoid a possible overflow. */
+    return STk_mul2(MAKE_INT(st.f_bsize),MAKE_INT(st.f_bfree));
+}
+
+/* 3.5 Process state */
+
+DEFINE_PRIMITIVE("umask", posix_umask, subr0, (void))
+{
+    mode_t u = umask(0);
+    umask(u);
+    return MAKE_INT(u);
+}
+
+DEFINE_PRIMITIVE("set-umask!", posix_set_umask, subr1, (SCM u))
+{
+    if (!INTP(u)) STk_error("Bad integer ~S", u);
+    umask(INT_VAL(u));
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("current-directory", posix_getcwd, subr0, (void))
+{
+  char buf[MAX_PATH_LENGTH], *s;
+  s = getcwd(buf, MAX_PATH_LENGTH);
+  if (!s) STk_error_posix(errno,"current-directory",STk_nil);
+  return STk_Cstring2string(buf);
+}
+
+DEFINE_PRIMITIVE("set-current-directory!", posix_chdir, subr1, (SCM dir))
+{
+    if (!STRINGP(dir)) STk_error("bad string ~S", dir);
+    int e = chdir(STRING_CHARS(dir));
+    if (e != 0) STk_error_posix(errno,"set-current-directory!",LIST1(dir));
+    return STk_void;
+}
+
+
+DEFINE_PRIMITIVE("nice", posix_nice, subr01, (SCM delta))
+{
+    int d = delta? INT_VAL(delta) : 1;
+    int new_delta = nice(d);
+    if (new_delta == -1)  STk_error_posix(errno,"nice", LIST1(delta));
+    return MAKE_INT(new_delta);
+}
+
+
+DEFINE_PRIMITIVE("user-uid", posix_getuid, subr0, (void))
+{
+    /* getuid is always successful, don't check for errors */
+    uid_t u = getuid();
+    
+    /* we *suppose* uid_t is always integer */
+    return MAKE_INT(u);
+}
+
+DEFINE_PRIMITIVE("user-effective-uid", posix_geteuid, subr0, (void))
+{
+    /* geteuid is always successful, don't check for errors */
+    uid_t u = geteuid();
+    
+    /* we *suppose* uid_t is always integer */
+    return MAKE_INT(u);
+}
+
+
+DEFINE_PRIMITIVE("user-gid", posix_getgid, subr0, (void))
+{
+    /* getuid is always successful, don't check for errors */
+    uid_t u = getgid();
+    
+    /* we *suppose* uid_t is always integer */
+    return MAKE_INT(u);
+}
+
+DEFINE_PRIMITIVE("user-effective-gid", posix_getegid, subr0, (void))
+{
+    /* geteuid is always successful, don't check for errors */
+    uid_t u = getegid();
+    
+    /* we *suppose* uid_t is always integer */
+    return MAKE_INT(u);
+}
+
+DEFINE_PRIMITIVE("user-supplementary-gids", posix_getgroups, subr0, (void))
+{
+    gid_t *groups;
+    int n = getgroups(0,NULL);
+
+    groups = malloc(sizeof(gid_t) * n);
+    if (groups == 0) STk_error("memory allocation error");
+    
+    int gs = getgroups(n, groups);
+    SCM list = STk_nil;
+
+    if (gs != 0) {
+        for (int i=0; i < n; i++) {
+            list = STk_cons(MAKE_INT(*groups),list);
+            groups++;
+        }
+    } else
+        STk_error_posix(errno,"user-supplementary-gids",STk_nil);
+    return(list);    
+}
+
+
+/* 3.6 User and group database access */
+
+DEFINE_PRIMITIVE("user-info",get_user_info, subr1, (SCM uid_name))
+{
+    struct passwd* info;
+
+    errno = 0;
+    if (STRINGP (uid_name))
+        info = getpwnam(STRING_CHARS(uid_name));
+    else if (INTP (uid_name)) /* FIXME: and positive */
+        info = getpwuid(INT_VAL(uid_name));
+    else {
+        STk_error("not string or integer ~S", uid_name);
+    }
+    if (info == 0) {
+        if (errno) STk_error_posix(errno,"user-info",LIST1(uid_name)); /* <- error */
+        else return STk_false;                                         /* <- no error, user
+                                                                          doesn't exist */
+    } else {
+        SCM argv[8];
+        argv[7]=user_info_type;
+        argv[6]=STk_Cstring2string(info->pw_name);
+        argv[5]=MAKE_INT(info->pw_uid);
+        argv[4]=MAKE_INT(info->pw_gid);
+        argv[3]=STk_Cstring2string(info->pw_dir);
+        argv[2]=STk_Cstring2string(info->pw_shell);
+        argv[1]=STk_Cstring2string(info->pw_gecos);
+        char *saveptr;
+        char *t = strtok_r(info->pw_gecos,",", &saveptr);
+        SCM name = STk_nil;
+        while(t != 0) {
+            name = STk_cons(STk_Cstring2string(t),name);
+            t = strtok_r(0, ",", &saveptr);
+        }
+        argv[0]=name;
+        return STk_make_struct(8, &argv[7]);
+    }
+    return STk_void; /* never reached */
+}
+
+DEFINE_PRIMITIVE("group-info",get_group_info, subr1, (SCM gid_name))
+{
+    struct group* info;
+
+    errno = 0;
+    if (STRINGP (gid_name))
+        info = getgrnam(STRING_CHARS(gid_name));
+    else if (INTP (gid_name)) /* FIXME: and positive */
+        info = getgrgid(INT_VAL(gid_name));
+    else {
+        STk_error("not string or integer ~S", gid_name);
+    }
+    if (info == 0) {
+        if (errno) STk_error_posix(errno,"group-info",LIST1(gid_name)); /* <- error */
+        else return STk_false;                                          /* <- no error, group
+                                                                           doesn't exist */
+    } else {
+        SCM argv[3];
+        argv[2]=group_info_type;
+        argv[1]=STk_Cstring2string(info->gr_name);
+        argv[0]=MAKE_INT(info->gr_gid);
+        return STk_make_struct(3, &argv[2]);
+    }
+    return STk_void; /* never reached */
+}
+
+/* 3.10 Time */
+
+DEFINE_PRIMITIVE("posix-time",posix_time, subr0, (void))
+{
+    struct timespec ts;
+    int e = clock_gettime(CLOCK_REALTIME, &ts);
+
+    if (e==-1) STk_error_posix(errno,"posix-time",STk_nil);
+
+    SCM argv[3];
+    argv[2]=time_type;
+    argv[1]=MAKE_INT(ts.tv_sec);
+    argv[0]=MAKE_INT(ts.tv_nsec);
+    return STk_make_struct(3, &argv[2]);
+}
+
+DEFINE_PRIMITIVE("monotonic-time",posix_monotonic_time, subr0, (void))
+{
+    struct timespec ts;
+    int e = clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    if (e==-1) STk_error_posix(errno,"monotonic-time",STk_nil);
+    
+    SCM argv[3];
+    argv[2]=time_type;
+    argv[1]=MAKE_INT(ts.tv_sec);
+    argv[0]=MAKE_INT(ts.tv_nsec);
+    return STk_make_struct(3, &argv[2]);
+}
+
+/* 3.12 Terminal device control */
+
+DEFINE_PRIMITIVE("terminal?",posix_isatty, subr1, (SCM port))
+{
+    if (!PORTP(port)) STk_error("bad port ~S", port);
+    if (!FPORTP(port)) STk_error("bad file port ~S", port);
+    int fd = PORT_FD(PORT_STREAM(port));
+    int e = isatty(fd);
+
+    if (e == 1) return STk_true;
+    if (errno == ENOTTY) return STk_false;
+    STk_error_posix(errno,"terminal?",LIST1(port));
+    return STk_false; /* never reached */       
+}
+
+
+
+/* -----------------
+   MODULE
+   ----------------- */
+
+MODULE_ENTRY_START("srfi-170")
+
+{
+  SCM module =  STk_create_module(STk_intern("SRFI-170"));
+
+  
+  /* 3.1 Error handling */
+
+  posix_error = STk_defcond_type("&posix-error", STk_false,
+                                 LIST5(STk_intern("procedure"),
+                                       STk_intern("args"),
+                                       STk_intern("errname"),
+                                       STk_intern("message"),
+                                       STk_intern("errno")),
+                                 module);
+  
+  ADD_PRIMITIVE_IN_MODULE(posix_strerror,module);
+  ADD_PRIMITIVE_IN_MODULE(get_posix_error_name,module);
+  
+  /* 3.2 I/O */
+
+  ADD_PRIMITIVE_IN_MODULE(posix_open,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_fd_port,module);
+
+  /* R,W,R+W should be specified in mode, but let's define the flags, since
+     the tests use them */
+  STk_define_variable(STk_intern("open/read"),      MAKE_INT(O_RDONLY), module);
+  STk_define_variable(STk_intern("open/write"),     MAKE_INT(O_WRONLY), module);
+  STk_define_variable(STk_intern("open/read+write"),  MAKE_INT(O_RDWR), module);
+  
+  STk_define_variable(STk_intern("open/append"),    MAKE_INT(O_APPEND), module);
+  STk_define_variable(STk_intern("open/create"),    MAKE_INT(O_CREAT), module);
+  STk_define_variable(STk_intern("open/exclusive"), MAKE_INT(O_EXCL), module);
+  STk_define_variable(STk_intern("open/nofollow"),  MAKE_INT(O_NOFOLLOW), module);
+  STk_define_variable(STk_intern("open/truncate"),  MAKE_INT(O_TRUNC), module);
+    
+  /* 3.3 File System */
+
+  file_info_type = STk_make_struct_type(STk_intern("%file-info"),
+                                        STk_false,
+                                        STk_append2(
+                                            LIST6(STk_intern("device"),
+                                                  STk_intern("inode"),
+                                                  STk_intern("mode"),
+                                                  STk_intern("nlinks"),
+                                                  STk_intern("uid"),
+                                                  STk_intern("gid")),
+                                            LIST10(STk_intern("rdev"),
+                                                   STk_intern("size"),
+                                                   STk_intern("blksize"),
+                                                   STk_intern("blocks"),
+                                                   STk_intern("atime"),
+                                                   STk_intern("mtime"),
+                                                   STk_intern("ctime"),
+                                                   STk_intern("atim"),
+                                                   STk_intern("mtim"),
+                                                   STk_intern("ctim"))));
+
+  STk_define_variable(STk_intern("%file-info"), file_info_type, module);
+
+  dir_info_type = STk_make_struct_type(STk_intern("%directory-info"),
+                                       STk_false,
+                                       LIST2(STk_intern("dir-object"),
+                                             STk_intern("dot-files")));
+
+  STk_define_variable(STk_intern("%directory-info"), dir_info_type, module);
+
+  
+  ADD_PRIMITIVE_IN_MODULE(posix_mkdir,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_mkfifo,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_link,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_rename,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_rmdir,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_utimensat,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_mkstemp,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_readlink,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_symlink,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_truncate, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_stat, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_opendir, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_readdir, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_closedir, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_realpath, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_chmod, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_chown, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_statvfs, module);
+
+  ADD_PRIMITIVE_IN_MODULE(posix_isdir, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_isfifo, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_issymlink, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_isregular, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_issocket, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_isdevice, module);
+  
+  /* 3.5 Process state */
+  
+  ADD_PRIMITIVE_IN_MODULE(posix_umask, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_set_umask, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_getcwd, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_chdir, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_nice, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_getuid, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_geteuid, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_getgid, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_getegid, module);
+  ADD_PRIMITIVE_IN_MODULE(posix_getgroups,module);
+
+  /* 3.6  User and group database access */
+
+  user_info_type = STk_make_struct_type(STk_intern("%user-info"),
+                                         STk_false,
+                                         LIST7(STk_intern("name"),
+                                               STk_intern("uid"),
+                                               STk_intern("gid"),
+                                               STk_intern("home-dir"),
+                                               STk_intern("shell"),
+                                               STk_intern("full-name"),
+                                               STk_intern("parsed-full-name")));
+
+  STk_define_variable(STk_intern("%user-info"), user_info_type, module);
+
+  group_info_type = STk_make_struct_type(STk_intern("%group-info"),
+                                         STk_false,
+                                         LIST2(STk_intern("name"),
+                                               STk_intern("gid")));
+
+  STk_define_variable(STk_intern("%group-info"), group_info_type, module);
+
+  ADD_PRIMITIVE_IN_MODULE(get_group_info,module);
+  ADD_PRIMITIVE_IN_MODULE(get_user_info,module);
+
+
+  /* 3.10 Time */
+
+  /* We need to make reference to structure %time: */
+  SCM ref;
+  time_type = STk_lookup(STk_intern("%time"), STk_STklos_module,&ref,TRUE);
+
+  ADD_PRIMITIVE_IN_MODULE(posix_time,module);
+  ADD_PRIMITIVE_IN_MODULE(posix_monotonic_time,module);
+
+
+  /* 3.12 Terminal device control */
+
+  ADD_PRIMITIVE_IN_MODULE(posix_isatty, module);
+  
+  /* Export all the symbols we have just defined */
+  STk_export_all_symbols(module);
+
+}
+MODULE_ENTRY_END

--- a/lib/srfi-170-impl.c
+++ b/lib/srfi-170-impl.c
@@ -261,7 +261,7 @@ DEFINE_PRIMITIVE("fd->port",posix_fd_port,subr23,(SCM fd, SCM type, SCM bufmode)
 
     if (!bufmode) bufmode = STk_false;
     
-    char *cname = malloc(25);
+    char *cname = STk_must_malloc(25);
     snprintf(cname,24,"fd->port(%ld)",INT_VAL(fd));
     
     char *mode;
@@ -388,7 +388,7 @@ DEFINE_PRIMITIVE("read-symlink", posix_readlink, subr1, (SCM name))
     if  (sb.st_size == 0)
         bsize = PATH_MAX;
 
-    char *buf = malloc(bsize);
+    char *buf = STk_must_malloc(bsize);
     if (buf == NULL) STk_error("cannot allocate memory for symlink resolved name ~S", name);
 
     e = readlink(cname, buf, bsize);
@@ -711,7 +711,7 @@ DEFINE_PRIMITIVE("close-directory", posix_closedir, subr1, (SCM dir) )
 DEFINE_PRIMITIVE("real-path", posix_realpath, subr1, (SCM p) )
 {
     char* pa;
-    char* rpath = malloc(PATH_MAX);
+    char* rpath = STk_must_malloc(PATH_MAX);
     
     if (!STRINGP(p)) STk_error("bad string ~S", p);
     
@@ -840,7 +840,7 @@ DEFINE_PRIMITIVE("user-supplementary-gids", posix_getgroups, subr0, (void))
     gid_t *groups;
     int n = getgroups(0,NULL);
 
-    groups = malloc(sizeof(gid_t) * n);
+    groups = STk_must_malloc(sizeof(gid_t) * n);
     if (groups == 0) STk_error("memory allocation error");
     
     int gs = getgroups(n, groups);

--- a/lib/srfi-170.stk
+++ b/lib/srfi-170.stk
@@ -1,0 +1,426 @@
+;;;;
+;;;; srfi-170.stk         -- SRFI-170: POSIX API
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 09-Jan-2021 09:14
+;;;; Last file update: 13-Jan-2021 00:21 (jpellegrini)
+;;;;
+
+(require "srfi-158")
+
+(load "srfi-170-impl")
+
+(define %%srfi-170-previous-module (current-module))
+
+(select-module SRFI-170)
+(import SRFI-158)
+
+;; defines a list of symbols evaluating to themselves:
+(define-syntax defsymbol
+  (syntax-rules ()
+    ((_ s)
+     (define s 's))
+    ((_ s t ...)
+     (begin (define s 's)
+            (defsymbol t ...)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 3.1  Error handling -- DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (define &posix-error ...)   implemented in C
+
+(define (posix-error errno :optional procedure args)
+  (let ((errname (%get-posix-error-name errno)))
+    (raise (make-condition &posix-error
+                           'procedure procedure
+                           'args args
+                           'errname (%get-posix-error-name errno)
+                           'message (posix-get-message-for-errno errno)
+                           'errno errno))))
+
+(define (posix-error? obj)
+  (and (condition? obj)
+       (condition-has-type? obj &posix-error)))
+
+(define (posix-error-name posix-error)
+  (condition-ref posix-error 'errname))
+
+(define (posix-error-procedure posix-error)
+  (condition-ref posix-error 'procedure))
+
+(define (posix-error-args posix-error)
+  (condition-ref posix-error 'args))
+
+(define (posix-error-message posix-error)
+  (condition-ref posix-error 'message))
+
+(define (posix-error-errno posix-error)
+  (condition-ref posix-error 'errno))
+
+;; (posix-error-message posix-error)   implemented as primitive
+
+(export posix-error
+        posix-error?
+        posix-error-name
+        posix-error-procedure
+        posix-error-args
+        posix-error-message
+        posix-error-errno)
+
+;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 3.2  I/O - DONE
+;;;
+;;;;;;;;;;;;;;;;;;;
+
+
+(defsymbol binary-input)
+(defsymbol textual-input)
+(defsymbol binary-output)
+(defsymbol textual-output)
+(defsymbol binary-input/output)
+
+(defsymbol buffer-none)
+(defsymbol buffer-block)
+(defsymbol buffer-line)
+
+;; open/append     implemented in C
+;; open/create     implemented in C
+;; open/exclusive  implemented in C
+;; open/nofollow   implemented in C
+;; open/truncate   implemented in C
+
+;; (open-file fname port-type flags [permission-bits [buffer-mode] ]) implemented as primitive
+;; (fd->port fd port-type [buffer-mode])                              implemented as primitive
+
+(export binary-input
+        textual-input
+        binary-output
+        textual-output
+        binary-input/output
+
+        buffer-none
+        buffer-block
+        buffer-line)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 3.3  File system - DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defsymbol
+  time/now
+  time/unchanged
+  owner/unchanged
+  group/unchanged)
+
+(define default-prefix
+  (let ((p (let ((tmpdir (getenv "TMPDIR")))
+             (or tmpdir "/tmp"))))
+    (format #f "~a/~a" p (getpid))))
+
+(define temp-file-prefix (make-parameter default-prefix))
+
+;; (create-directory fname [permission-bits])  implemented as primitive
+;; (create-fifo fname [permission-bits])       implemented as primitive
+;; (create-hard-link old-fname new-fname)      implemented as primitive
+;; (create-symlink old-fname new-fname)        implemented as primitive
+;; (read-symlink fname)                        implemented as primitive
+;; (rename-file old-fname new-fname)           implemented as primitive
+;; (delete-directory fname)                    implemented as primitive
+
+;; set-file-owner needs to take into account the /unchanged parameters,
+;; and it's easier to do it here in Scheme.
+;; (%set-file-owner fname uid gid)              implemented as primitive
+(define (set-file-owner fname uid gid)
+  (let ((info (file-info fname #t)))
+    (let ((uid-to-go (if (eq? uid owner/unchanged)
+                         (file-info:uid info)
+                         uid))
+          (gid-to-go (if (eq? gid group/unchanged)
+                         (file-info:gid info)
+                         gid)))
+      (%set-file-owner fname uid-to-go gid-to-go))))
+  
+;; (set-file-times fname [access-time-object modify-time-object]) implemented as primitive
+;; (truncate-file fname/port len)              implemented as primitive
+;; (file-info fname/port follow?)              implemented as primitive
+
+(define (file-info? obj)
+  (and (struct? obj)
+       (struct-is-a? obj %file-info)))
+
+(define (file-info:device file-info)  (struct-ref file-info 'device))
+(define (file-info:inode file-info)   (struct-ref file-info 'inode))  
+(define (file-info:mode file-info)    (struct-ref file-info 'mode))  
+(define (file-info:nlinks file-info)  (struct-ref file-info 'nlinks))  
+(define (file-info:uid file-info)     (struct-ref file-info 'uid))  
+(define (file-info:gid file-info)     (struct-ref file-info 'gid))  
+(define (file-info:rdev file-info)    (struct-ref file-info 'rdev))  
+(define (file-info:size file-info)    (struct-ref file-info 'size))  
+(define (file-info:blksize file-info) (struct-ref file-info 'blksize))  
+(define (file-info:blocks file-info)  (struct-ref file-info 'blocks))  
+(define (file-info:atime file-info)   (struct-ref file-info 'atim))
+(define (file-info:mtime file-info)   (struct-ref file-info 'mtim))
+(define (file-info:ctime file-info)   (struct-ref file-info 'ctim))
+(define (file-info:atim file-info)    (struct-ref file-info 'atime))
+(define (file-info:mtim file-info)    (struct-ref file-info 'mtime))
+(define (file-info:ctim file-info)    (struct-ref file-info 'ctime))
+
+;; (file-info-directory? file-info) implemented as primitive
+;; (file-info-fifo? file-info)      implemented as primitive
+;; (file-info-symlink? file-info)   implemented as primitive
+;; (file-info-regular? file-info)   implemented as primitive
+;; (file-info-socket? file-info)    implemented as primitive
+;; (file-info-device? file-info)    implemented as primitive
+;; (set-file-mode fname bits)       implemented as primitive
+
+;; directory-files already exists in STklos, but does not throw
+;; &posix-error. This version, which calls open-directory and
+;; read-directory, does.
+(define (directory-files path :optional dot)
+  (let ((dir (open-directory path dot))
+        (files '()))
+    (let again ((f (read-directory dir)))
+      (if (eof-object? f)
+          files
+          (begin (set! files (cons f files))
+                 (again (read-directory dir)))))))
+
+(define (make-directory-files-generator path :optional dot)
+  (let ((dir (open-directory path dot)))
+    (make-unfold-generator eof-object?
+                           (lambda (x) (read-directory dir))
+                           (lambda (x) x)
+                           ())))
+
+;; (open-directory dir [dot-files?])  implemented as primitive
+;; (read-directory directory-object)  implemented as primitive
+;; (close-directory directory-object) implemented as primitive
+;; (real-path path)                   implemented as primitive
+;; (file-space path-or-port)          implemented as primitive
+
+
+;; About create-temp-file:
+;;
+;; 1. It is not clear from the SRFI text what should happen if the prefix
+;; denominates a non-existing directory. We don't create it, and let
+;; mkstemp throw a ENOENT error (it's a POSIX API, so mimic'ing whatever
+;; a POSIX function does seems appropriate). Gauche and Loko do the same.
+;;
+;; 2. Loko tries to protect against symlink attacks; Gauche just calls mkstemp
+;; directly. $mkstemp does the same as Gauche.
+;;
+(define (create-temp-file . arg)
+  (when (> (length arg) 1) (error 'create-temp-file "accepts at most one argument"))
+  (let ((pref (if (null? arg)
+                  (temp-file-prefix)
+                  (car arg))))
+    (%mkstemp (string-append pref "XXXXXX"))))
+
+
+(define alpha "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_")
+
+(define (random-string n)
+  (let ((s (make-string n)))
+    (dotimes (i n)
+      (string-set! s i (string-ref alpha (random-integer 63))))
+    s))
+
+;; FIXME: needs review.
+(define (call-with-temporary-filename maker . arg)
+  (let ((pref (if (null? arg)
+                  (temp-file-prefix)
+                  (car arg))))
+    (let again ((tries 100))
+      (let ((name (string-append pref (random-string 12))))
+        (let-values (((x . rest)
+                      (guard (e
+                              ((and (condition-has-type? e &posix-error)
+                                    (not (eqv? 0 tries)))
+                               #f))
+                        (maker name))))
+          (if (not x)
+              (again (fx- tries 1))
+              (apply values x rest)))))))
+
+(export temp-file-prefix
+        
+        time/now
+        time/unchanged
+
+        owner/unchanged
+        group/unchanged
+
+        directory-files
+        make-directory-files-generator
+        
+        set-file-owner
+        create-temp-file
+        call-with-temporary-filename
+        
+        file-info?
+        file-info:device
+        file-info:inode 
+        file-info:mode 
+        file-info:nlinks 
+        file-info:uid 
+        file-info:gid 
+        file-info:rdev 
+        file-info:size 
+        file-info:blksize
+        file-info:blocks 
+        file-info:atime 
+        file-info:mtime 
+        file-info:ctime 
+        file-info:atim 
+        file-info:mtim 
+        file-info:ctim )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 3.5 Process state  --  DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (umask)                               implemented as primitive
+;; (set-umask! umask)                    implemented as primitive
+;; (define current-directory getcwd)     implemented as primitive
+;; (define set-current-directory! chdir) implemented as primitive
+
+(define pid getpid) ; in STklos, always successful
+
+;; (nice delta)              implemented as primitive
+;; (user-uid)                implemented as primitive
+;; (user-gid)                implemented as primitive
+;; (user-effective-uid)      implemented as primitive
+;; (user-effective-gid)      implemented as primitive
+;; (user-supplementary-gids) implemented as primitive
+
+(export pid)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 
+;;; 3.6  User and group database access -- DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (user-info uid/name)        implemented as primitive
+
+(define (user-info? obj)
+  (and (struct? obj)
+       (struct-is-a? obj %user-info)))
+
+(define (user-info:name obj)             (struct-ref obj 'name))
+(define (user-info:uid obj)              (struct-ref obj 'uid))
+(define (user-info:gid obj)              (struct-ref obj 'gid))
+(define (user-info:home-dir obj)         (struct-ref obj 'home-dir))
+(define (user-info:shell obj)            (struct-ref obj 'shell))
+(define (user-info:full-name obj)        (struct-ref obj 'full-name))
+(define (user-info:parsed-full-name obj) (struct-ref obj 'parsed-full-name))
+
+;; (group-info gid/name)      implemented as primitive
+
+(define (group-info:name obj) (struct-ref obj 'name))
+(define (group-info:gid obj)  (struct-ref obj 'gid))
+(define (group-info? obj)
+  (and (struct? obj)
+       (struct-is-a? obj (in-module SRFI-170 %group-info))))
+                                                  
+(export user-info?
+        user-info:name
+        user-info:uid
+        user-info:gid
+        user-info:home-dir
+        user-info:shell
+        user-info:full-name
+        user-info:parsed-full-name
+        
+        group-info?
+        group-info:name
+        group-info:gid)
+
+;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 3.10  Time -- DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (posix-time)      implemented as primitive
+;; (monotonic-time)  implemented as primitive
+
+(define (%make-time sec nano)
+  (make-struct %time sec nano))
+  
+(define (time-second x) (struct-ref x 'second))
+(define (time-nanosecond x) (struct-ref x 'nanosecond))
+
+(export %make-time
+        time-second
+        time-nanosecond)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 3.11  Environment variables -- DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; FIXME: implement as primitives
+(define set-environment-variable! setenv!)
+(define delete-environment-variable! unsetenv!)
+
+(export set-environment-variable!
+        delete-environment-variable!)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 
+;;; 3.12  Terminal device control -- DONE
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+;; (terminal? port)  implemented as primitive
+
+;;;
+;;; END OF MODULE
+;;;
+
+(select-module STklos)
+(import SRFI-170)
+
+(define %rename-file      rename-file)
+(define %directory-files  directory-files)
+(define %delete-directory delete-directory)
+(define %open-file        open-file)
+
+(define rename-file      (in-module SRFI-170 rename-file))
+(define directory-files  (in-module SRFI-170 directory-files))
+(define delete-directory (in-module SRFI-170 delete-directory))
+(define (open-file . args)
+  (if (= (length args) 2)
+      (apply %open-file args)
+      (apply (in-module SRFI-170 open-file) args)))
+
+(provide "srfi-170")

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -208,7 +208,7 @@
     ;; 167  Ordered Key Value Store
     ;; 168  Generic Tuple Store Database
     (169 "Underscores in numbers")
-    ;; 170  POSIX API
+    (170 "POSIX API" (posix) "srfi-170")
     (171 "Transducers" (transducers) "srfi-171")
     ;; 172  Two Safer Subsets of R7RS
     (173 "Hooks" (hooks) "srfi-173")


### PR DESCRIPTION
Hello @egallesio !

I think it's mostly done, there are just a couple of questions and small issues to be dealt with.

Tell me what you think about the proposed changes in core -- I can change this PR to include them.

# Comments

* We need to raise errors reporting `errno`, so:
  * the FFI was not used, since we cannot check `errno` with it;
  * some procedures, like `file-directories`, were re-written
    in srfi-170-impl.c.

* I wrote a new    `&posix-error` condition with slots for several data as recommended per the SRFI. It can be creted in Scheme as

```
(make-condition &posix-error
                           'procedure procedure
                           'args args
                           'errname (%get-posix-error-name errno)  ; a symbol with the same name as the C constant
                                                                   ; describing the error (for instance, `'EINVAL`)
                           'message (posix-get-message-for-errno errno)
                           'errno errno)
```


# Issues

* There's `error_posix` in `system.c` and  `STk_error_posix` in SRFI-170, which uses the newcondition.
  Proposal:
  * remove `error_posix` from `system.c`;
  * include `STk_error_posix` and the `%posix-error` condition in STklos core and update
    calls to `error_posix` to use this new one instead;
  This way we can even remove some code duplication, moving for example `directory-files` and a few others from the SRFI into the core.

* We ignore buffering modes in the SRFI. Is this OK?

* `open-directory` needs review, I think.

* I used `STk_eq` and `STk_intern` to compare symbols. Is that the correct  way?

* should we change `%time` to `time` in STklos core?
  * structure `%time` only has 2 slots, `second` and `nanoescond`, but SRFI-19 requires `time` to contain a slot with its type (utc, monotonic etc)
  * the SRFI explicitly says that the name of the structure should be `time-utc`, probably a subtype of `time`, or `time` with a slot saying it's UTC.
  * the SRFI exports a time-creating procedure `%make-time`, ugly. What about having  a `make-time` procedure in STklos core?

* If `p` is a port, but not a *file* port, should `(terminal? p)` return `#f`  or should it raise an error? The SRFI wasn't really clear.
  Gauche and Loko return `#f`