### PR TITLE
Add SRFI-25: Multi-dimensional Array Primitives

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -34,6 +34,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-18: Multithreading support
     - SRFI-22: Running Scheme Scripts on Unix
     - SRFI-23: Error reporting mechanism
+    - SRFI-25: Multi-dimensional Arrays
     - SRFI-26: Notation for Specializing Parameters without Currying
     - SRFI-27: Source of random bits
     - SRFI-28: Basic Format Strings

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -90,6 +90,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-13.stk         \
           srfi-14.stk         \
           srfi-17.stk         \
+          srfi-25.stk         \
           srfi-26.stk         \
           srfi-27.stk         \
           srfi-31.stk         \
@@ -143,7 +144,8 @@ SRC_STK = bigloo-support.stk  \
           tar.stk             \
           trace.stk
 
-SRC_C = srfi-133-impl.c \
+SRC_C = srfi-25-impl.c \
+        srfi-133-impl.c \
         srfi-170-impl.c \
         srfi-175-impl.c
 
@@ -172,6 +174,7 @@ scheme_OBJS = compfile.ostk     \
           srfi-13.ostk          \
           srfi-14.ostk          \
           srfi-17.ostk          \
+          srfi-25.ostk          \
           srfi-26.ostk          \
           srfi-27.ostk          \
           srfi-31.ostk          \
@@ -225,7 +228,8 @@ scheme_OBJS = compfile.ostk     \
           tar.ostk              \
           trace.ostk
 
-scheme_SOLIBS = srfi-133-impl.@SH_SUFFIX@ \
+scheme_SOLIBS = srfi-25-impl.@SH_SUFFIX@ \
+                srfi-133-impl.@SH_SUFFIX@ \
                 srfi-170-impl.@SH_SUFFIX@ \
                 srfi-175-impl.@SH_SUFFIX@ 
 

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -57,6 +57,14 @@
      ((struct-type? x)  (format port "the type structure named ~A"
 				(struct-type-name x)))
      ((module? x)	(format port "a module named ~A" (module-name x)))
+
+     ;; for srfi-25. arrays are a native type, but 'array?' is only available
+     ;; when the SRFI is loaded.
+     ((and (provided? "srfi-25")
+           (array? x))            (format port "an array of rank ~A and size ~A"
+                                          (array-rank x)
+                                          (array-size x)))
+
      (else	  	(format port "an an instance of class ~A"
 				(class-name (class-of x)))))
   (format port ".~%")

--- a/lib/srfi-25-impl.c
+++ b/lib/srfi-25-impl.c
@@ -516,7 +516,7 @@ DEFINE_PRIMITIVE("make-array",srfi_25_make_array,subr12,(SCM shape, SCM obj))
 
 DEFINE_PRIMITIVE("shape",srfi_25_shape,vsubr,(int argc, SCM *argv))
 {
-  if (argc % 2) STk_error("bad array shape numracketber or args ~S", argc);
+  if (argc % 2) STk_error("odd number of arguments (~S) given for shape", argc);
 
   /* shape of a shape is 0 d 0 2 */
   long *meta_shape = STk_must_malloc(4*sizeof(long));

--- a/lib/srfi-25-impl.c
+++ b/lib/srfi-25-impl.c
@@ -543,7 +543,7 @@ DEFINE_PRIMITIVE("array", srfi_25_array, vsubr, (int argc, SCM *argv))
     if (argc < 1) STk_error("not enough arguments");
     
     SCM shape = *argv--;
-    if (!STk_srfi_25_shapep(shape)) STk_error("bad array shape ~S",shape);
+    if (STk_srfi_25_shapep(shape) == STk_false) STk_error("bad array shape ~S",shape);
     
     long *cshape = shapetoCshape(shape);
     long len = ARRAY_LENGTH(shape);

--- a/lib/srfi-25-impl.c
+++ b/lib/srfi-25-impl.c
@@ -513,7 +513,7 @@ DEFINE_PRIMITIVE("make-array",srfi_25_make_array,subr12,(SCM shape, SCM obj))
 
 DEFINE_PRIMITIVE("shape",srfi_25_shape,vsubr,(int argc, SCM *argv))
 {
-  if (argc % 2) STk_error("bad array shape nummber or args ~S", argc);
+  if (argc % 2) STk_error("bad array shape number or args ~S", argc);
 
   /* shape of a shape is 0 d 0 2 */
   long *meta_shape = STk_must_malloc(4*sizeof(long));

--- a/lib/srfi-25-impl.c
+++ b/lib/srfi-25-impl.c
@@ -513,7 +513,7 @@ DEFINE_PRIMITIVE("make-array",srfi_25_make_array,subr12,(SCM shape, SCM obj))
 
 DEFINE_PRIMITIVE("shape",srfi_25_shape,vsubr,(int argc, SCM *argv))
 {
-  if (argc % 2) STk_error("bad array shape number or args ~S", argc);
+  if (argc % 2) STk_error("bad array shape numracketber or args ~S", argc);
 
   /* shape of a shape is 0 d 0 2 */
   long *meta_shape = STk_must_malloc(4*sizeof(long));
@@ -637,7 +637,7 @@ DEFINE_PRIMITIVE("array-ref", srfi_25_array_ref,vsubr, (int argc, SCM *argv))
         index = get_index_from_array(array, *argv);
         
     } else STk_error("Index must be vector, array or sequence of integers");
-    
+
     return ARRAY_DATA(array)[index];
 }
 
@@ -897,7 +897,7 @@ DEFINE_PRIMITIVE("share-array", srfi_25_share_array, subr3, (SCM old_array, SCM 
  * (shared-array? array)
  *
  * Will return true when the array has its data shared with other
- * arrays.
+ * arrays, and false otherwise.
 doc>
  */
 DEFINE_PRIMITIVE("shared-array?",srfi_25_shared_arrayp,subr1,(SCM array))
@@ -914,8 +914,9 @@ DEFINE_PRIMITIVE("shared-array?",srfi_25_shared_arrayp,subr1,(SCM array))
  * elements through |(share-array array shape proc)|, and that were not
  * yet garbage collected.
  * Note that it may take a long time for an object to be garbage
- * collected automatically, but it is possible to force a garbage
- * collection pass with |gc|
+ * collected automatically. It is possible to force a garbage
+ * collection pass by calling |(gc)|, but even that does not guarantee that
+ * a specific object will be collected.
 doc>
  */
 DEFINE_PRIMITIVE("array-share-count",srfi_25_array_share_count,subr1,(SCM array))
@@ -1022,7 +1023,7 @@ DEFINE_PRIMITIVE("array-copy+share",srfi_25_array_copy_share,subr1,(SCM old_arra
  * This procedure will apply proc to all valid sequences of
  * indices in |shape|, in row-major order.
  *
- * If |index-object| is not provided, then proc must accept
+ * If |index-object| is not provided, then |proc| must accept
  * as many arguments as the number of dimensions that the shape
  * describes.
  * @lisp
@@ -1035,8 +1036,8 @@ DEFINE_PRIMITIVE("array-copy+share",srfi_25_array_copy_share,subr1,(SCM old_arra
  * [2 11]
  * @end lisp
  * If |index-object| is provided, it is used as a place to store the
- * indices, so proc must accept a vector (this is to avoid pushing
- * and popping too many values when calling proc).
+ * indices, so proc must accept either a vector or an array (this is to
+ * avoid pushing and popping too many values when calling |proc|).
  * |index-object|, when present, must be aither a vector or array.
  * @lisp
  * (let ((vec (make-vector 2 #f)))
@@ -1196,7 +1197,7 @@ DEFINE_PRIMITIVE("shape-for-each", srfi_25_shape_for_each, vsubr, (int argc, SCM
 
 static void print_array(SCM array, SCM port, int mode)
 {
-   /* This should probably use shape-for-each, but thta function expects us
+   /* This should probably use shape-for-each, but that function expects us
       to pass it a Scheme procedure to be called in each step, so I left this
       as a hard-coded loop (actually I first wrote this function then used its
       loop as a template for shape-for-each). -- jpellegrini */

--- a/lib/srfi-25-impl.c
+++ b/lib/srfi-25-impl.c
@@ -1216,15 +1216,9 @@ static void print_array(SCM array, SCM port, int mode)
    int rank = ARRAY_RANK(array);
 
    char buffer[100];
-   sprintf(buffer,"#%d",rank);
-   STk_puts(buffer, port);
-
-   /* if the array is shared, we prepend "S" */
-   if (ARRAY_SHARED(array)) STk_putc('S',port);
+   STk_puts("#,(array (",port);
 
    /* write the array shape */
-   STk_puts("A((",port);
-   
    for (int i =0; i< rank; i++) {
      sprintf(buffer,"%ld %ld",
              ARRAY_SHAPE(array)[2*i],    /* lower bound */
@@ -1232,7 +1226,7 @@ static void print_array(SCM array, SCM port, int mode)
      STk_puts(buffer, port);
      if (i != rank-1 ) STk_putc(' ', port);
    }
-   STk_puts(")", port);
+   STk_putc(')', port);
 
    /* now, the tricky part. we could easily just run through ARRAY_DATA(array),
       printing the elements and including ")(" to separate strides, however
@@ -1270,7 +1264,7 @@ static void print_array(SCM array, SCM port, int mode)
    if ( (rank==0) || empty) {
        /* Empty arrays may have a default value. We show it here. */
        if (ARRAY_DATA(array)[0]) {
-           STk_putc(' ', port);
+           STk_putc(' ',port);
            STk_print(ARRAY_DATA(array)[0], port, mode);
        }
    } else {
@@ -1278,12 +1272,7 @@ static void print_array(SCM array, SCM port, int mode)
        int updated = 1;
        while(updated) {
            updated = 0;
-           
-           /* last dimension index is the lowest. open parens */
-           if (INT_VAL(VECTOR_DATA(idx)[rank-1]) == ARRAY_SHAPE(array)[(rank-1)*2])
-               STk_putc('(', port);
-           
-           
+
            /* now we print one element: */
            SCM x = STk_srfi_25_array_ref(2, &args[1]);
            if (x)
@@ -1291,13 +1280,7 @@ static void print_array(SCM array, SCM port, int mode)
            else
                STk_error("array element is NULL, not a Scheme value -- this should not have happened!");
            
-           /* if last dimension index is the highest possible, close parens;
-              otherwise, put a blank to separate the values. */
-           if (INT_VAL(VECTOR_DATA(idx)[rank-1]) + 1 == ARRAY_SHAPE(array)[(rank-1)*2+1])
-               STk_putc(')', port);
-           else
-               STk_putc(' ', port);
-           
+          
            /* update idx vector */
            for(int d = rank - 1; d >= 0; d--)
                if (INT_VAL(VECTOR_DATA(idx)[d]) < ARRAY_SHAPE(array)[d*2+1] - 1) { /* we can increase */
@@ -1306,6 +1289,7 @@ static void print_array(SCM array, SCM port, int mode)
                        VECTOR_DATA(idx)[i] = MAKE_INT(ARRAY_SHAPE(array)[i*2]);
                    }
                    updated=1;
+                   STk_putc(' ', port);
                    break;
                }
        }

--- a/lib/srfi-25-impl.c
+++ b/lib/srfi-25-impl.c
@@ -1,0 +1,1347 @@
+/*
+ * srfi-25.c   -- Implementation of SRFI-25: Multi-dimensional Array Primitives
+ *
+ * Copyright © 2021 Jerônimo Pellegrini <j_p@aleph0.info>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ *
+ *           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+ *    Creation date: 28-Mar-2021 18:41
+ * Last file update: 04-Apr-2021 17:48 (jpellegrini)
+ */
+
+#include "stklos.h"
+
+EXTERN_PRIMITIVE("list-set!", list_set, subr3, (SCM list, SCM k, SCM obj));
+
+/*
+
+ *
+ * ARRAY STRUCTURE
+ *
+ 
+  An array object is:
+
+  struct array_obj {
+    stk_header header;
+    int shared;                does this array share data with another? (the counter)
+    int *orig_share_count;     pointer to original array share counter
+    MUT_FIELD(share_cnt_lock); lock for share counter 
+    long size;                 size of data 
+    long length;               # of elements
+    int  rank;                 # of dimensons 
+    long offset;               offset from zero, to be added when calculaing index 
+    long *shape;               pairs of bounds for each dimenson 
+    long *multipliers;         size of each dimension stride 
+    SCM  *data_ptr;            pointer to data
+  }
+
+  DATA_PTR: pointer to data. We cannot do as it is done with vectors, and implement
+            this as "SCM data[1]", then allocate more than the necessary size, because
+            shared arrays do not have theyr data vector with them. But we
+            do something similar (we allocate more than necessary when the array
+            is not shared).
+        
+  SHARED: when share-array is applied to array A in order to create array B,
+          *both* A and B are marked as "shared". But they're different.
+
+          - an array created with array or make-array is original. it contains
+            its own data vector, and has a share-counter that is always >=0.
+            this counter keeps track of how many others point to this array's
+            data.
+
+          - an array created with share-array is a share-array. it contains a pointer
+            to another array's data vector. its share-counter is always -1, and
+            when this array is garbage-collected, its finalizer decreases the
+            original array's counter.
+
+  RANK: is the number of dimensions specified in the shape, even if there
+        are empty dimensions!
+
+  MULTIPLIERS: Suppose arrays always begin at index zero. Then, when an index
+               (i j k) is used in array-ref or array-set!, it is translated into
+
+  multipliers[0] * i +
+  multipliers[1] * j +
+  multipliers[2] * k
+
+  
+  OFFSET: When an index (i j k) is used in array-ref or array-set!, it is translated
+          as the sum
+
+  multipliers[0] * ( -(array-start 0) + i )   +
+  multipliers[1] * ( -(array-start 1) + j )   +
+  multipliers[2] * ( -(array-start 2) + k )
+
+  Factoring out the constants, we have:
+
+  ---
+  multipliers[0] * i +
+  multipliers[1] * j +
+  multipliers[2] * k +
+
+  -(multipliers[0] * (array-start 0) +
+    multipliers[1] * (array-start 1) +
+    multipliers[2] * (array-start 2))
+  ---
+  The last term is the offset, fixed for each array.
+
+
+  *
+  * MACROS
+  *
+  
+ ARRAYP(p)            
+ ARRAY_SHARED(p)
+ ARRAY_SHARE_COUNT(p) 
+ ARRAY_SIZE(p)
+ ARRAY_LENGTH(p)
+ ARRAY_RANK(p)        
+ ARRAY_OFFSET(p)      
+ ARRAY_SHAPE(p)       
+ ARRAY_MULTS(p)       
+ ARRAY_DATA(p)        
+
+ *
+ * empty arrays and default values
+ *
+ 
+ The SRFI requires support for empty arrays (or at least
+ it is implied by the reference implementation and mailing
+ list archives). But the reference implementation is not
+ consistent, but I have adopter the same behavior:
+ 
+ * arrays are created with a default value, so
+   (make-array (shape)) has a default value of #void
+ 
+   (array-ref (make-array (shape)))  =>  #void
+ 
+ * from the reference implementation, from Kawa and Gauche,
+   (shape) is an array of rank 2, but there are no indices that
+   can be used on it, so referencing (shape) is an error:
+  
+  (array-ref (shape) i j) => out of bounds, no matter what i, j are!
+
+* from the reference implementation:
+
+  (define a (make-array (shape) -2))  ; empty array, default value -2
+  (array-ref a) => -2
+  
+  (define b (make-array (shape 1 1) -2))  ; empty array, not referenceable:
+  (array-ref b) => error
+ 
+};
+
+
+ *
+ * efficiency
+ *
+ 
+ I have tried as much as possible to make a fast
+ implementation -- however, there are lots of verifications
+ necessary for each element access. For example,
+ 
+ * the element position may be specifed as arguments, as
+   elements in a vector, or as elements in an array.
+   This requires one more "if"...
+ * arrays may be empty, and may or not have a default value.
+   More checks.
+   This also requires us to store a single element, even
+   when the "data" vector is supposed to have length zero...
+
+ */
+
+
+EXTERN_PRIMITIVE("array-ref", srfi_25_array_ref,vsubr, (int argc, SCM *argv));
+
+
+/* WARNING: following function assumes array was already type checked. */
+int array_zero_basedp(SCM array)
+{
+    for (int i = 0; i < ARRAY_RANK(array); i++)
+        if (ARRAY_SHAPE(array)[2*i] != 0) return 0;
+    return 1;
+}
+
+/*******************/
+/* INDEX VERIFIERS */
+/*******************/
+
+static inline
+void check_index_arguments(SCM array, int nargs, SCM *args)
+{
+    if (ARRAY_RANK(array) != nargs)
+        STk_error("wrong number of indices ~S, should be ~S",
+                  MAKE_INT(nargs),
+                  MAKE_INT(ARRAY_RANK(array)));
+    for (; nargs; nargs--)
+        if (!INTP(*args)) STk_error("bad integer ~S used as index", *args--);
+}
+
+static inline
+void check_index_vector(SCM vec, SCM array)
+{
+    if (ARRAY_RANK(array) != VECTOR_SIZE(vec)) STk_error("wrong number of indices");
+    for (int i=0; i<VECTOR_SIZE(vec); i++)
+        if (!INTP(VECTOR_DATA(vec)[i])) STk_error("bad integer ~S used in index vector ~S",
+                                                  VECTOR_DATA(vec)[i],
+                                                  vec);
+}
+
+
+/*
+  checks if index_arr contains valid indices for array.
+ */
+static inline
+void check_index_array(SCM index_arr, SCM array)
+{
+    if (ARRAY_RANK(index_arr)!=1)        STk_error("Index array must be of rank 1");
+    if (!array_zero_basedp(index_arr))   STk_error("Index array ~S is not zero-based", index_arr);
+    if (ARRAY_RANK(array) != ARRAY_LENGTH(index_arr))
+        STk_error("wrong number of indices ~S, should be ~S",
+                  MAKE_INT(ARRAY_LENGTH(index_arr)),
+                  MAKE_INT(ARRAY_RANK(array)));
+
+    /* FIXME: optimize. we should only use array-ref if the array is shared */
+    SCM args[2];
+    for (int i=0; i<ARRAY_LENGTH(index_arr); i++) {
+        args[1] = index_arr;
+        args[0] = MAKE_INT(i);
+        if (!INTP  (STk_srfi_25_array_ref(2, &args[1])) )
+            STk_error("bad integer ~S used in index vector ~S",
+                      STk_srfi_25_array_ref(2, &args[1]),
+                      index_arr);
+    }
+}
+
+/*
+  checks if single index given_index is valid for array's dimension "dim".
+ */
+static inline
+void check_array_dim_bounds(SCM array, int given_index, int dim)
+{
+    if (given_index <  ARRAY_SHAPE(array)[2*dim])
+        STk_error("array index ~S < ~S for dimension ~S",
+                  MAKE_INT(given_index),
+                  MAKE_INT(ARRAY_SHAPE(array)[2*dim]),
+                  MAKE_INT(dim));
+    if(given_index >= ARRAY_SHAPE(array)[2*dim+1])
+        STk_error("array index ~S >= ~S for dimension ~S",
+                  MAKE_INT(given_index),
+                  MAKE_INT(ARRAY_SHAPE(array)[2*dim+1]),
+                  MAKE_INT(dim));
+}
+
+
+/*****************/
+/* INDEX GETTERS */
+/*****************/
+
+static inline long
+get_index_from_C_args(SCM array, int argc, int *argv)
+{
+    register long index = ARRAY_OFFSET(array);
+    register long dim_idx;
+    for(register int i=0; i < argc; i++) {
+        dim_idx = *argv--; /* the index given by user for dimension i */
+        check_array_dim_bounds(array,  dim_idx,  i);
+        index +=  ARRAY_MULTS(array)[i] * dim_idx;
+    }
+    return index;
+}
+
+static inline long
+raw_get_index_from_C_args(SCM array, int argc, int *argv)
+{
+    register long index = ARRAY_OFFSET(array);
+    for(register int i=0; i < argc; i++)
+        index +=  ARRAY_MULTS(array)[i] * (*argv--); /* the index given by user for dimension i */
+    return index;
+}
+
+
+static inline long
+get_index_from_args(SCM array, int argc, SCM *argv)
+{
+    register long index = ARRAY_OFFSET(array);
+    register long dim_idx;
+    for(register int i=0; i < argc; i++) {
+        dim_idx = INT_VAL(*argv--); /* the index given by user for dimension i */
+        check_array_dim_bounds(array,  dim_idx,  i);
+        index +=  ARRAY_MULTS(array)[i] * dim_idx;
+    }
+    return index;
+}
+
+static inline long
+get_index_from_vector (SCM array, SCM vec)
+{
+    register long index = ARRAY_OFFSET(array);
+    register long dim_idx;
+    for(register int i=0; i<VECTOR_SIZE(vec); i++) {
+        dim_idx = INT_VAL(VECTOR_DATA(vec)[i]); /* the index given by user for dimension i */
+        check_array_dim_bounds(array, dim_idx, i);
+        index +=  ARRAY_MULTS(array)[i] * dim_idx;
+    }
+    return index;
+}
+
+static inline long
+get_index_from_array (SCM array, SCM idx_arr)
+{
+    register long index = ARRAY_OFFSET(array);
+    register int dim_idx;
+    if (ARRAY_SHARED(idx_arr) == -1) { /* it's a copy! can't directly acess ARRAY_DATA */
+        SCM arg;
+        for(register long i=0; i < ARRAY_LENGTH(idx_arr); i++) {
+            arg = MAKE_INT(i);
+            long dim_idx_idx = get_index_from_args(idx_arr, 1, &arg);
+            dim_idx = INT_VAL(ARRAY_DATA(idx_arr)[dim_idx_idx]);
+            check_array_dim_bounds(array, dim_idx, i);
+            index +=  ARRAY_MULTS(array)[i] * dim_idx;
+        }
+    }  else
+        for(register long i=0; i < ARRAY_LENGTH(idx_arr); i++) {
+            dim_idx = INT_VAL(ARRAY_DATA(idx_arr)[i]); /* the index given by user for dimension i */
+            check_array_dim_bounds(array, dim_idx, i);
+            index +=  ARRAY_MULTS(array)[i] * dim_idx;
+        }
+    return index;
+}
+
+/**************/
+/* AREF, ASET */
+/**************/
+
+/* AREF1 and ASET1are fast array-referencers/setters for internal use.
+   They are macros so as to avoid the use of an index vector.
+   The index, however, needs to be a lvalue (register variables won't work).
+   Indices are NOT checked (we suppose that is done before using these. */
+   
+#define AREF1(array, i) ( ARRAY_DATA(array) [ raw_get_index_from_C_args(array,1,&i) ] )
+
+#define ASET1(array, i, val) { ARRAY_DATA(array) [ raw_get_index_from_C_args(array,1,&i) ] = val; }
+
+
+/******************/
+/* ARRAY BUILDERS */
+/******************/
+
+
+/* returns the size of an array (the number of elements in it),
+   given its rank and shape.
+   - if rank is zero, size is zero;
+   - if a dimension has no possible index, for example as the
+     second dimension in (shape 0 3 5 5  0 3), the size
+     will be zero. */   
+static inline long
+get_array_size(int rank, long *shape)
+{
+    if (rank == 0) return 0;
+    long size = 1;
+    for (int i=0; i<rank; i++)
+        size *= (shape[i*2+1] - shape[i*2]);
+
+    return size;
+}
+
+
+SCM STk_make_array(int rank, long *shape, SCM init)
+{
+  /* size = number of elements, not number of bytes! */
+  long size = get_array_size(rank, shape);
+
+  /* Not explicit in SRFI-25, but the tests and reference implementation
+     expect you to be able to make an empty array WITH AN INIT VALUE,
+     which IS TO BE RETURNED by (array-ref a), and set
+     by (array-set! a new-value). So we need to keep at least one cell
+     in the array.  */
+  long elements_size = size ? size : 1;
+
+  /* shape is rank * 2 * sizeof(long),
+     multipliers is rank *  sizeof(long).
+     add them to size of data[]           */
+  long metadata_size = elements_size + rank * 3;
+    
+  register long i;
+
+  SCM a;
+  NEWCELL_WITH_LEN(a, array,
+                   sizeof(struct array_obj) +
+                   sizeof(int) +                  /* shared */
+                   sizeof(int*) +                 /* orig_share_count */
+                   sizeof(long) +                 /* size */
+                   sizeof(long) +                 /* length */
+                   sizeof(int) +                  /* rank */
+                   sizeof(long) +                 /* offset */
+                   sizeof(long*) +                /* shape */
+                   sizeof(long*) +                /* multipliers */
+                   sizeof(SCM*) +                 /* data_ptr */
+                   elements_size * sizeof(SCM) +  /* data (elements) */
+                   metadata_size * sizeof(long)); /* meta-data (multipliers & shape) */
+
+  struct array_obj *s = (struct array_obj *) a;
+
+  s->shared           = 0;
+  s->orig_share_count = &s->shared;
+  s->size             = size;
+  s->length           = size;
+  s->rank             = rank;
+  s->offset           = 0L;     /* will be updated, see below */
+
+  /* data begins right after the data pointer: */
+  s->data_ptr = (SCM *)(&(s->data_ptr)) + 1;
+
+  /* then multipliers, then shape! */
+  s->multipliers = (long*) (s->data_ptr + elements_size);
+  s->shape = s->multipliers + rank;
+
+  /* copy shape array */
+  for(i=0; i<rank*2; i++)
+      s->shape[i] = shape[i];
+
+  /* the size of each stride:
+     multipliers[j] is the size of stride for j-th dimension */
+  if (rank) {
+      long m = size;
+      long d;
+      for(i=0; i<rank; i++)  {
+          d =  (shape[i*2+1] - shape[i*2]);
+          if (d) {
+              m /= d;
+              s->multipliers[i] = m;
+              s->offset -= m * shape[i*2];
+          } else {
+              /* we found an empty dimension! there are *no* sequence
+                 of indices that can address any element here, so we
+                 should treat this as an empty array, but tests from
+                 the reference implementation require that
+                 (= (array-rank (shape -1 -1)) 2)... So we don't change
+                 the rank, but do change the size!
+                 Regarding multipliers: we do calculate them, but
+                 won't ever be used anyway... */
+              s->length = 0;
+          }
+      }
+  }
+
+  /* an array created with an empty shape has one element. */
+  if (rank == 0) s->length = 1;
+
+  if (init) {
+      register SCM *tmp = ARRAY_DATA(a);
+      for(i=0; i < elements_size; i++) *tmp++ = init;
+  }
+
+  return a;
+}
+
+DEFINE_PRIMITIVE("array?", srfi_25_arrayp, subr1, (SCM obj))
+{
+  return MAKE_BOOLEAN(ARRAYP(obj));
+}
+
+static int
+long * shapetoCshape(SCM shape)
+{
+    int len = ARRAY_LENGTH(shape);
+
+    if (len%2) STk_error("bad array shape ~S", shape);
+
+    /* shape could be a shared array, so we can't blindly traverse its data array. */
+    long *cshape = STk_must_malloc(len * sizeof(long));
+    long index;
+    SCM arg[2];
+
+    for (int i = 0; i < len/2; i++) {
+        for (int j = 0; j < 2; j++) {
+            arg[1]=MAKE_INT(i);
+            arg[0]=MAKE_INT(j);
+            index = get_index_from_args(shape,2,&arg[1]);
+            cshape[2*i+j] = INT_VAL(ARRAY_DATA(shape)[index]);
+        }
+    }
+    return cshape;
+}
+
+
+/*
+<doc EXT shape?
+ * (shape? obj)
+ *
+ * Checks if |obj| is an array shape. SRFI-25 dictates that a
+ * shape is an ordinary array, with rank two and shape |(0 r 0 2)|,
+ * where |r| is the rank of the array that the shape describes.
+ * So -- any array of shape |(0 r 0 2| is a shape, for any non-negative
+ * integer |r|.
+doc>
+*/
+DEFINE_PRIMITIVE("shape?", srfi_25_shapep, subr1, (SCM obj))
+{
+    if (!ARRAYP(obj))               return STk_false;
+    if (ARRAY_RANK(obj) != 2)       return STk_false;
+    if (ARRAY_SHAPE(obj)[0] != 0)   return STk_false;
+    if (ARRAY_SHAPE(obj)[2] != 0)   return STk_false;
+    if (ARRAY_SHAPE(obj)[3] != 2)   return STk_false;
+    return STk_true;
+}
+
+
+DEFINE_PRIMITIVE("make-array",srfi_25_make_array,subr12,(SCM shape, SCM obj))
+{
+    if (!obj) obj = STk_void;
+    if (STk_srfi_25_shapep(shape) == STk_false) STk_error("bad array shape ~S",shape);
+    long *cshape = shapetoCshape(shape);
+    long len = ARRAY_LENGTH(shape);
+
+    return STk_make_array(len/2, cshape, obj);
+}
+
+DEFINE_PRIMITIVE("shape",srfi_25_shape,vsubr,(int argc, SCM *argv))
+{
+  if (argc % 2) STk_error("bad array shape nummber or args ~S", argc);
+
+  /* shape of a shape is 0 d 0 2 */
+  long *meta_shape = STk_must_malloc(4*sizeof(long));
+  meta_shape[0]=0L;
+  meta_shape[1]=argc/2L; 
+  meta_shape[2]=0L;
+  meta_shape[3]=2L; /* two elements (start/end) */
+
+  SCM s = STk_make_array(2, meta_shape, NULL);
+  for (int i=0; i < argc; i++)
+      ARRAY_DATA(s)[i] = *argv--;
+
+  for (int i=0; i < argc/2; i++)
+      if (INT_VAL(ARRAY_DATA(s)[2*i])  >  INT_VAL(ARRAY_DATA(s)[2*i+1])) {
+          STk_error("shape has upper bound below lower bound");
+      }
+  
+  return s;
+}
+
+
+DEFINE_PRIMITIVE("array", srfi_25_array, vsubr, (int argc, SCM *argv))
+{
+    if (argc < 1) STk_error("not enough arguments");
+    
+    SCM shape = *argv--;
+    if (!STk_srfi_25_shapep(shape)) STk_error("bad array shape ~S",shape);
+    
+    long *cshape = shapetoCshape(shape);
+    long len = ARRAY_LENGTH(shape);
+
+    /* The empty array may or may not have a single init element */
+    if (len > 0) {
+        if (get_array_size(len/2,cshape) != (argc-1))
+            STk_error("shape does not match argument count");
+        
+    } else if (argc > 2) /* The empty array case: one or zero inits */
+            STk_error("shape does not match argument count");
+    
+    SCM a = STk_make_array(len/2, cshape, NULL);
+
+    /* array, empty or not, with init. use it. */
+    for(int i = 0; i < argc-1; i++)
+        ARRAY_DATA(a)[i] = *argv--;
+
+    /* empty array *without* init; use NULL (should this be #void?) */
+    if ((len == 0) && (argc == 1))
+        ARRAY_DATA(a)[0] = NULL;
+    
+    return a;
+}
+
+DEFINE_PRIMITIVE("array-rank", srfi_25_array_rank, subr1, (SCM obj))
+{
+  if (!ARRAYP(obj)) STk_error("bad array ~S", obj);
+  return MAKE_INT(ARRAY_RANK(obj));
+}
+
+DEFINE_PRIMITIVE("array-start", srfi_25_array_start,subr2, (SCM array, SCM k))
+{
+    if(!ARRAYP(array))STk_error("bad array ~S", array);
+    if(!INTP(k)) STk_error("bad integer ~S", k);
+    long dim = INT_VAL(k);
+    if (dim >= ARRAY_RANK(array)) STk_error("array dimension ~S too high",k);
+    if (dim < 0L)  STk_error("negative array dimension ~S", k);
+    return MAKE_INT((ARRAY_SHAPE(array)[2*dim]));
+}
+
+DEFINE_PRIMITIVE("array-end", srfi_25_array_end,subr2, (SCM array, SCM k))
+{
+    if(!ARRAYP(array))STk_error("bad array ~S", array);
+    if(!INTP(k)) STk_error("bad integer ~S", k);
+    long dim = INT_VAL(k);
+    if (dim >= ARRAY_RANK(array)) STk_error("array dimension ~S too high",k);
+    if (dim < 0L)  STk_error("negative array dimension ~S", k);
+    return MAKE_INT((ARRAY_SHAPE(array)[2*dim+1]));
+}
+
+
+
+DEFINE_PRIMITIVE("array-ref", srfi_25_array_ref,vsubr, (int argc, SCM *argv))
+{
+    if (argc<1) STk_error("not enough arguments");
+
+    /* we have at least the first argument, the array: */
+    SCM array = *argv--;
+    if(!ARRAYP(array)) STk_error("bad array ~S", array);
+
+    /* The empty array. rank == 0,  argc == 1. */
+    if (ARRAY_RANK(array) == 0 && argc == 1) {
+        if (!ARRAY_DATA(array)[0]) STk_error("array ~S has no default value", array);
+        return ARRAY_DATA(array)[0];
+    }
+
+    /* SRFI-25 says indices can be split into args, (array-set! A i j k value)
+       OR they can be in a vector, (array-set! A #(i j k) value),
+       OR an array,  (array-set! A #1A((0 3)(i j k)) value),.
+       So we need to check all these cases here.    */
+
+    register long index;
+    
+    if (INTP(*argv)) {
+        check_index_arguments(array, argc-1, argv);
+        index = get_index_from_args(array, argc-1, argv);
+        
+    } else if (VECTORP(*argv)) {
+        if (VECTOR_SIZE(*argv)==0) {
+            if (!ARRAY_DATA(array)[0]) STk_error("array ~S has no default value", array);
+            return ARRAY_DATA(array)[0];
+        }
+        check_index_vector(*argv, array);
+        index = get_index_from_vector(array, *argv);
+        
+    } else if (ARRAYP(*argv)) {
+        check_index_array(*argv,array);
+        
+        if (ARRAY_RANK(array) == 0)  {
+            if (!ARRAY_DATA(array)[0]) STk_error("array ~S has no default value", array);
+            return  ARRAY_DATA(array)[0];
+        }
+        index = get_index_from_array(array, *argv);
+        
+    } else STk_error("Index must be vector, array or sequence of integers");
+    
+    return ARRAY_DATA(array)[index];
+}
+
+
+
+DEFINE_PRIMITIVE("array-set!", srfi_25_array_set,vsubr, (int argc, SCM *argv))
+{
+    if (argc<2) STk_error("not enough arguments");
+
+    /* we have at least the first argument, the array: */
+    SCM array = *argv--;
+    if(!ARRAYP(array)) STk_error("bad array ~S", array);
+
+    /* The empty array. rank == 0, argc == 2. */
+    if (ARRAY_RANK(array) == 0 && argc == 2) {
+        ARRAY_DATA(array)[0] = *argv;
+        return STk_void;
+    }
+    
+    /* SRFI-25 says indices can be split into args, (array-set! A i j k value)
+       OR they can be in a vector, (array-set! A #(i j k) value),
+       OR an array,  (array-set! A #1A((0 3)(i j k)) value),.
+       So we need to check all these cases here.    */
+
+    register long index;
+    
+    if (INTP(*argv)) {
+        check_index_arguments(array, argc-2, argv);
+        index = get_index_from_args(array, argc-2, argv);
+        argv -= (argc-2) ; /* skip indices */
+    } else if (VECTORP(*argv)) {
+        if (VECTOR_SIZE(*argv)==0) {
+            argv--;
+            ARRAY_DATA(array)[0] = *argv;
+            return STk_void;
+        }
+        check_index_vector(*argv,array);
+        index = get_index_from_vector(array, *argv);
+        argv--; /* skip the vector with indices */
+        
+    } else if (ARRAYP(*argv)) {
+        check_index_array(*argv,array);
+        
+        if (ARRAY_RANK(array) == 0) {
+            argv--;
+            ARRAY_DATA(array)[0] = *argv;
+            return STk_void;
+        }
+        index = get_index_from_array(array, *argv);
+        argv--; /* skip the array with indices */
+        
+    } else STk_error("Index must be vector, array or sequence of integers");
+    
+    ARRAY_DATA(array)[index] = *argv;
+
+    return STk_void;
+}
+
+
+/***************/
+/* SHARE-ARRAY */
+/***************/
+
+SCM *get_coefficients (SCM proc, int p)
+{
+    SCM *coefs = STk_must_malloc((p+1) * sizeof(SCM));
+    SCM args = STk_vector2list(STk_makevect(p, MAKE_INT(0)));
+    SCM zero = MAKE_INT(0);
+    SCM one = MAKE_INT(1);
+    int i, j;
+
+    /*
+      The affine map mentioned in the SRFI is a linear map plus a
+      constant -- the linear map is identified by running proc
+      on the canonical basis, so we identify the map coefficients.
+      
+      # GIVEN:
+      
+      new array indices      r1, r2, ..., rp
+                multipliers  n1, n2, ..., np
+                offset       f
+                
+      old array indices      x1, x2, ..., xq
+                multipliers  m1, m2, ..., mq
+                offset       o
+
+      # THEN:
+
+      * MAP COEFFICIENTS from indices r_ to indices x_ :
+
+      x_1 = a_11 r1 + a_12 r2 + ... a_1p rp   + k_1
+      x_2 = a_21 r1 + a_22 r2 + ... a_2p rp   + k_2
+      x_3 = a_31 r1 + a_32 r2 + ... a_3p rp   + k_3
+      ...
+      x_q = a_q1 r1 + a_q2 r2 + ... a_qp rp   + k_q
+
+      * MAP CONSTANTS are
+
+      k_1 k_2 ... k_q
+      
+      * MULTIPLIERS for the new array are:
+
+      n1 = a_11 m1 + a_21 m2 + ... + a_q1 mq
+      n2 = a_12 m1 + a_22 m2 + ... + a_q2 mq
+      ...
+      np = a_1p m1 + a_2p m2 + ... + a_qp mq
+
+      * OFFSET for the new array is:
+      
+      f = o + m1 k1 + m2 k2 + ... + mq kq
+    */
+
+    /*
+     
+      (proc r1=0 ... ri=1 ... rp=0) retruns Q values:
+      
+      a_i1 + k_1,   a_i2 + k_2,   ... ,  a_iq + k_q
+
+     */
+    
+    
+    /* k_1 ... k_q  q = rank of old array */
+    SCM k = STk_values2vector(STk_C_apply_list(proc, args),NULL);
+    int q = VECTOR_SIZE(k);
+        
+    /* coefs[i] is a vector with the a_j,i coefficients --
+       the coefficient a_ji in the affine map */
+    for (i=0; i < p; i++) {
+
+        STk_list_set(args, MAKE_INT(i), one);
+        
+        coefs[i] = STk_values2vector(STk_C_apply_list(proc, args),NULL);
+        
+        for (j=0; j < q; j++)
+            VECTOR_DATA(coefs[i])[j] = MAKE_INT(INT_VAL(VECTOR_DATA(coefs[i])[j]) -
+                                                INT_VAL(VECTOR_DATA(k)[j]));
+            
+        STk_list_set(args, MAKE_INT(i), zero);
+    }
+    coefs[p] = k;
+
+    /* COEFS:
+
+       0 -> a_10 ... a_q0
+       1 -> a_11 ... a_q1
+       2 -> a_12 ... a_q2
+       .
+       .
+       .
+       p -> k_1 k_2 ... k_q
+     */
+     
+    return coefs;
+}
+
+
+/* Increases the sare counter of an array. */
+static void shared_array_inc_count(SCM array)
+{
+    struct array_obj *a = (struct array_obj *) array;
+    MUT_LOCK(a->share_cnt_lock);
+    (*(a->orig_share_count))++;
+    MUT_UNLOCK(a->share_cnt_lock);
+};
+
+/* Decreases the sare counter of an array. This is registered as a finalizer
+   only for arrays that were build with share-array. */
+static void shared_array_dec_count(SCM array)
+{
+    struct array_obj *a = (struct array_obj *) array;
+    MUT_LOCK(a->share_cnt_lock);
+    (*(a->orig_share_count))--;
+    MUT_UNLOCK(a->share_cnt_lock);
+};
+
+
+DEFINE_PRIMITIVE("share-array", srfi_25_share_array, subr3, (SCM old_array, SCM new_shape, SCM proc))
+{
+    if (!ARRAYP(old_array)) STk_error("bad array ~S", old_array);
+    if (STk_srfi_25_shapep(new_shape)==STk_false) STk_error("bad arrayp ~S", new_shape);
+    if (!CLOSUREP(proc)) STk_error("bad procedure ~S", proc);
+
+    int p = ARRAY_LENGTH(new_shape)/2; /* rank of new */
+    int q = ARRAY_RANK(old_array);     /* rank of old */
+    int i, j;
+
+    /* shape of the new vector. we store shapes as C arrays, not as Scheme arrays,
+       so we need to recover each value... */
+    long *cshape= shapetoCshape(new_shape);
+
+    /* the number of elements that will be accessible from this array. */
+    long elements_size = get_array_size(p,cshape);
+    
+    /* mark old array as shared by one more array, OR of the original
+       array (the right thing will be done) */    
+    shared_array_inc_count(old_array);
+    
+    SCM a;
+    NEWCELL_WITH_LEN(a, array,
+                   sizeof(struct array_obj) +
+                   sizeof(int) +                  /* shared */
+                   sizeof(int*) +                 /* orig_share_count */
+                   sizeof(long) +                 /* size */
+                   sizeof(long) +                 /* length */
+                   sizeof(int) +                  /* rank */
+                   sizeof(long) +                 /* offset */
+                   sizeof(long*) +                /* shape */
+                   sizeof(long*) +                /* multipliers */
+                   sizeof(SCM*));                 /* data_ptr */
+                   /* don't include data elements, we'll use the othre array's */
+
+    /* multipliers */
+    long *old_mult = ARRAY_MULTS(old_array);
+
+    SCM *coefs = get_coefficients(proc, p );
+
+    long offset = ARRAY_OFFSET(old_array);
+    for (i=0; i<q; i++)
+        offset += old_mult[i] * INT_VAL(VECTOR_DATA(coefs[p])[i]);
+
+    long *new_mult = STk_must_malloc(p * sizeof(long));
+    for (i=0; i<p; i++) {
+        new_mult[i] = 0L;
+        for (j=0; j<q; j++)
+            new_mult[i] += old_mult[j] * INT_VAL(VECTOR_DATA(coefs[i])[j]);
+    }
+        
+    struct array_obj *s = (struct array_obj *) a;
+    
+    s->shared           = -1;
+    if (ARRAY_SHARE_COUNT(old_array) >= 0) /* original has the data */
+        s->orig_share_count = &ARRAY_SHARED(old_array);
+    else
+        s->orig_share_count = ARRAY_SHARE_COUNT(old_array); /* original was already a copy, has pointer */
+    s->size             = ARRAY_SIZE(old_array);            /* we share the data object! */
+    s->length           = elements_size;                    /* number of elements  usable in THIS array */
+    s->rank             = p;
+    s->offset           = offset;
+    s->shape            = cshape;
+    s->multipliers      = new_mult;
+    s->data_ptr         = ARRAY_DATA(old_array);
+
+    STk_register_finalizer(a, shared_array_dec_count);
+
+    return a;
+}
+
+/*===========================================================================*\
+ *
+ *  EXTRA
+ *
+\*===========================================================================*/
+
+
+/*
+<doc EXT shared-array?
+ * (shared-array? array)
+ *
+ * Will return true when the array has its data shared with other
+ * arrays.
+doc>
+ */
+DEFINE_PRIMITIVE("shared-array?",srfi_25_shared_arrayp,subr1,(SCM array))
+{
+  if (!ARRAYP(array)) STk_error("bad array ~S", array);
+  return MAKE_BOOLEAN(ARRAY_SHARED(array));
+}
+
+/*
+<doc EXT array-share-count
+ * (array-share-count array)
+ *
+ * Returns the number of arrays that were built sharing |array|'s
+ * elements through |(share-array array shape proc)|, and that were not
+ * yet garbage collected.
+ * Note that it may take a long time for an object to be garbage
+ * collected automatically, but it is possible to force a garbage
+ * collection pass with |gc|
+doc>
+ */
+DEFINE_PRIMITIVE("array-share-count",srfi_25_array_share_count,subr1,(SCM array))
+{
+  if (!ARRAYP(array)) STk_error("bad array ~S", array);
+  return MAKE_INT(ARRAY_SHARED(array));
+}
+
+
+/*
+<doc EXT array-shape
+ * (array-shape array)
+ *
+ * Returns the shape of |array|.
+doc>
+ */
+DEFINE_PRIMITIVE("array-shape",srfi_25_array_shape,subr1,(SCM array))
+{
+    if (!ARRAYP(array)) STk_error("bad array ~S", array);
+
+    long *ashape = ARRAY_SHAPE(array);
+    int dim = 2 * ARRAY_RANK(array);
+        
+    long *meta_shape = STk_must_malloc(4*sizeof(long));
+    meta_shape[0]=0L;
+    meta_shape[1]=ARRAY_RANK(array);
+    meta_shape[2]=0L;
+    meta_shape[3]=2L;               
+
+    SCM shape = STk_make_array(2,meta_shape,NULL);
+
+    for (int i = 0; i < dim; i++)
+        ARRAY_DATA(shape)[i] = MAKE_INT(ashape[i]);
+        
+    return shape;
+}
+
+/*
+<doc EXT array-size
+ * (array-size array)
+ *
+ * Returns the number of elements in |array|.
+doc>
+ */
+DEFINE_PRIMITIVE("array-size",srfi_25_array_size,subr1,(SCM array))
+{
+    if (!ARRAYP(array)) STk_error("bad array ~S", array);
+    long size = ARRAY_LENGTH(array);
+    return MAKE_INT( size);/*? size : 1); / * empty arrays always have the default value */
+}
+
+
+/*
+<doc EXT array-copy+share
+ * (array-copy+share array)
+ *
+ * Returns a copy of |array|.
+ * If array does not have its own internal data, but was built using
+ * share-array, then the new array will be similar -- it will be a copy of
+ * array, sharing the elements in the same way.
+doc>
+ */
+DEFINE_PRIMITIVE("array-copy+share",srfi_25_array_copy_share,subr1,(SCM old_array))
+{
+    if (!ARRAYP(old_array)) STk_error("bad array ~S", old_array);
+    SCM new_array;
+
+    long total_size =
+        sizeof(struct array_obj) +
+        sizeof(int) +                  /* shared */
+        sizeof(long) +                 /* size */
+        sizeof(long) +                 /* length */
+        sizeof(int) +                  /* rank */
+        sizeof(long) +                 /* offset */
+        sizeof(long*) +                /* shape */
+        sizeof(long*) +                /* multipliers */
+        sizeof(SCM*) +                 /* data_ptr */
+        ARRAY_SIZE(old_array);
+    
+    NEWCELL_WITH_LEN(new_array, array, total_size);
+    
+    struct array_obj *n = (struct array_obj *) new_array;
+    struct array_obj *o = (struct array_obj *) old_array;
+
+    memcpy(n,o, total_size);
+
+    /* If old_array was not share-created, then we copied its data vector,
+       and nobody points to the new copy. We created a fresh, non-shared array. */
+    if (*ARRAY_SHARE_COUNT(old_array) >= 0)  *ARRAY_SHARE_COUNT(new_array)=0;
+
+    /* If old_array was share-created, then we created a new copy of its pointer to the
+       original! :)
+       We then increase the original array's share-counter. */
+    if (*ARRAY_SHARE_COUNT(old_array) == -1) shared_array_inc_count(old_array);
+    
+    return new_array;
+}
+
+
+/*
+<doc EXT shape-for-each
+ * (shape-for-each shape proc [index-object])
+ *
+ * This procedure will apply proc to all valid sequences of
+ * indices in |shape|, in row-major order.
+ *
+ * If |index-object| is not provided, then proc must accept
+ * as many arguments as the number of dimensions that the shape
+ * describes.
+ * @lisp
+ * (shape-for-each (shape 1 3 10 12)
+ *                 (lambda (x y)
+ *                   (format #t "[~a ~a]~%" x y)))
+ * [1 10]
+ * [1 11]
+ * [2 10]
+ * [2 11]
+ * @end lisp
+ * If |index-object| is provided, it is used as a place to store the
+ * indices, so proc must accept a vector (this is to avoid pushing
+ * and popping too many values when calling proc).
+ * |index-object|, when present, must be aither a vector or array.
+ * @lisp
+ * (let ((vec (make-vector 2 #f)))
+ *   (shape-for-each (shape 1 3 10 12)
+ *                   (lambda (o)
+ *                     (format #t "[~a ~a]~%"
+ *                     (vector-ref o 0)
+ *                     (vector-ref o 1)))
+ *                   vec))
+ * [1 10]
+ * [1 11]
+ * [2 10]
+ * [2 11]
+ *
+ * (let ((arr (make-array (shape 0 2))))
+ *   (shape-for-each (shape 1 3 10 12)
+ *                   (lambda (o)
+ *                     (format #t "[~a ~a]~%"
+ *                     (array-ref o 0)
+ *                     (array-ref o 1)))
+ *                   arr))
+ * [1 10]
+ * [1 11]
+ * [2 10]
+ * [2 11]
+ * @end lisp
+doc>
+ */
+DEFINE_PRIMITIVE("shape-for-each", srfi_25_shape_for_each, vsubr, (int argc, SCM *argv))
+{
+    if (argc < 2 || argc > 3) STk_error ("either 2 or 3 arguments needed");
+    
+    SCM shape = *argv--;
+    SCM proc  = *argv;
+
+    if (!ARRAYP(shape))  STk_error("shape ~S is not an array", shape);
+    if (!CLOSUREP(proc)) STk_error("bad procedure ~S", proc);
+
+    long * cshape = shapetoCshape(shape);
+    
+    int rank = ARRAY_LENGTH(shape)/2;
+    SCM idx; // the index vector -- may or mey not be used.
+    int updated = 1;
+    register int i, d, dim;
+    
+    if (argc == 3) {
+        argv--;
+        SCM obj = *argv;
+
+        if (VECTORP(obj)) {
+            /*****************/
+            /** VECTOR CASE **/
+            /*****************/
+            idx = obj;
+
+            /* initialize idx with the lowest index for each dimension */
+            for (dim = 0; dim < rank; dim++)
+                VECTOR_DATA(idx)[dim] = MAKE_INT(cshape[dim*2]);
+
+            updated = 1;
+            while(updated) {
+                updated = 0;
+                
+                STk_C_apply(proc,1,idx);
+                    
+                /* update idx vector */
+                for(d = rank - 1; d >= 0; d--)
+                    if (INT_VAL(VECTOR_DATA(idx)[d]) < cshape[d*2+1] - 1) { /* we can increase */
+                        VECTOR_DATA(idx)[d] = MAKE_INT(INT_VAL(VECTOR_DATA(idx)[d])+1);
+                        for(i = d+1; i < rank; i++) {
+                            VECTOR_DATA(idx)[i] = MAKE_INT(cshape[i*2]);
+                        }
+                        updated=1;
+                        break;
+                    }
+            }
+            return STk_void;
+
+            
+        } else if (ARRAYP(obj)) {
+            /****************/
+            /** ARRAY CASE **/
+            /****************/
+            idx = obj;
+
+            /* initialize idx with the lowest index for each dimension.
+               since we're working on a n array, we need to first get the index into its
+               internal data. */
+            int i, dim, d;
+            for (dim = 0; dim < rank; dim++)
+                ASET1(idx, dim, MAKE_INT(cshape[dim*2]));
+
+            updated = 1;
+            while(updated) {
+                updated = 0;
+                
+                STk_C_apply(proc,1,idx);
+                    
+                /* update idx vector */
+                for(d = rank - 1; d >= 0; d--)
+                    
+                    if (INT_VAL(AREF1(idx, d)) < cshape[d*2+1] - 1) { /* we can increase */
+                        ASET1(idx, d, MAKE_INT(INT_VAL(AREF1(idx, d))+1));
+                        for(i = d+1; i < rank; i++) 
+                            ASET1(idx, i, MAKE_INT(cshape[i*2]));
+                        
+                        updated=1;
+                        break;
+                    }
+            }
+            return STk_void;
+
+        } else
+            STk_error("index-object ~S is neither array nor vector");
+    } else {
+        /***************/
+        /** ARGS CASE **/
+        /***************/
+        if (rank != CLOSURE_ARITY(proc) && CLOSURE_ARITY(proc) >=0)
+            STk_error("length of shape (~S) is different fromm procedure arity (~S)",
+                      MAKE_INT(rank),
+                      MAKE_INT(CLOSURE_ARITY(proc)));
+        
+        SCM idx = STk_makevect(rank,NULL);
+
+        /* initialize idx with the lowest index for each dimension */
+        for (dim = 0; dim < rank; dim++)
+            VECTOR_DATA(idx)[dim] = MAKE_INT(cshape[2*dim]);
+
+        while(updated) {
+            updated = 0;
+            
+            STk_C_apply_list(proc, STk_vector2list(idx));
+        
+            /* update idx vector */
+            for(d = rank - 1; d >= 0; d--)
+                if (INT_VAL(VECTOR_DATA(idx)[d]) < cshape[d*2+1] - 1) { /* we can increase */
+                    VECTOR_DATA(idx)[d] = MAKE_INT(INT_VAL(VECTOR_DATA(idx)[d])+1);
+                    for(i = d+1; i < rank; i++) {
+                        VECTOR_DATA(idx)[i] = MAKE_INT(cshape[i*2]);
+                    }
+                    updated=1;
+                    break;
+                }
+        }
+    }
+    return STk_void;
+}
+
+
+/*===========================================================================* \
+ *
+ *  Array extended type definition
+ *
+\*===========================================================================*/
+
+
+static void print_array(SCM array, SCM port, int mode)
+{
+   /* This should probably use shape-for-each, but thta function expects us
+      to pass it a Scheme procedure to be called in each step, so I left this
+      as a hard-coded loop (actually I first wrote this function then used its
+      loop as a template for shape-for-each). -- jpellegrini */
+   int i;
+   int rank = ARRAY_RANK(array);
+
+   char buffer[100];
+   sprintf(buffer,"#%d",rank);
+   STk_puts(buffer, port);
+
+   /* if the array is shared, we prepend "S" */
+   if (ARRAY_SHARED(array)) STk_putc('S',port);
+
+   /* write the array shape */
+   STk_puts("A((",port);
+   
+   for (int i =0; i< rank; i++) {
+     sprintf(buffer,"%ld %ld",
+             ARRAY_SHAPE(array)[2*i],    /* lower bound */
+             ARRAY_SHAPE(array)[2*i+1]); /* upper bound */
+     STk_puts(buffer, port);
+     if (i != rank-1 ) STk_putc(' ', port);
+   }
+   STk_puts(")", port);
+
+   /* now, the tricky part. we could easily just run through ARRAY_DATA(array),
+      printing the elements and including ")(" to separate strides, however
+      this would not work for shared arrays, because they may share the same
+      ARRAY_DATA from another array, and *NOT* even use all elements there!
+      we actually need to use array-ref, so we build an index vector that is
+      updated after each iteration.
+      for example, if the shape is (2 4 1 3), the index vector will be
+      updated sequentially as
+      #(2 1)
+      #(2 2)
+      #(3 1)
+      #(3 2)
+      and used as argument to array-ref. */
+
+   SCM idx = STk_makevect(rank,NULL);
+   int dim;
+   
+   /* initialize idx with the lowest values for all indices */
+   for (dim = 0; dim < rank; dim++)
+       VECTOR_DATA(idx)[dim] = MAKE_INT(ARRAY_SHAPE(array)[dim*2]);
+
+   SCM args[2];
+   args[1]=array;
+   args[0]=idx;
+
+   /* check for empty arrays */
+   int empty = 0;
+   for (int d=0; d<rank; d++)
+       if (ARRAY_SHAPE(array)[d*2] == ARRAY_SHAPE(array)[d*2+1]) {
+           empty = 1;
+           break;
+       }
+
+   if ( (rank==0) || empty) {
+       /* Empty arrays may have a default value. We show it here. */
+       if (ARRAY_DATA(array)[0]) {
+           STk_putc(' ', port);
+           STk_print(ARRAY_DATA(array)[0], port, mode);
+       }
+   } else {
+       STk_puts(" (", port);
+       int updated = 1;
+       while(updated) {
+           updated = 0;
+           
+           /* last dimension index is the lowest. open parens */
+           if (INT_VAL(VECTOR_DATA(idx)[rank-1]) == ARRAY_SHAPE(array)[(rank-1)*2])
+               STk_putc('(', port);
+           
+           
+           /* now we print one element: */
+           SCM x = STk_srfi_25_array_ref(2, &args[1]);
+           if (x)
+               STk_print(STk_srfi_25_array_ref(2, &args[1]), port, mode);
+           else
+               STk_error("array element is NULL, not a Scheme value -- this should not have happened!");
+           
+           /* if last dimension index is the highest possible, close parens;
+              otherwise, put a blank to separate the values. */
+           if (INT_VAL(VECTOR_DATA(idx)[rank-1]) + 1 == ARRAY_SHAPE(array)[(rank-1)*2+1])
+               STk_putc(')', port);
+           else
+               STk_putc(' ', port);
+           
+           /* update idx vector */
+           for(int d = rank - 1; d >= 0; d--)
+               if (INT_VAL(VECTOR_DATA(idx)[d]) < ARRAY_SHAPE(array)[d*2+1] - 1) { /* we can increase */
+                   VECTOR_DATA(idx)[d] = MAKE_INT(INT_VAL(VECTOR_DATA(idx)[d])+1);
+                   for(i = d+1; i < rank; i++) {
+                       VECTOR_DATA(idx)[i] = MAKE_INT(ARRAY_SHAPE(array)[i*2]);
+                   }
+                   updated=1;
+                   break;
+               }
+       }
+       STk_putc(')', port);
+   }
+   STk_putc(')', port);
+}
+
+
+static struct extended_type_descr xtype_array = {
+  "array",
+  print_array
+};
+
+
+/*===========================================================================*\
+ *
+ *  Module for SRFI-25
+ *
+\*===========================================================================*/
+
+MODULE_ENTRY_START("srfi-25")
+{
+  SCM module =  STk_create_module(STk_intern("SRFI-25"));
+  DEFINE_XTYPE(array, &xtype_array);
+
+
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_arrayp, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_shapep, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_make_array, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_shape, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_rank, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_start, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_end, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_ref, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_set, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_share_array, module);
+  
+  /* EXTRA procedures: */
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_shared_arrayp, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_share_count, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_shape, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_size, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_array_copy_share, module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_25_shape_for_each, module);
+  
+  STk_export_all_symbols(module);
+
+}
+MODULE_ENTRY_END

--- a/lib/srfi-25.stk
+++ b/lib/srfi-25.stk
@@ -1,0 +1,249 @@
+;;;;
+;;;; srfi-25.stk         -- SRFI-25: Multi-dimensional Array Primitives
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 27-Mar-2021 02:33
+;;;; Last file update: 04-Apr-2021 18:13 (jpellegrini)
+;;;;
+
+
+(load "srfi-25-impl")
+
+(select-module SRFI-25)
+
+;; extra:
+;;
+;;; (array-shape arr)        
+;;; (array-length arr dim)
+;;; (array-size arr)
+;;; (array-equal? arr1 arr2) 
+;;; (shape-for-each shp proc [ind])
+;;; (array-for-each-index arr proc [ind])
+;;; (tabulate-array shp proc)
+;;; (tabulate-array! shp proc ind)
+;;; (array-map [shp] proc arr0 arr1 ...)
+;;; (array-map! arr [shp] proc arr0 arr1 ...)
+;;; (array->vector arr) (array->list arr)
+
+;;; NOT implemented:
+;;; (share-array/prefix arr k ...) (share-row arr k) (share-column arr k)
+;;; (share-array/origin arr k ...) (share-array/origin arr ind)
+;;; (array-append dim arr0 arr1 ...)
+;;; (transpose arr dim ...)
+;;; (share-nths arr dim n)
+;;; (array-retabulate! arr shp proc [ind])
+
+
+#|
+<doc EXT array-length
+ * |(array-length array dim)|
+ *
+ * will return the length of dimension |dim| in array |array|.
+doc>
+|#
+(define (array-length arr dim)
+  (- (array-end arr dim)
+     (array-start arr dim)))
+
+#|
+<doc EXT array-for-each-index
+ *
+ * |(array-for-each-index arr proc [index-object])| will loop
+ * through all valid indices of array, applying |proc| to those
+ * indices.
+ *
+ * If |index-object| is not provided, then proc must accept
+ * as many arguments as the number of dimensions that the shape
+ * describes.
+ * If |index-object| is provided, it is used as a place to store the
+ * indices, so proc must accept a vector (this is to avoid pushing
+ * and popping too many values when calling proc).
+ * |index-object|, when present, must be aither a vector or array.
+ *
+ * See the documentation of |shape-for-each| for more information
+ * on |index-object|.
+doc>
+|#
+(define (array-for-each-index arr proc :optional (ind #f))
+  (if ind
+      (shape-for-each (array-shape arr) proc ind)
+      (shape-for-each (array-shape arr) proc)))
+
+
+#|
+<doc EXT array->vector
+ * (array->vector array)
+ *
+ * Returns a vector that contains a copy of the elements of |array|,
+ * in row-major order. The new vector does not share elements with
+ * the original array (it is a fresh copy).
+ * This is not recursive, and will not flatten the array.
+doc>
+|#
+(define (array->vector arr)
+  (let ((shape (array-shape arr))
+        (rank  (array-rank arr))
+        (len   (array-size arr)))
+    (let ((vec (make-vector len))
+          (arr-ind (make-vector rank))
+          (vec-ind 0))
+      (array-for-each-index arr
+                            (lambda (arr-ind)
+                              (vector-set! vec vec-ind (array-ref arr arr-ind))
+                              (set! vec-ind (+ 1 vec-ind)))
+                            arr-ind)
+      vec)))
+
+#|
+<doc EXT array->list
+ * (array->list array)
+ *
+ * Returns a list that contains a copy of the elements of |array|,
+ * in row-major order.
+ * This is not recursive, and will not flatten the array.
+doc>
+|#
+(define (array->list arr)
+  (vector->list (array->vector arr)))
+
+#|
+<doc EXT array-map!
+ * (array-map! array [shape] proc arr0 arr1 ...)
+ *
+ * For each valid index |idx|, applies proc to the corresponding
+ * position in |arr0|, |arr1|, ...  and then sets the same
+ * place in |array| to the result.
+ *
+ * If |shape| is specified, it should specify a subarray of
+ * |array|, and only that section will be mapped.
+|#
+(define (array-map! target shape-or-proc . more)
+  (when (< (length more) 1) (error "at least three arguments required, ~S provided"
+                                   (+ 3 (length more))))
+  
+  (when (not (array? target)) (error "bad array ~S" target))
+  
+    (let ((shape (if (shape? shape-or-proc) shape (array-shape target)))
+          (proc  (if (shape? shape-or-proc) (car more) shape-or-proc))
+          (args  (if (shape? shape-or-proc) (cdr more) more))
+          (idx-vec (make-vector (array-rank target))))
+    
+      (when (not (shape? shape))    (error "bad shape ~S" shape))
+      (when (not (procedure? proc)) (error "bad procedure ~S" proc))
+      
+      (shape-for-each shape
+                      (lambda (iv) ; idx-vec goes here
+                        (array-set! target
+                                    iv
+                                    (apply proc
+                                           (map (lambda (source)
+                                                  (array-ref source iv))
+                                                args))))
+                      idx-vec)))
+
+
+#|
+<doc EXT array-map
+ * (array-map [shape] proc arr0 arr1 ...)
+ *
+|#
+(define (array-map . args)
+  (when (< (length args) 2) (error "at least two arguments required, ~S provided"
+                                   (length args)))
+  
+  (let ((shape (cond ((shape? (car args))  ;; (array-map shape proc arr0 ...)
+                      (car args))
+                     
+                     ((array? (cadr args)) ;; (array-map proc arr0 ...)
+                      (array-shape (cadr args)))
+                     
+                     (else (error "first argument ~S is not a shape, but second ~S is not an array"
+                                  (car args) (cdr args))))))
+    (let ((new (make-array shape #void)))
+      (apply array-map! (cons new args))
+      new)))
+
+#|
+<doc EXT array-copy
+ * (array-copy array)
+ *
+ * Returns a copy of |array|.
+ * The new copy will have no data shared with any other array, even if the
+ * argument |array| did.
+|#
+(define (array-copy arr)
+  (array-map (lambda (x) x) arr))
+
+
+#|
+<doc EXT tabulate-array
+* (tabulate-array shape proc [idx])
+*
+* Returns a new array of shape |shape|, populated according
+* to |proc|. Each valid index in |shape| is passed to |proc|,
+* and the result is place in the according array position.
+*
+* |idx| is an object that may be used to store the indices, and
+* it may be either a vector or an array. If it is not present, or
+* if it is |\#f|, then an index vector will be created internally.
+doc>
+|#
+(define (tabulate-array shape proc :optional (ind #f))
+  ;; we use vector index objects always, regardless of what the
+  ;; user gave us. 
+  (let* ((arr (make-array shape)))
+    (cond ((or (vector? ind) (array? ind))
+           (lambda (idx) (array-set! arr idx (proc idx)))
+           (shape-for-each shape (lambda (idx) (array-set! arr
+                                                      idx
+                                                      (proc idx)))
+                           ind))
+          
+          ((not ind)
+           (shape-for-each shape (lambda idx (array-set! arr
+                                                    (list->vector idx)
+                                                    (apply proc idx)))))
+          
+          (else
+           (error "index object ~S is none of vector, array or #f" ind)))
+    arr))
+
+
+;; The following is here just for compatibility, requiring the third argument.
+;; * Racket only implements tabulate-array, and does not accept the index argument
+;; * Gauche implements tabulate-array, and accepts an optional ind argumet. This
+;;   seems consistent with the other procedures.
+(define (tabulate-array! shape proc ind)
+  (tabulate-array shape proc ind))
+
+  
+(export array-for-each-index
+        array->vector
+        array->list
+        array-map!
+        array-map
+        array-copy
+        tabulate-array)
+
+(select-module STklos)
+(import SRFI-25)
+
+(provide "srfi-25")

--- a/lib/srfi-25.stk
+++ b/lib/srfi-25.stk
@@ -54,28 +54,32 @@
 
 #|
 <doc EXT array-length
- * |(array-length array dim)|
+ * (array-length array dim)
  *
- * will return the length of dimension |dim| in array |array|.
+ * Returns the length of dimension |dim| in array |array|.
 doc>
 |#
 (define (array-length arr dim)
+  (when (not (array? arr))
+    (error "bad array ~S" arr))
   (- (array-end arr dim)
      (array-start arr dim)))
 
 #|
 <doc EXT array-for-each-index
  *
- * |(array-for-each-index arr proc [index-object])| will loop
- * through all valid indices of array, applying |proc| to those
- * indices.
+ * (array-for-each-index arr proc [index-object])
  *
- * If |index-object| is not provided, then proc must accept
+ * Will loop through all valid indices of |array|, applying |proc|
+ * to those indices.
+ *
+ * If |index-object| is not provided, then |proc| must accept
  * as many arguments as the number of dimensions that the shape
  * describes.
+ * 
  * If |index-object| is provided, it is used as a place to store the
- * indices, so proc must accept a vector (this is to avoid pushing
- * and popping too many values when calling proc).
+ * indices, so |proc| must accept a vector or an array (this is to avoid
+ * pushing and popping too many values when calling proc).
  * |index-object|, when present, must be aither a vector or array.
  *
  * See the documentation of |shape-for-each| for more information
@@ -83,6 +87,11 @@ doc>
 doc>
 |#
 (define (array-for-each-index arr proc :optional (ind #f))
+  (when (not (array? arr))
+    (error "bad array ~S" arr))
+  (when (not (procedure? proc))
+    (error "bad procedure ~S" proc))
+
   (if ind
       (shape-for-each (array-shape arr) proc ind)
       (shape-for-each (array-shape arr) proc)))
@@ -99,6 +108,8 @@ doc>
 doc>
 |#
 (define (array->vector arr)
+  (when (not (array? arr))
+    (error "bad array ~S" arr))
   (let ((shape (array-shape arr))
         (rank  (array-rank arr))
         (len   (array-size arr)))
@@ -136,8 +147,8 @@ doc>
  * |array|, and only that section will be mapped.
 |#
 (define (array-map! target shape-or-proc . more)
-  (when (< (length more) 1) (error "at least three arguments required, ~S provided"
-                                   (+ 3 (length more))))
+  (when (null? more) (error "at least three arguments required, ~S provided"
+                            (+ 2 (length more))))
   
   (when (not (array? target)) (error "bad array ~S" target))
   
@@ -148,11 +159,17 @@ doc>
     
       (when (not (shape? shape))    (error "bad shape ~S" shape))
       (when (not (procedure? proc)) (error "bad procedure ~S" proc))
-      
+      (when (not (every array? args)) (error "non-array in array list"))
+      (let ((list-shape (array->list shape)))
+        (when (not (every (lambda (arr) (equal? list-shape arr))
+                          (map array->list (map array-shape (cons target args)))))
+          (error "shapes are not compatible: ~S"
+                 (map array->list (map array-shape (cons shape args))))))
+
       (shape-for-each shape
                       (lambda (iv) ; idx-vec goes here
                         (array-set! target
-                                    iv
+                                    iv 
                                     (apply proc
                                            (map (lambda (source)
                                                   (array-ref source iv))
@@ -164,6 +181,15 @@ doc>
 <doc EXT array-map
  * (array-map [shape] proc arr0 arr1 ...)
  *
+ * This procedure is similar to |map| for lists:
+ * it will run |proc| on an element of each of the
+ * |arr0|, |arr1|, ... arguments, storing the result in
+ * the equivalent position of a newly created array.
+ *
+ * The shapes of the arrays must be the same.
+ *
+ * The prodecude will create a new array with shape |shape|
+ * (or |arr0|'s shape, if |shape was not specified).
 |#
 (define (array-map . args)
   (when (< (length args) 2) (error "at least two arguments required, ~S provided"
@@ -208,7 +234,9 @@ doc>
 |#
 (define (tabulate-array shape proc :optional (ind #f))
   ;; we use vector index objects always, regardless of what the
-  ;; user gave us. 
+  ;; user gave us.
+  (when (not (shape? shape)) (error "bad shape ~S" shape))
+  (when (not (procedure? proc)) (error "bad procedure ~S" proc))
   (let* ((arr (make-array shape)))
     (cond ((or (vector? ind) (array? ind))
            (lambda (idx) (array-set! arr idx (proc idx)))

--- a/lib/srfi-25.stk
+++ b/lib/srfi-25.stk
@@ -262,14 +262,20 @@ doc>
 (define (tabulate-array! shape proc ind)
   (tabulate-array shape proc ind))
 
-  
+;; reader for arrays
+(define-reader-ctor 'array
+  (lambda args
+    (apply array (apply shape (car args)) (cdr args))))
+
+
 (export array-for-each-index
         array->vector
         array->list
         array-map!
         array-map
         array-copy
-        tabulate-array)
+        tabulate-array
+        tabulate-array!)
 
 (select-module STklos)
 (import SRFI-25)

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -63,7 +63,7 @@
     (22 "Running Scheme Scripts on Unix")
     (23 "Error reporting mechanism" (error))
     ;;  24 ........ Withdrawn
-    ;;  25 Multi-dimensional Arrays
+    (25 "Multi-dimensional Arrays" () "srfi-25")
     (26 "Notation for Specializing Parameters without Currying" () "srfi-26")
     (27 "Source of random bits" (random) "srfi-27")
     (28 "Basic Format Strings")

--- a/src/boolean.c
+++ b/src/boolean.c
@@ -391,6 +391,22 @@ DEFINE_PRIMITIVE("equal?", equal, subr2, (SCM x, SCM y))
       if (BOXED_TYPE_EQ(y, tc_uvector))
         return MAKE_BOOLEAN(STk_uvector_equal(x, y));
       break;
+    case tc_array:
+        if (ARRAYP(y)) {
+            long lx, ly, i;
+            SCM *dx, *dy;
+
+            lx = ARRAY_SIZE(x); ly = ARRAY_SIZE(y);
+            if (lx == ly) {
+                dx = ARRAY_DATA(x);
+                dy = ARRAY_DATA(y);
+                for (i=0; i < lx;  i++) {
+                    if (STk_equal(dx[i], dy[i]) == STk_false) return STk_false;
+                }
+                return STk_true;
+            }
+        }
+        break;
 #ifdef FIXME
 //EG:       default:
 //EG:           if (EXTENDEDP(x) && EXTENDEDP(y) && TYPE(x) == TYPE(y))

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -1435,6 +1435,13 @@ struct array_obj {
 #define ARRAY_MULTS(p)       (((struct array_obj *) (p))->multipliers)
 #define ARRAY_DATA(p)        (((struct array_obj *) (p))->data_ptr)
 
+#ifdef THREADS_NONE
+#  define ARRAY_MUTEX(p)
+#  define ARRAY_MUTEX_SIZE 1
+#else
+#  define ARRAY_MUTEX(p) (((struct array_obj *) (p))->share_cnt_lock)
+#  define ARRAY_MUTEX_SIZE (sizeof(pthread_mutex_t))
+#endif
 
 /*
   ------------------------------------------------------------------------------

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -188,6 +188,7 @@ typedef enum {
   tc_regexp, tc_process, tc_continuation, tc_values, tc_parameter,      /* 30 */
   tc_socket, tc_struct_type, tc_struct, tc_thread, tc_mutex,            /* 35 */
   tc_condv, tc_box, tc_ext_func, tc_pointer, tc_callback,               /* 40 */
+  tc_array,                                                             /* 45 */
   tc_last_standard /* must be last as indicated by its name */
 } type_cell;
 
@@ -1390,6 +1391,50 @@ EXTERN_PRIMITIVE("list->vector", list2vector, subr1, (SCM l));
 
 SCM STk_makevect(int len, SCM init);
 int STk_init_vector(void);
+
+
+/*
+  ------------------------------------------------------------------------------
+  ----
+  ----                                 A R R A Y . C
+  ----
+  ------------------------------------------------------------------------------
+*/
+
+/* Only the definition of the array structure and related macros are here.
+   All the rest is in srfi-25-impl.c.
+   These bits are here so we can use 'tc_array' as a type -- however, without
+   loading SRFI 25, nothing can be done on arrays.
+
+   See srfi-25-impl.c for implementation details -- there is an explanation
+   in the beginning of the file.   */
+
+
+struct array_obj {
+  stk_header header;
+  int shared;                /* does this array share data with another? */
+  int *orig_share_count;     /* pointer to original array share counter */
+  MUT_FIELD(share_cnt_lock); /* lock for share counter */
+  long size;                 /* size of data */
+  long length;               /* # of elements */
+  int  rank;                 /* # of dimensons */
+  long offset;               /* offset from zero, to be added when calculaing index */
+  long *shape;               /* pairs of bounds for each dimenson */
+  long *multipliers;         /* size of each dimension stride */
+  SCM  *data_ptr;            /* pointer to data */
+};
+
+#define ARRAYP(p)            (BOXED_TYPE_EQ((p), tc_array))
+#define ARRAY_SHARED(p)      (((struct array_obj *) (p))->shared)
+#define ARRAY_SHARE_COUNT(p) (((struct array_obj *) (p))->orig_share_count)
+#define ARRAY_SIZE(p)        (((struct array_obj *) (p))->size)
+#define ARRAY_LENGTH(p)      (((struct array_obj *) (p))->length)
+#define ARRAY_RANK(p)        (((struct array_obj *) (p))->rank)
+#define ARRAY_OFFSET(p)      (((struct array_obj *) (p))->offset)
+#define ARRAY_SHAPE(p)       (((struct array_obj *) (p))->shape)
+#define ARRAY_MULTS(p)       (((struct array_obj *) (p))->multipliers)
+#define ARRAY_DATA(p)        (((struct array_obj *) (p))->data_ptr)
+
 
 /*
   ------------------------------------------------------------------------------

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -882,3 +882,30 @@
   (let ((c (mult a b)))
     (test "srfi-25 jp.matrix-mult.1" '(0 2 0 2) (array->list (array-shape c)))
     (test "srfi-25 jp.matrix-mult.2" '(-4 -4 5 1) (array->list c))))
+
+
+;; some tests for the reader.
+;;
+(test "srfi-25 jp.reader.1" #t (array? (read-from-string "#,(array ())")))
+(test "srfi-25 jp.reader.2" 0 (array-rank (read-from-string "#,(array ())")))
+(test "srfi-25 jp.reader.3" 2 (array-rank (array-shape (read-from-string "#,(array ())"))))
+(test "srfi-25 jp.reader.4" #f (shared-array? (read-from-string "#,(array ())")))
+
+(test "srfi-25 jp.reader.4" #t (array? (read-from-string "#,(array (0 0 1 2))")))
+(test "srfi-25 jp.reader.5" 2 (array-rank (read-from-string "#,(array (0 0 1 2))")))
+(test "srfi-25 jp.reader.6" 2 (array-rank (array-shape (read-from-string "#,(array (0 0 1 2))"))))
+(test "srfi-25 jp.reader.7" #f (shared-array? (read-from-string "#,(array (0 0 1 2))")))
+
+(test "srfi-25 jp.reader.7" #t (array? (read-from-string "#,(array (0 1 1 3) -1 -2)")))
+(test "srfi-25 jp.reader.8" 2 (array-rank (array-shape (read-from-string "#,(array (0 1 1 3) -1 -2)"))))
+(test "srfi-25 jp.reader.9" 2 (array-rank (read-from-string "#,(array (0 1 1 3) -1 -2)")))
+(test "srfi-25 jp.reader.10" #f (shared-array? (read-from-string "#,(array (0 0 1 2))")))
+
+(test "srfi-25 jp.reader.11" #t (array? (read-from-string "#,(array (0 1 1 3 -2 0) -1 -2 -3 -4)")))
+(test "srfi-25 jp.reader.12"
+      '(-1 -2 -3 -4)
+      (array->list (read-from-string "#,(array (0 1 1 3 -2 0) -1 -2 -3 -4)) ")))
+
+(test "srfi-25 jp.reader.13" 42 (array-ref (read-from-string "#,(array () 42)")))
+(test/error "srfi-25 jp.reader.14" (array-ref (read-from-string "#,(array ())")))            ;; no default value
+(test/error "srfi-25 jp.reader.15" (array-ref (read-from-string "#,(array (0 0 1 2))") 0 1)) ;; no possible indices

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -56,6 +56,8 @@
 
 ;;; Simple tests
 
+
+      
 (test "srfi-25 1"
       #f
       (not (and (shape)
@@ -839,4 +841,44 @@
         (array-share-count orig))
   (test "srfi 25 jp 25.threads.2" #t (shared-array? orig)))
 
-  
+
+(test "srfi-25 26.shape.1" #t (shape? (shape)))
+(test "srfi-25 26.shape.2" #t (shape? (shape 0 0)))
+(test "srfi-25 26.shape.3" #t (shape? (shape 0 1)))
+(test "srfi-25 26.shape.4" #t (shape? (shape 1 10 -10 1)))
+
+(test "srfi-25 26.array.1" #t (array? (make-array (shape) #eof)))
+(test "srfi-25 26.array.2" #t (array? (make-array (shape 0 0))))
+(test "srfi-25 26.array.3" #t (array? (make-array (shape 0 1) #eof)))
+(test "srfi-25 26.array.4" #t (array? (make-array (shape 1 10 -10 1) #eof)))
+
+(test "srfi-25 26.array.5" #t (array? (array (shape) #eof)))
+(test "srfi-25 26.array.6" #t (array? (array (shape 0 0))))
+(test "srfi-25 26.array.7" #t (array? (array (shape 0 1) #eof)))
+(test "srfi-25 26.array.8" #t (array? (array (shape 1 3 -3 1)
+                                             -1 -2 -3 -4 -5 -6 -7 -8)))
+
+(define (mult a b)
+  (let ((rows (array-end a 0))
+        (cols (array-end b 1))
+        (x    (array-end a 1)))
+    (let ((c (make-array (shape 0 rows 0 cols) 0)))
+      (dotimes (i rows)
+        (dotimes (j cols)
+          (dotimes (k x)
+            (array-set! c i j
+                        (+ (array-ref c i j)
+                           (* (array-ref a i k)
+                              (array-ref b k j)))))))
+      c)))
+
+(let ((a (array (shape 0 2 0 3)
+                1 -2 0
+                4  1 1))
+      (b (array (shape 0 3 0 2)
+                0  0
+                2  2
+                3 -1)))
+  (let ((c (mult a b)))
+    (test "srfi-25 jp.matrix-mult.1" '(0 2 0 2) (array->list (array-shape c)))
+    (test "srfi-25 jp.matrix-mult.2" '(-4 -4 5 1) (array->list c))))

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -1,0 +1,808 @@
+;;;; 25.stk         -- tests for SRFI-25: Multi-dimensional Array Primitives
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Jussi Piitulainen, it is copyrighted as:
+;;;;
+;;;;;; Copyright (C) Jussi Piitulainen (2001). All Rights Reserved.
+;;;;;;
+;;;;;; Redistribution and use in source and binary forms, with or without
+;;;;;; modification, are permitted provided that the following conditions
+;;;;;; are met:
+;;;;;; 1. Redistributions of source code must retain the above copyright
+;;;;;;    notice, this list of conditions and the following disclaimer.
+;;;;;; 2. Redistributions in binary form must reproduce the above copyright
+;;;;;;    notice, this list of conditions and the following disclaimer in the
+;;;;;;    documentation and/or other materials provided with the distribution.
+;;;;;; 3. The name of the authors may not be used to endorse or promote products
+;;;;;;    derived from this software without specific prior written permission.
+;;;;;;
+;;;;;; THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+;;;;;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;;;;;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;;;;;; IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+;;;;;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;;;;;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;;;;;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;;;;;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;;;;;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;;;;;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 29-Mar-2021 22:21 (jpellegrini)
+;;;; Last file update: 04-Apr-2021 18:05 (jpellegrini)
+
+(define (tail n)
+  (if (< n (length (past)))
+      (list-tail (past) (- (length (past)) n))
+      (past)))
+
+;;; Simple tests
+
+(test "srfi-25 1"
+      #f
+      (not (and (shape)
+                (shape -1 -1)
+                (shape -1 0)
+                (shape -1 1)
+                (shape 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8))))
+
+(test "srfi-25 2"
+      #f
+      (not (and (make-array (shape))
+                (make-array (shape) *)
+                (make-array (shape -1 -1))
+                (make-array (shape -1 -1) *)
+                (make-array (shape -1 1))
+                (make-array (shape 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8 1 2 3 4) *))))
+
+(test "srfi-25 3"
+      #f
+      (not (and (array (shape) *)
+                (array (shape -1 -1))
+                (array (shape -1 1) * *)
+                (array (shape 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8) *))))
+
+(test "srfi-25 4.1" 2 (array-rank (shape)))
+(test "srfi-25 4.2" 2 (array-rank (shape -1 -1)))
+(test "srfi-25 4.3" 2 (array-rank (shape -1 1)))
+(test "srfi-25 4.4" 2 (array-rank (shape 1 2 3 4 5 6 7 8)))
+
+(test "srfi-25 5" #t (and (= (array-rank (make-array (shape))) 0)
+                          (= (array-rank (make-array (shape -1 -1))) 1)
+                          (= (array-rank (make-array (shape -1 1))) 1)
+                          (= (array-rank (make-array (shape 1 2 3 4 5 6 7 8))) 4)))
+
+(test "srfi-25 6" #t (and (= (array-rank (array (shape) *)) 0)
+                         (= (array-rank (array (shape -1 -1))) 1)
+                         (= (array-rank (array (shape -1 1) * *)) 1)
+                         (= (array-rank (array (shape 1 2 3 4 5 6 7 8) *)) 4)))
+
+(test "srfi-25 7" #t (and (= (array-start (shape -1 -1) 0) 0)
+                          (= (array-start (shape -1 -1) 1) 0)
+                          (= (array-start (shape -1 1) 0) 0)
+                          (= (array-start (shape -1 1) 1) 0)
+                          (= (array-start (shape 1 2 3 4 5 6 7 8) 0) 0)
+                          (= (array-start (shape 1 2 3 4 5 6 7 8) 1) 0)))
+
+(test "srfi-25 8" #t (and (= (array-end (shape -1 -1) 0) 1)
+                          (= (array-end (shape -1 -1) 1) 2)
+                          (= (array-end (shape -1 1) 0) 1)
+                          (= (array-end (shape -1 1) 1) 2)
+                          (= (array-end (shape 1 2 3 4 5 6 7 8) 0) 4)
+                          (= (array-end (shape 1 2 3 4 5 6 7 8) 1) 2)))
+
+(test "srfi-25 9.1" -1 (array-start (make-array (shape -1 -1)) 0))
+(test "srfi-25 9.2" -1 (array-start (make-array (shape -1 1)) 0))
+(test "srfi-25 9.3"  1 (array-start (make-array (shape 1 2 3 4 5 6 7 8)) 0))
+(test "srfi-25 9.4"  3 (array-start (make-array (shape 1 2 3 4 5 6 7 8)) 1))
+(test "srfi-25 9.5"  5 (array-start (make-array (shape 1 2 3 4 5 6 7 8)) 2))
+(test "srfi-25 9.6"  7 (array-start (make-array (shape 1 2 3 4 5 6 7 8)) 3))
+
+(test "srfi-25 10" #t (and (= (array-end (make-array (shape -1 -1)) 0) -1)
+                           (= (array-end (make-array (shape -1 1)) 0) 1)
+                           (= (array-end (make-array (shape 1 2 3 4 5 6 7 8)) 0) 2)
+                           (= (array-end (make-array (shape 1 2 3 4 5 6 7 8)) 1) 4)
+                           (= (array-end (make-array (shape 1 2 3 4 5 6 7 8)) 2) 6)
+                           (= (array-end (make-array (shape 1 2 3 4 5 6 7 8)) 3) 8)))
+
+(test "srfi-25 11" #t (and (= (array-start (array (shape -1 -1)) 0) -1)
+                           (= (array-start (array (shape -1 1) * *) 0) -1)
+                           (= (array-start (array (shape 1 2 3 4 5 6 7 8) *) 0) 1)
+                           (= (array-start (array (shape 1 2 3 4 5 6 7 8) *) 1) 3)
+                           (= (array-start (array (shape 1 2 3 4 5 6 7 8) *) 2) 5)
+                           (= (array-start (array (shape 1 2 3 4 5 6 7 8) *) 3) 7)))
+
+(test "srfi-25 12" #t (and (= (array-end (array (shape -1 -1)) 0) -1)
+                           (= (array-end (array (shape -1 1) * *) 0) 1)
+                           (= (array-end (array (shape 1 2 3 4 5 6 7 8) *) 0) 2)
+                           (= (array-end (array (shape 1 2 3 4 5 6 7 8) *) 1) 4)
+                           (= (array-end (array (shape 1 2 3 4 5 6 7 8) *) 2) 6)
+                           (= (array-end (array (shape 1 2 3 4 5 6 7 8) *) 3) 8)))
+
+(test "srfi-25 13.1" 'a (array-ref (make-array (shape) 'a)))
+(test "srfi-25 13.2" 'b (array-ref (make-array (shape -1 1) 'b) -1))
+(test "srfi-25 13.3" 'c (array-ref (make-array (shape -1 1) 'c) 0))
+(test "srfi-25 13.4" 'd (array-ref (make-array (shape 1 2 3 4 5 6 7 8) 'd) 1 3 5 7))
+
+
+(test "srfi-25 14.1" 'a (array-ref (make-array (shape) 'a) '#()))
+(test "srfi-25 14.2" 'b (array-ref (make-array (shape -1 1) 'b) '#(-1)))
+(test "srfi-25 14.3" 'c (array-ref (make-array (shape -1 1) 'c) '#(0)))
+(test "srfi-25 14.4" 'd (array-ref (make-array (shape 1 2 3 4 5 6 7 8) 'd) '#(1 3 5 7)))
+
+(test "srfi-25 15.1" 'a (array-ref (make-array (shape) 'a)
+                                   (array (shape 0 0))))
+(test "srfi-25 15.2" 'b (array-ref (make-array (shape -1 1) 'b)
+                                   (array (shape 0 1) -1)))
+(test "srfi-25 15.3" 'c (array-ref (make-array (shape -1 1) 'c)
+                                   (array (shape 0 1) 0)))
+(test "srfi-25 15.4" 'd (array-ref (make-array (shape 1 2 3 4 5 6 7 8) 'd)
+                                   (array (shape 0 4) 1 3 5 7)))
+
+(let ((arr (make-array (shape) 'o)))
+  (array-set! arr 'a)
+  (test "srfi-25 16.0" 'a (array-ref arr)))
+
+(let ((arr (make-array (shape -1 1) 'o)))
+  (array-set! arr -1 'b)
+  (array-set! arr 0 'c)
+  (test "srfi-25 16.1" 'b (array-ref arr -1))
+  (test "srfi-25 16.2" 'c (array-ref arr 0)))
+
+(test "srfi-25 16.3" 'd (let ((arr (make-array (shape 1 2 3 4 5 6 7 8) 'o)))
+                          (array-set! arr 1 3 5 7 'd)
+                          (array-ref arr 1 3 5 7)))
+
+(test "srfi-25 17.0" 'a (let ((arr (make-array (shape) 'o)))
+                          (array-set! arr '#() 'a)
+                          (array-ref arr)))
+
+(let ((arr (make-array (shape -1 1) 'o)))
+  (array-set! arr '#(-1) 'b)
+  (array-set! arr '#(0) 'c)
+  (test "srfi-25 17.1" 'b (array-ref arr -1))
+  (test "srfi-25 17.2" 'c (array-ref arr 0)))
+
+(test "srfi-25 17.3" 'd (let ((arr (make-array (shape 1 2 3 4 5 6 7 8) 'o)))
+                          (array-set! arr '#(1 3 5 7) 'd)
+                          (array-ref arr 1 3 5 7)))
+
+(test "srfi-25 18.0" 'a (let ((arr (make-array (shape) 'o)))
+                          (array-set! arr 'a)
+                          (array-ref arr)))
+
+(let ((arr (make-array (shape -1 1) 'o)))
+  (array-set! arr (array (shape 0 1) -1) 'b)
+  (array-set! arr (array (shape 0 1)  0) 'c)
+  (test "srfi-25 18.1" 'b (array-ref arr -1))
+  (test "srfi-25 18.2" 'c (array-ref arr 0)))
+
+(test "srfi-25 18.3" 'd (let ((arr (make-array (shape 1 2 3 4 5 6 7 8) 'o)))
+                          (array-set! arr (array (shape 0 4) 1 3 5 7) 'd)
+                          (array-ref arr 1 3 5 7)))
+
+;;; Share and change:
+;;;
+;;;  org     brk     swp            box
+;;;
+;;;   0 1     1 2     5 6
+;;; 6 a b   2 a b   3 d c   0 2 4 6 8: e
+;;; 7 c d   3 e f   4 f e
+;;; 8 e f
+
+(let* ((org (array (shape 6 9 0 2) 'a 'b 'c 'd 'e 'f))
+       (brk (share-array
+             org
+             (shape 2 4 1 3)
+             (lambda (r k)
+               (values
+                (+ 6 (* 2 (- r 2)))
+                (- k 1)))))
+       (swp (share-array
+             org
+             (shape 3 5 5 7)
+             (lambda (r k)
+               (values
+                (+ 7 (- r 3))
+                (- 1 (- k 5))))))
+       (box (share-array
+             swp
+             (shape 0 1 2 3 4 5 6 7 8 9)
+             (lambda _ (values 4 6))))
+       (org-contents (lambda ()
+                       (list (array-ref org 6 0) (array-ref org 6 1)
+                             (array-ref org 7 0) (array-ref org 7 1)
+                             (array-ref org 8 0) (array-ref org 8 1))))
+       (brk-contents (lambda ()
+                       (list (array-ref brk 2 1) (array-ref brk 2 2)
+                             (array-ref brk 3 1) (array-ref brk 3 2))))
+       (swp-contents (lambda ()
+                       (list (array-ref swp 3 5) (array-ref swp 3 6)
+                             (array-ref swp 4 5) (array-ref swp 4 6))))
+       (box-contents (lambda ()
+                       (list (array-ref box 0 2 4 6 8)))))
+  (test "srfi-25 19.1"  '(a b c d e f) (org-contents))
+  (test "srfi-25 19.2"  '(a b e f) (brk-contents))
+  (test "srfi-25 19.3"  '(d c f e) (swp-contents))
+  (test "srfi-25 19.4"  '(e) (box-contents))
+ (array-set! org 6 0 'x) 
+  (test "srfi-25 19.5"  '(x b c d e f) (org-contents))
+  (test "srfi-25 19.6"  '(x b e f) (brk-contents))
+  (test "srfi-25 19.7"  '(d c f e) (swp-contents))
+  (test "srfi-25 19.8"  '(e) (box-contents))
+ (array-set! brk 3 1 'y) 
+  (test "srfi-25 19.9"  '(x b c d y f) (org-contents))
+  (test "srfi-25 19.10"  '(x b y f) (brk-contents))
+  (test "srfi-25 19.11"  '(d c f y) (swp-contents))
+  (test "srfi-25 19.12"  '(y) (box-contents))
+ (array-set! swp 4 5 'z) 
+  (test "srfi-25 19.13"  '(x b c d y z) (org-contents))
+  (test "srfi-25 19.14"  '(x b y z) (brk-contents))
+  (test "srfi-25 19.15"  '(d c z y) (swp-contents))
+  (test "srfi-25 19.16"  '(y) (box-contents))
+ (array-set! box 0 2 4 6 8 'e) 
+  (test "srfi-25 19.17"  '(x b c d e z) (org-contents))
+  (test "srfi-25 19.18"  '(x b e z) (brk-contents))
+  (test "srfi-25 19.19"  '(d c z e) (swp-contents))
+  (test "srfi-25 19.20"  '(e) (box-contents)))
+
+;;; Check that arrays copy the shape specification
+
+(test "srfi-25 20" #t (let ((shp (shape 10 12)))
+                        (let ((arr (make-array shp))
+                              (ars (array shp * *))
+                              (art (share-array (make-array shp) shp (lambda (k) k))))
+                          (array-set! shp 0 0 '?)
+                          (array-set! shp 0 1 '!)
+                          (and (= (array-rank shp) 2)
+                               (= (array-start shp 0) 0)
+                               (= (array-end shp 0) 1)
+                               (= (array-start shp 1) 0)
+                               (= (array-end shp 1) 2)
+                               (eq? (array-ref shp 0 0) '?)
+                               (eq? (array-ref shp 0 1) '!)
+                               (= (array-rank arr) 1)
+                               (= (array-start arr 0) 10)
+                               (= (array-end arr 0) 12)
+                               (= (array-rank ars) 1)
+                               (= (array-start ars 0) 10)
+                               (= (array-end ars 0) 12)
+                               (= (array-rank art) 1)
+                               (= (array-start art 0) 10)
+                               (= (array-end art 0) 12)))))
+
+;;; Check that index arrays work even when they share
+;;;
+;;; arr       ixn
+;;;   5  6      0 1
+;;; 4 nw ne   0 4 6
+;;; 5 sw se   1 5 4
+
+(let ((arr (array (shape 4 6 5 7) 'nw 'ne 'sw 'se))
+      (ixn (array (shape 0 2 0 2) 4 6 5 4)))
+  (let ((col0 (share-array
+               ixn
+               (shape 0 2)
+               (lambda (k)
+                 (values k 0))))
+        (row0 (share-array
+               ixn
+               (shape 0 2)
+               (lambda (k)
+                 (values 0 k))))
+        (wor1 (share-array
+               ixn
+               (shape 0 2)
+               (lambda (k)
+                 (values 1 (- 1 k)))))
+        (cod (share-array
+              ixn
+              (shape 0 2)
+              (lambda (k)
+                (case k
+                  ((0) (values 1 0))
+                  ((1) (values 0 1))))))
+        (box (share-array
+              ixn
+              (shape 0 2)
+              (lambda (k)
+                (values 1 0)))))
+   (test "srfi-25 21.1" 'nw (array-ref arr col0))
+   (test "srfi-25 21.2" 'ne (array-ref arr row0))
+   (test "srfi-25 21.3" 'nw (array-ref arr wor1))
+   (test "srfi-25 21.4" 'se (array-ref arr cod))
+   (test "srfi-25 21.5" 'sw (array-ref arr box))
+   (array-set! arr col0 'ul)
+   (array-set! arr row0 'ur)
+   (array-set! arr cod 'lr)
+   (array-set! arr box 'll)
+   (test "srfi-25 21.6" 'ul (array-ref arr 4 5))
+   (test "srfi-25 21.7" 'ur (array-ref arr 4 6))
+   (test "srfi-25 21.8" 'll (array-ref arr 5 5))
+   (test "srfi-25 21.9" 'lr (array-ref arr 5 6))
+   (array-set! arr wor1 'xx)
+    (test "srfi-25 21.10" 'xx (array-ref arr 4 5))))
+
+
+;; ;;; Check that shape arrays work even when they share
+;; ;;;
+;; ;;; arr             shp       shq       shr       shs
+;; ;;;    1  2  3  4      0  1      0  1      0  1      0  1 
+;; ;;; 1 10 12 16 20   0 10 12   0 12 20   0 10 10   0 12 12
+;; ;;; 2 10 11 12 13   1 10 11   1 11 13   1 11 12   1 12 12
+;; ;;;                                     2 12 16
+;; ;;;                                     3 13 20
+
+(let ((arr (array (shape 1 3 1 5) 10 12 16 20 10 11 12 13)))
+  (let ((shp (share-array
+              arr
+              (shape 0 2 0 2)
+              (lambda (r k)
+                (values (+ r 1) (+ k 1)))))
+        (shq (share-array
+              arr
+              (shape 0 2 0 2)
+              (lambda (r k)
+                (values (+ r 1) (* 2 (+ 1 k))))))
+        (shr (share-array
+              arr
+              (shape 0 4 0 2)
+              (lambda (r k)
+                (values (- 2 k) (+ r 1)))))
+        (shs (share-array
+              arr
+              (shape 0 2 0 2)
+              (lambda (r k)
+                (values 2 3)))))
+    (let ((arr-p (make-array shp)))
+      (test "srfi-25 22.1" 2 (array-rank arr-p))
+      (test "srfi-25 22.2" 10 (array-start arr-p 0))
+      (test "srfi-25 22.3" 12 (array-end arr-p 0))
+      (test "srfi-25 22.4" 10 (array-start arr-p 1))
+      (test "srfi-25 22.5" 11 (array-end arr-p 1)))
+    (let ((arr-q (array shq * * * *  * * * *  * * * *  * * * *)))
+      (test "srfi-25 22.6" 2  (array-rank arr-q))
+      (test "srfi-25 22.7" 12 (array-start arr-q 0))
+      (test "srfi-25 22.8" 20 (array-end arr-q 0))
+      (test "srfi-25 22.9" 11 (array-start arr-q 1))
+      (test "srfi-25 22.10" 13 (array-end arr-q 1)))
+    (let ((arr-r (share-array
+                  (array (shape) *)
+                  shr
+                  (lambda _ (values)))))
+      (test "srfi-25 22.11" 4  (array-rank arr-r))
+      (test "srfi-25 22.12" 10 (array-start arr-r 0))
+      (test "srfi-25 22.13" 10 (array-end arr-r 0))
+      (test "srfi-25 22.14" 11 (array-start arr-r 1))
+      (test "srfi-25 22.15" 12 (array-end arr-r 1))
+      (test "srfi-25 22.16" 12 (array-start arr-r 2))
+      (test "srfi-25 22.17" 16 (array-end arr-r 2))
+      (test "srfi-25 22.18" 13 (array-start arr-r 3))
+      (test "srfi-25 22.19" 20 (array-end arr-r 3)))
+    (let ((arr-s (make-array shs)))
+      (test "srfi-25 22.20" 2  (array-rank arr-s))
+      (test "srfi-25 22.21" 12 (array-start arr-s 0))
+      (test "srfi-25 22.22" 12 (array-end arr-s 0))
+      (test "srfi-25 22.23" 12 (array-start arr-s 1))
+      (test "srfi-25 22.24" 12 (array-end arr-s 1)))))
+
+(let ((super (array (shape 4 7 4 7)
+                    1 * *
+                    * 2 *
+                    * * 3))
+      (subshape (share-array
+                 (array (shape 0 2 0 3)
+                        * 4 *
+                        * 7 *)
+                 (shape 0 1 0 2)
+                 (lambda (r k)
+                   (values k 1)))))
+  (let ((sub (share-array super subshape (lambda (k) (values k k)))))
+    ;;(array-equal? subshape (shape 4 7))
+    (test "srfi-25 23.1" 2 (array-rank subshape))
+    (test "srfi-25 23.2" 0 (array-start subshape 0))
+    (test "srfi-25 23.3" 1 (array-end subshape 0))
+    (test "srfi-25 23.4" 0 (array-start subshape 1))
+    (test "srfi-25 23.5" 2 (array-end subshape 1))
+    (test "srfi-25 23.6" 4 (array-ref subshape 0 0))
+    (test "srfi-25 23.7" 7 (array-ref subshape 0 1))
+    ;;(array-equal? sub (array (shape 4 7) 1 2 3))
+    (test "srfi-25 24.1" 1 (array-rank sub))
+    (test "srfi-25 24.2" 4 (array-start sub 0))
+    (test "srfi-25 24.3" 7 (array-end sub 0))
+    (test "srfi-25 24.4" 1 (array-ref sub 4))
+    (test "srfi-25 24.5" 2 (array-ref sub 5))
+    (test "srfi-25 24.6" 3 (array-ref sub 6))))
+
+
+;;;
+;;; EXTRA TESTS  -- jpellegrini
+;;;
+
+(let ((a (make-array (shape 1 2 3 4 5 6) -1)))
+  (test/error "srfi-25 jp 1"    (array-start a -1))
+  (test/error "srfi-25 jp 2"    (array-start a  3))
+  (test/error "srfi-25 jp 3"    (array-end a   -1))
+  (test/error "srfi-25 jp 4"    (array-end a    3))
+  (test       "srfi-25 jp 5"  1 (array-start a 0))
+  (test       "srfi-25 jp 6"  3 (array-start a 1))
+  (test       "srfi-25 jp 7"  5 (array-start a 2))
+  (test       "srfi-25 jp 8"  2 (array-end a 0))
+  (test       "srfi-25 jp 9"  4 (array-end a 1))
+  (test       "srfi-25 jp 10" 6 (array-end a 2)))
+
+;; from the SRFI text:
+
+(test "srfi-25 jp 11"
+      'cuatro
+      (array-ref (array (shape 0 2 0 3)
+                        'uno 'dos 'tres
+                        'cuatro 'cinco 'seis)
+                 1 0))
+
+(test "srfi-25 jp 12"
+      '(3 1 4)
+       (let ((a (array (shape 4 7 1 2) 3 1 4)))
+         (list (array-ref a 4 1)
+               (array-ref a (vector 5 1))
+               (array-ref a (array (shape 0 2)
+                                   6 1)))))
+
+(test "srfi-25 jp 13"
+      'huuhkaja
+      (let ((a (make-array
+                (shape 4 5 4 5 4 5))))
+        (array-set! a 4 4 4 'huuhkaja)
+        (array-ref a 4 4 4)))
+
+;; test row-major order, and array-ref corner cases:
+(let ((a (array (shape 0 2 0 3 0 4)
+                ;; (0 i j)
+                -1  -2  -3  -4
+                -5  -6  -7  -8
+                -9 -10 -11 -12
+                
+                ;; (1 k j)
+                -13 -14 -15 -16
+                -17 -18 -19 -20
+                -21 -22 -23 -24))
+      (v -1))
+  (dotimes (i 2)
+    (dotimes (j 3)
+      (dotimes (k 4)
+        (test "srfi-25 jp 14.loop"
+              v
+              (array-ref a i j k))
+        (set! v (- v 1))))))
+
+
+(let ((a (array (shape 1 4 1 4 2 6)
+                ;; (1 i j)
+                -1  -2  -3  -4
+                -5  -6  -7  -8
+                -9 -10 -11 -12
+                
+                ;; (2 k j)
+                -13 -14 -15 -16
+                -17 -18 -19 -20
+                -21 -22 -23 -24
+
+                ;; (3 k j)
+                -25 -26 -27 -28
+                -29 -30 -31 -32
+                -33 -34 -35 -36)))
+  ;;
+  ;;       s
+  ;;
+  ;;    -13 -15
+  ;; r  -17 -19
+  ;;    -21 -23
+  ;;
+  (let ((b (share-array a
+                        (shape 3 6  2 4)
+                        (lambda (r s)
+                          
+                          (values 2
+                                  (- r 2)        ;; r in {3, 4, 5} -> {1, 2, 3}
+                                  (- (* 2 s) 2)  ;; s in {2, 3}    -> {2, 4}
+                                  )))))
+    (test "srfi-25 jp 15.share.1" -13 (array-ref b 3 2))
+    (test "srfi-25 jp 15.share.2" -15 (array-ref b 3 3))
+    (test "srfi-25 jp 15.share.3" -17 (array-ref b 4 2))
+    (test "srfi-25 jp 15.share.4" -19 (array-ref b 4 3))
+    (test "srfi-25 jp 15.share.5" -21 (array-ref b 5 2))
+    (test "srfi-25 jp 15.share.6" -23 (array-ref b 5 3))))
+
+(let* ((i (array
+           (shape 0 4 0 4)
+           1 2 3 4
+           5 6 7 8
+           9 10 11 12
+           13 14 15 16))
+       (d (share-array i
+                       (shape 0 4)
+                       (lambda (k)
+                         (values k k)))))
+  (test "srfi-25 jp 16.share.1" 11 (array-ref d 2))
+  (test "srfi-25 jp 16.share.2" 11 (array-ref d 2))
+  (test "srfi-25 jp 16.share.3" 11 (array-ref d 2))
+  (test "srfi-25 jp 16.share.4" 11 (array-ref d 2)))
+
+
+
+
+(define orig (array (shape 0 2 0 3) -1 -2 -3 -4 -5 -6))
+(test "srfi-25 jp 17.share.1" #f (shared-array? orig))
+(test "srfi-25 jp 17.share.2" 0  (array-share-count orig))
+(define one (share-array orig
+                         (shape 1 3 1 4)
+                         (lambda (x y) (values y x))))
+(test "srfi-25 jp 17.share.3" #t (shared-array? orig))
+(test "srfi-25 jp 17.share.4" 1  (array-share-count orig))
+(test "srfi-25 jp 17.share.5" #t (shared-array? one))
+(test "srfi-25 jp 17.share.6" -1 (array-share-count one))
+(define two (share-array orig
+                         (shape 0 2 0 3)
+                         (lambda (x y) (values x x))))
+(test "srfi-25 jp 17.share.7" #t (shared-array? orig))
+(test "srfi-25 jp 17.share.8" 2  (array-share-count orig))
+(test "srfi-25 jp 17.share.9" #t (shared-array? one))
+(test "srfi-25 jp 17.share.10" -1 (array-share-count one))
+(test "srfi-25 jp 17.share.11" #t (shared-array? two))
+(test "srfi-25 jp 17.share.12" -1 (array-share-count two))
+(define three (share-array one
+                           (shape 0 2 0 3)
+                           (lambda (x y) (values y y))))
+(test "srfi-25 jp 17.share.13" #t (shared-array? orig))
+(test "srfi-25 jp 17.share.14" 3  (array-share-count orig))
+(test "srfi-25 jp 17.share.15" #t (shared-array? one))
+(test "srfi-25 jp 17.share.16" -1 (array-share-count one))
+(test "srfi-25 jp 17.share.17" #t (shared-array? two))
+(test "srfi-25 jp 17.share.18" -1 (array-share-count two))
+(test "srfi-25 jp 17.share.19" #t (shared-array? three))
+(test "srfi-25 jp 17.share.20" -1 (array-share-count three))
+;;
+;; Ok, so it seems that we can't force the GC to collect the
+;; unreachable arrays at the time we awnt it to... So these
+;; tests won't work:
+;;
+;; (set! two #f)
+;; (gc)
+;; (thread-sleep! 1)
+;; (test "srfi-25 jp 17.share.21" #t (shared-array? orig))
+;; (test "srfi-25 jp 17.share.22" 2  (array-share-count orig))
+;; (test "srfi-25 jp 17.share.23" #t (shared-array? one))
+;; (test "srfi-25 jp 17.share.24" -1 (array-share-count one))
+;; (test "srfi-25 jp 17.share.25" #t (shared-array? three))
+;; (test "srfi-25 jp 17.share.26" -1 (array-share-count three))
+;; (set! one #f)
+;; (set! three #f)
+;; (gc)
+;; (thread-sleep! 1)
+;; (test "srfi-25 jp 17.share.27" #f (shared-array? orig))
+;; (test "srfi-25 jp 17.share.28" 0  (array-share-count orig))
+
+(let ((orig (array (shape 0 2 0 3) -1 -2 -3 -4 -5 -6)))
+  (let ((new (array-copy orig)))
+    (test "srfi-25 jp 18.copy.1"
+          '(-1 -2 -3
+            -4 -5 -6)
+          (array->list new))))
+
+(let ((orig (array (shape 0 2 0 3) -1 -2 -3 -4 -5 -6)))
+  (let ((sh (share-array orig (shape 0 3 0 2) (lambda (x y) (values y x)))))
+    (let ((cp (array-copy sh)))
+      (test "srfi-25 jp 18.copy.2"
+            '(-1 -4
+              -2 -5
+              -3 -6)
+          (array->list cp))
+      (test "srfi-25 jp 18.copy.3" #t (shared-array? orig))
+      (test "srfi-25 jp 18.copy.4" #t (shared-array? sh))
+      (test "srfi-25 jp 18.copy.5" #f (shared-array? cp))
+      (test "srfi-25 jp 18.copy.6"  1 (array-share-count orig))
+      (test "srfi-25 jp 18.copy.7" -1 (array-share-count sh))
+      (test "srfi-25 jp 18.copy.8"  0 (array-share-count cp)))))
+
+(let ((orig (array (shape 0 2 0 3) -1 -2 -3 -4 -5 -6)))
+  (let ((sh (share-array orig (shape 0 3 0 2) (lambda (x y) (values y x)))))
+    (let ((cp (array-copy+share sh)))
+            (test "srfi-25 jp 18.copy.9"  #f (shared-array? orig))
+            (test "srfi-25 jp 18.copy.10" #t (shared-array? sh))
+            (test "srfi-25 jp 18.copy.11" #t (shared-array? cp))
+            (test "srfi-25 jp 18.copy.12"  0 (array-share-count orig))
+            (test "srfi-25 jp 18.copy.13" -1 (array-share-count sh))
+            (test "srfi-25 jp 18.copy.14" -1 (array-share-count cp)))))
+
+(let ((orig (array (shape 0 2 0 3) -1 -2 -3 -4 -5 -6)))
+  (test "srfi-25 jp 19.shape.1"
+        '(0 2 0 3)
+        (array->list (array-shape orig))))
+
+
+(define-syntax push!
+  (syntax-rules ()
+    ((_ e lst)
+     (set! lst (cons e lst))))) 
+
+
+(let ((shp (shape 1 3 10 12)))
+  (let ((res '()))
+    (shape-for-each shp                
+                    (lambda (x y) (push! (list x y) res)))
+    (test "srfi-25 jp 20.shape-for-each.1"
+          '( (1 10) (1 11) (2 10)  (2 11) )
+          (reverse res)))
+  
+  (let ((res '())
+        (vec (make-vector 2 'unused)))
+    (shape-for-each shp
+                    (lambda (v) (push! (list (vector-ref v 0)
+                                        (vector-ref v 1)) res))
+                    vec)
+    (test "srfi-25 jp 20.shape-for-each.2"
+          '( (1 10) (1 11) (2 10)  (2 11) )
+          (reverse res)))
+  
+  (let ((res '())
+        (arr (make-array (shape 0 2) 'unused)))
+    (shape-for-each shp                
+                    (lambda (a) (push! (list (array-ref a 0)
+                                        (array-ref a 1)) res))
+                    arr)
+    (test "srfi-25 jp 20.shape-for-each.3"
+          '( (1 10) (1 11) (2 10)  (2 11) )
+          (reverse res))))
+
+
+
+(define-syntax push!
+  (syntax-rules ()
+    ((_ e lst)
+     (set! lst (cons e lst))))) 
+
+
+(let ((shp (shape 1 3 10 12)))
+  (let ((arr2 (make-array shp 'x)))
+    (let ((res '()))
+      (array-for-each-index arr2
+                            (lambda (x y) (push! (list x y) res)))
+      (test "srfi-25 jp 20.array-for-each-index.1"
+            '( (1 10) (1 11) (2 10)  (2 11) )
+            (reverse res)))
+    
+  (let ((res '())
+        (vec (make-vector 2 'unused)))
+    (array-for-each-index arr2
+                    (lambda (v) (push! (list (vector-ref v 0)
+                                        (vector-ref v 1)) res))
+                    vec)
+    (test "srfi-25 jp 20.array-for-each-index.2"
+          '( (1 10) (1 11) (2 10)  (2 11) )
+          (reverse res)))
+  
+  (let ((res '())
+        (arr (make-array (shape 0 2) 'unused)))
+    (array-for-each-index arr2
+                    (lambda (a) (push! (list (array-ref a 0)
+                                        (array-ref a 1)) res))
+                    arr)
+    (test "srfi-25 jp 20.array-for-each-index.3"
+          '( (1 10) (1 11) (2 10)  (2 11) )
+          (reverse res)))))
+
+
+(test "srfi-25 jp 21.size.1" 24 (array-size (make-array (shape -2 2 -3 3) 'x)))
+(test "srfi-25 jp 21.size.2"  0 (array-size (make-array (shape  2 2 -3 3) 'x)))
+(test "srfi-25 jp 21.size.3"  1 (array-size (make-array (shape) 'x)))
+(test "srfi-25 jp 21.size.4"  1 (array-size (make-array (shape))))
+
+(let ((orig (array (shape 0 2 0 3) -1 -2 -3 -4 -5 -6)))
+  (let ((sh (share-array orig (shape 0 3 0 2) (lambda (x y) (values y x)))))
+    (let ((cp (array-copy sh)))
+      (test "srfi-25 jp 21.size.5" 6 (array-size orig))
+      (test "srfi-25 jp 21.size.6" 6 (array-size sh))
+      (test "srfi-25 jp 21.size.7" 6 (array-size cp)))))
+
+
+(let* ((a (make-array (shape 0 2) 'a))
+       (b (make-array (shape 0 2) (array-copy a)))
+       (c (array (shape 0 2) a b)))
+  (array-set! a 1 'x)
+  (test "srfi-25 jp 22.array->list.1" '(a x) (array->list a))
+  (test "srfi-25 jp 22.array->list.2" 'a (array-ref (car (array->list b)) 1))
+  (test "srfi-25 jp 22.array->list.3" 'x (array-ref (car (array->list c)) 1))
+  (test "srfi-25 jp 22.array->list.4" 'a (array-ref (car (array->list c)) 0))
+  (test "srfi-25 jp 22.array->list.5" 'a (array-ref
+                                          (array-ref (cadr (array->list c)) 0)
+                                          1)))
+
+(let* ((a (make-array (shape 0 2) 'a))
+       (b (make-array (shape 0 2) (array-copy a)))
+       (c (array (shape 0 2) a b)))
+  (array-set! a 1 'x)
+  (test "srfi-25 jp 23.array->vector.1" '#(a x) (array->vector a))
+  (test "srfi-25 jp 23.array->vector.2" 'a (array-ref (vector-ref (array->vector b) 0) 1))
+  (test "srfi-25 jp 23.array->vector.3" 'x (array-ref (vector-ref (array->vector c) 0) 1))
+  (test "srfi-25 jp 23.array->vector.4" 'a (array-ref (vector-ref (array->vector c) 0) 0))
+  (test "srfi-25 jp 23.array->vector.5" 'a (array-ref
+                                          (array-ref (vector-ref (array->vector c) 1) 0)
+                                          1)))
+
+
+(let ((a (tabulate-array  (shape 2 4 2 5)
+                          (lambda (x y) (* x y)))))
+  (test "srfi 25 jp 24.tabulate-array 1" '(2 4 2 5) (array->list (array-shape a)))
+  (test "srfi 25 jp 24.tabulate-array 2" '(4 6 8 6 9 12) (array->list a)))
+
+(let ((v (make-vector 2 'x)))
+  (let ((a (tabulate-array  (shape 2 4 2 5)
+                            (lambda (x) (* (vector-ref x 0) (vector-ref x 1)))
+                            v)))
+  (test "srfi 25 jp 24.tabulate-array 3" '(2 4 2 5) (array->list (array-shape a)))
+  (test "srfi 25 jp 24.tabulate-array 4" '(4 6 8 6 9 12) (array->list a))))
+
+;; REALLY EXTRA -- it seems that nobody else supports this:
+(let ((a-ind (array (shape 0 2) 'x 'y)))
+  (let ((a (tabulate-array  (shape 2 4 2 5)
+                            (lambda (x) (* (array-ref x 0) (array-ref x 1)))
+                            a-ind)))
+  (test "srfi 25 jp 24.tabulate-array 3" '(2 4 2 5) (array->list (array-shape a)))
+  (test "srfi 25 jp 24.tabulate-array 4" '(4 6 8 6 9 12) (array->list a))))
+
+
+(let ((a (array (shape 0 2 0 3)
+                -1 -2 -3
+                -4 -5 -6)))
+  (let ((b (array-map (lambda (x) (* x x)) a)))
+    (test "srfi 25 jp 25.array-map.1" '(0 2 0 3) (array->list (array-shape b)))
+    (test "srfi 25 jp 25.array-map.2" '(1 4 9 16 25 36) (array->list b))))
+
+(let ((a (array (shape 0 2 0 3)
+                -1 -2 -3
+                -4 -5 -6))
+      (b (array (shape 0 2 0 3)
+                -1  1 -1
+                -2  2 -2)))
+  (let ((c (array-map (lambda (x y) (* x y)) a b)))
+    (test "srfi 25 jp 25.array-map.3" '(0 2 0 3) (array->list (array-shape c)))
+    (test "srfi 25 jp 25.array-map.4" '(1 -2 3 8 -10 12) (array->list c))))
+
+
+(let ((a (array (shape 0 2 0 3)
+                -1 -2 -3
+                -4 -5 -6)))
+  (let ((b (make-array (array-shape a) 'x)))
+    (array-map! b (lambda (x) (* x x)) a)
+    (test "srfi 25 jp 25.array-map!.1" '(0 2 0 3) (array->list (array-shape b)))
+    (test "srfi 25 jp 25.array-map!.2" '(1 4 9 16 25 36) (array->list b))))
+
+(let ((a (array (shape 0 2 0 3)
+                -1 -2 -3
+                -4 -5 -6))
+      (b (array (shape 0 2 0 3)
+                -1  1 -1
+                -2  2 -2)))
+  (let ((c (make-array (array-shape b) 'z)))
+    (array-map! c (lambda (x y) (* x y)) a b)
+    (test "srfi 25 jp 25.array-map!.3" '(0 2 0 3) (array->list (array-shape c)))
+    (test "srfi 25 jp 25.array-map!.4" '(1 -2 3 8 -10 12) (array->list c))))
+

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -806,3 +806,37 @@
      (test "srfi 25 jp 25.array-map!.3" '(0 2 0 3) (array->list (array-shape c)))
      (test "srfi 25 jp 25.array-map!.4" '(1 -2 3 8 -10 12) (array->list c))))
 
+
+;; create 50 threads; each thread creates 20 arrays sharing content with a single
+;; array.
+;; then:
+;; - each thread checks that its arrays are shared and have -1 share-count
+;; - after joining all threads, we check that the original array is shared
+;;   and its shared count is exactly the 
+(let* ((thread-num 50)
+       (arrays-per-thread 20)
+       (t '())
+       (orig (make-array (shape 0 2 0 3) 'unused))
+       (a (make-array (shape 0 thread-num 0 arrays-per-thread) #f)))
+  (dotimes (i thread-num)
+    (push! (make-thread (lambda ()
+                            (dotimes (j arrays-per-thread)
+                              (array-set! a i j (share-array orig
+                                                             (shape 0 2 0 3)
+                                                             (lambda (x y) (values x y)))))
+                            (dotimes (j arrays-per-thread)
+                              (test "srfi 25 jp 25.threads.3"
+                                    #t
+                                    (shared-array? (array-ref a i j)))
+                              (test "srfi 25 jp 25.threads.4"
+                                    -1
+                                    (array-share-count (array-ref a i j))))))
+           t))
+  (for-each thread-start! t)
+  (for-each thread-join! t) 
+  (test "srfi 25 jp 25.threads.1"
+        (* thread-num arrays-per-thread)
+        (array-share-count orig))
+  (test "srfi 25 jp 25.threads.2" #t (shared-array? orig)))
+
+  

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -803,6 +803,6 @@
                 -2  2 -2)))
   (let ((c (make-array (array-shape b) 'z)))
     (array-map! c (lambda (x y) (* x y)) a b)
-    (test "srfi 25 jp 25.array-map!.3" '(0 2 0 3) (array->list (array-shape c)))
-    (test "srfi 25 jp 25.array-map!.4" '(1 -2 3 8 -10 12) (array->list c))))
+     (test "srfi 25 jp 25.array-map!.3" '(0 2 0 3) (array->list (array-shape c)))
+     (test "srfi 25 jp 25.array-map!.4" '(1 -2 3 8 -10 12) (array->list c))))
 


### PR DESCRIPTION
# SRFI-25 proposal

Hi @egallesio !
I have tried to make this one as efficient as possible, while keeping the code clean.
And I have implemented several extra procedures. See below...

## commit message

Also included are the following procedures from the array library
proposed by the SRFi author, Jussi Piitulainen:

```
;;; (array-shape arr)
;;; (array-length arr dim)
;;; (array-size arr)
;;; (array-equal? arr1 arr2)
;;; (shape-for-each shp proc [ind])
;;; (array-for-each-index arr proc [ind])
;;; (tabulate-array shp proc)
;;; (tabulate-array! shp proc ind)
;;; (array-map [shp] proc arr0 arr1 ...)
;;; (array-map! arr [shp] proc arr0 arr1 ...)
;;; (array->vector arr) (array->list arr)
```

And some others:

```
shared-array?
array-share-count
array-copy+share
```

## documentation

I did not document the SRFI procedures, but there are extra 
procedures that implementors usually add to the SRFI (they
are in the SRFI git repository, but not in the SRFI text).

I did document those, but I am not sure where they'll end up in
the documentation.

Also, how do I generate the documentation? It seems that `make`
is not enough.

## equal?

I have changed boolean.c, but it is not enough -- I'm not sure
where else to look.

PENDING: in bookean.c I didn't yet check array shape compatibility

## efficiency

I have tried as much as possible to make a fast
implementation -- however, there are lots of verifications
necessary for each element access. For example,
the element position may be specifed as arguments, as
elements in a vector, or as elements in an array.
This requires one more "if"...


## shared arrays

The SRFI requires it to be possible to share array 
elements through a procedure. Since our implementation
is in C, I have not used the reference code.

I have implmented an extra procedure, shared-array?,
which checks if an array is shared.

An array remembers if it points to some other array's data,
or if someone else points to its data. This is kept in a
counter, protected by a mutex.
The `shared-array?` and `share-array-count` procedures 
expose that to the user.

I did *not* implement a bookkeeping method to tell which
vectores share data with which ones, because it didn't
seem necessary, although it would be fun to imeplemnt.

## empty arrays and default values

The SRFI requires support for empty arrays (or at least
it is implied by the reference implementation and mailing
list archives). But the reference implementation is not
consistent, but I have adopter the same behavior:

* arrays are created with a default value, so
  (make-array (shape)) has a default value of #void
  
  (array-ref (make-array (shape)))  =>  #void
  
* from the reference implementation, from Kawa and Gauche,
  (shape) is an array of rank 2, but there are no indices that
  can be used on it, so referencing (shape) is an error:
  
  (array-ref (shape) i j) => out of bounds, no matter what i, j are!

* from the reference implementation:

 ` (define a (make-array (shape) -2))  ; empty array, default value -2`
  `(array-ref a) => -2`
  
  `(define b (make-array (shape 1 1) -2))  ; empty array, not referenceable:`
  `(array-ref b) => error`

  So...
  
## printing arrays

I uesd a somewhat simple representation,

```
stklos> (define a (array (shape 0 2 0 3 0 4)
                ;; (0 i j)
                -1  -2  -3  -4
                -5  -6  -7  -8
                -9 -10 -11 -12
                
                ;; (1 k j)
                -13 -14 -15 -16
                -17 -18 -19 -20
                -21 -22 -23 -24))

stklos> a
#3A((0 2 0 3 0 4)(-1 -2 -3 -4)(-5 -6 -7 -8)(-9 -10 -11 -12)(-13 -14 -15 -16)(-17 -18 -19 -20)(-21 -22 -23 -24))
```

I considered Kawa's system, but it's too complex. Maybe in the future...

When an array has a default value, it is shown:

```
stklos> (make-array (shape) 'whatever)
#0A(() whatever)
```

## EXTRA

(briefly mentioned in the commit message; expanded here)

Besides the reference implementation, there is an "array lib" in the SRFI
git repository. Different Schemes vary in what they implement of it.

```
;;; (array-shape arr)
;;; (array-length arr dim) 
;;; (array-size arr)
;;; (array-equal? arr1 arr2)
;;; (shape-for-each shp proc [ind])
;;; (array-for-each-index arr proc [ind])
;;; (tabulate-array shp proc)
;;; (tabulate-array! shp proc ind)
;;; (array-retabulate! arr shp proc [ind])
;;; (array-map [shp] proc arr0 arr1 ...)
;;; (array-map! arr [shp] proc arr0 arr1 ...)
;;; (array->vector arr) (array->list arr)
;;; (share-array/prefix arr k ...) (share-row arr k) (share-column arr k)
;;; (share-array/origin arr k ...) (share-array/origin arr ind)
;;; (array-append dim arr0 arr1 ...)
;;; (transpose arr dim ...)
;;; (share-nths arr dim n)
```

* Chicken and Larceny only implement what is in the SRFI document
* Kawa *only* implements `array-shape` and `array->vector`
* Gauche implements all *except* 
  `tablate-array!`
  `share-array/prefix`
  `share-array/origin`
  `array-append`
  `transpose`
  `share-nths`
* Racket implements all of them *except*
  `tabulate-array!`

We have the same as Gauche, plus `tabulate-array!`.

