### PR TITLE
Add SRFI-29: Localization

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -38,6 +38,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-26: Notation for Specializing Parameters without Currying
     - SRFI-27: Source of random bits
     - SRFI-28: Basic Format Strings
+    - SRFI-29: Localization
     - SRFI-30: Nested Multi-line Comments
     - SRFI-31: A special form for recursive evaluation
     - SRFI-34: Exception Handling for Programs

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -93,6 +93,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-25.stk         \
           srfi-26.stk         \
           srfi-27.stk         \
+          srfi-29.stk         \
           srfi-31.stk         \
           srfi-35.stk         \
           srfi-36.stk         \
@@ -177,6 +178,7 @@ scheme_OBJS = compfile.ostk     \
           srfi-25.ostk          \
           srfi-26.ostk          \
           srfi-27.ostk          \
+          srfi-29.ostk          \
           srfi-31.ostk          \
           srfi-35.ostk          \
           srfi-36.ostk          \

--- a/lib/srfi-29.stk
+++ b/lib/srfi-29.stk
@@ -209,7 +209,8 @@
 
     (if (null? args)
         ;; just the string don't enter the rewriting loop:
-
+        (%stklos-format port fmt)
+        
         ;; there are arguments after the format string.
         (let ((orig-args (list-copy args)))
           (let ((n-args (let loop ((fmt fmt)
@@ -266,6 +267,7 @@
             ;; and remove the extra arguments at the end of the list:
             (let ((fmt (regexp-replace-all positional-directive-regexp fmt ""))
                   (args (take args (+ 1 n-args))))
+              ;;(%stklos-format #t "--> ~a ~a ~a~%" port fmt args)
               (apply %stklos-format (cons port (cons fmt args)))))))))
 
 );; END OF DEFINE-MODULE

--- a/lib/srfi-29.stk
+++ b/lib/srfi-29.stk
@@ -180,22 +180,35 @@
 ;; Extracted from SRFI-1, with argument checking removed
 ;; (it's not exposed and we know only (list number) will
 ;; ever be passed to it).
+;; and allowing k to be as large as one wants
 (define (take lis k)
   (let recur ((lis lis) (k k))
-    (if (zero? k) '()
+    (if (or (zero? k) (null? lis)) '()
         (cons (car lis)
               (recur (cdr lis) (- k 1))))))
 
 
 
-(define (%srfi-29:format A . rest)
-  (let ((port (if (string? A) #f A))
-        (fmt  (if (string? A) A (car rest)))
-        (args (if (string? A) rest (cdr rest))))
-    
+(define (%srfi-29:format . args)
+  (when (< (length args) 1) (error "need at least one argument"))
+  
+  (let ((port #f)
+        (fmt #f))
+
+  (let ((first (car args)))
+    (when (not (string? first))
+      (when (null? (cdr args)) (error "port given, but no format string"))
+      (set! port first)
+      (set! args (cdr args))))
+
+  (let ((first (car args))) ; we already checked this car exists!
+    (if (string? first)
+        (begin (set! fmt  first)
+               (set! args (cdr args)))
+        (error "bad format string ~S" first)))
+
     (if (null? args)
         ;; just the string don't enter the rewriting loop:
-        (%stklos-format port fmt)
 
         ;; there are arguments after the format string.
         (let ((orig-args (list-copy args)))
@@ -249,7 +262,6 @@
                                                 (loop (substring fmt (cadar m) (string-length fmt)) (+ arg-pos 1)))
                                             arg-pos)))
                                 arg-pos)))))
-            
             ;; now remove all instances of '~nnn@*' from the format string
             ;; and remove the extra arguments at the end of the list:
             (let ((fmt (regexp-replace-all positional-directive-regexp fmt ""))
@@ -262,6 +274,6 @@
 
 (import SRFI-29)
 
-(define %format (in-module SRFI-29 %srfi-29:format))
+(define format (in-module SRFI-29 %srfi-29:format))
 
 (provide "srfi-29")

--- a/lib/srfi-29.stk
+++ b/lib/srfi-29.stk
@@ -212,7 +212,7 @@
         (%stklos-format port fmt)
         
         ;; there are arguments after the format string.
-        (let ((orig-args (list-copy args))
+        (let ((orig-args args)
               (orig-fmt  (string-copy fmt)))
           (let ((n-args (let loop ((fmt fmt)
                                    (arg-pos 0)) ;; we're processing the i-th argument

--- a/lib/srfi-29.stk
+++ b/lib/srfi-29.stk
@@ -171,7 +171,7 @@
 ;; in the directive, so ~-1@* will work; that is why we have the minus sign in
 ;; the character class [-[:digit:]].
 (define format-regexp
-  (string->regexp "\\~(?:(?:((?:[-[:digit:]])+)(?:@\\*|f|F))|(?i)[aswdxobcyf\\?])"))
+  (string->regexp "\\~(?:(?:((?:[-[:digit:]])+)(?:@\\*))|(?:(?:(?:[-[:digit:]])+)(?:f|F))|(?i)[aswdxobcyf\\?])"))
 
 ;; this matches the positional-directive of SRFI-29.
 (define positional-directive-regexp
@@ -212,7 +212,8 @@
         (%stklos-format port fmt)
         
         ;; there are arguments after the format string.
-        (let ((orig-args (list-copy args)))
+        (let ((orig-args (list-copy args))
+              (orig-fmt  (string-copy fmt)))
           (let ((n-args (let loop ((fmt fmt)
                                    (arg-pos 0)) ;; we're processing the i-th argument
                           
@@ -244,9 +245,10 @@
                                           ;; are allowed, obviously.
                                           (when (>= (+ arg-pos num) (length orig-args))
                                             (error (%stklos-format #f
-                                                           "SRFI-29 directive ~[N]@* referenced index ~d after last index ~d"
+                                                           "SRFI-29 directive ~[N]@* referenced index ~d after last index ~d, format was ~w"
                                                            (+ arg-pos num)
-                                                           (- (length orig-args) 1))))
+                                                           (- (length orig-args) 1)
+                                                           orig-fmt)))
                                           (when (< (+ arg-pos num) 0)
                                             (error "SRFI-29 directive ~[N]@* referenced negative index "
                                                    (+ arg-pos num)))

--- a/lib/srfi-29.stk
+++ b/lib/srfi-29.stk
@@ -1,0 +1,267 @@
+;;;;
+;;;; srfi-29.stk         -- SRFI-29: Localization
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Scott G. Miller, it is copyrighted as:
+;;;;
+;;;;;; 
+;;;;;; Copyright (C) Scott G. Miller (2002). All Rights Reserved.
+;;;;;; 
+;;;;;; This document and translations of it may be copied and furnished to
+;;;;;; others, and derivative works that comment on or otherwise explain it
+;;;;;; or assist in its implementation may be prepared, copied, published and
+;;;;;; distributed, in whole or in part, without restriction of any kind,
+;;;;;; provided that the above copyright notice and this paragraph are
+;;;;;; included on all such copies and derivative works. However, this
+;;;;;; document itself may not be modified in any way, such as by removing
+;;;;;; the copyright notice or references to the Scheme Request For
+;;;;;; Implementation process or editors, except as needed for the purpose of
+;;;;;; developing SRFIs in which case the procedures for copyrights defined
+;;;;;; in the SRFI process must be followed, or as required to translate it
+;;;;;; into languages other than English.
+;;;;;; 
+;;;;;; The limited permissions granted above are perpetual and will not be
+;;;;;; revoked by the authors or their successors or assigns.
+;;;;;; 
+;;;;;; This document and the information contained herein is provided on
+;;;;;; an "AS IS" basis and THE AUTHOR AND THE SRFI EDITORS DISCLAIM ALL
+;;;;;; WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+;;;;;; WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY
+;;;;;; RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+;;;;;; PARTICULAR PURPOSE.
+;;;;;; 
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 07-Apr-2021 20:20
+;;;; Last file update: 07-Apr-2021 21:25 (jpellegrini)
+;;;;
+
+(define %stklos-format format)
+
+(define-module SRFI-29
+
+  (export current-language
+          current-country
+          current-locale-details
+          load-bundle!
+          store-bundle!
+          declare-bundle!
+          localized-template)
+  
+;; The association list in which bundles will be stored
+(define *localization-bundles* '())
+
+(define (get-locale-pair)
+  (let ((locale (string-split (%get-locale) ";")))
+    (let ((locale-defs (map (lambda (x) (string-split x "=")) locale)))
+      (let ((some (string-split (cadar locale-defs) "_.")))
+        (list (string->symbol (string-downcase (car some)))
+              (string->symbol (string-downcase (cadr some))))))))
+
+
+
+(define current-language
+  (let ((current-language-value (car (get-locale-pair))))
+    (lambda args
+      (if (null? args)
+          current-language-value
+          (set! current-language-value (car args))))))
+
+(define current-country
+  (let ((current-country-value (cadr (get-locale-pair))))
+    (lambda args
+      (if (null? args)
+          current-country-value
+          (set! current-country-value (car args))))))
+
+(define current-locale-details
+  (let ((current-locale-details-value (if (%use-utf8?) '(utf-8) '() )))
+    (lambda args
+      (if (null? args)
+          current-locale-details-value
+          (set! current-locale-details-value (car args))))))
+
+;; The load-bundle! and store-bundle! both return #f in this
+;; reference implementation.  A compliant implementation need
+;; not rewrite these procedures.
+(define load-bundle!
+  (lambda (bundle-specifier)
+    #f))
+
+(define store-bundle!
+  (lambda (bundle-specifier)
+    #f))
+
+;; Declare a bundle of templates with a given bundle specifier
+(define declare-bundle!
+  (letrec ((remove-old-bundle
+            (lambda (specifier bundle)
+              (cond ((null? bundle) '())
+                    ((equal? (caar bundle) specifier)
+                     (cdr bundle))
+                    (else (cons (car bundle)
+                                (remove-old-bundle specifier
+                                                   (cdr bundle))))))))
+    (lambda (bundle-specifier bundle-assoc-list)
+      (set! *localization-bundles*
+            (cons (cons bundle-specifier bundle-assoc-list)
+                  (remove-old-bundle bundle-specifier
+                                     *localization-bundles*))))))
+
+;;Retrieve a localized template given its package name and a template name
+(define localized-template
+  (letrec ((rdc
+            (lambda (ls)
+              (if (null? (cdr ls))
+                  '()
+                  (cons (car ls) (rdc (cdr ls))))))
+           (find-bundle
+            (lambda (specifier template-name)
+              (cond ((assoc specifier *localization-bundles*) =>
+                     (lambda (bundle) bundle))
+                    ((null? specifier) #f)
+                    (else (find-bundle (rdc specifier)
+                                       template-name))))))
+    (lambda (package-name template-name)
+      (let loop ((specifier (cons package-name
+                                  (list (current-language)
+                                        (current-country)))))
+        (and (not (null? specifier))
+             (let ((bundle (find-bundle specifier template-name)))
+               (and bundle
+                    (cond ((assq template-name bundle) => cdr)
+                          ((null? (cdr specifier)) #f)
+                          (else (loop (rdc specifier)))))))))))
+
+
+;; inserts e before the n-th element of list lst
+(define (insert-before e lst n)
+  (if (= n 0)
+      (begin
+        (set-cdr! lst (cons (car lst) (cdr lst)))
+        (set-car! lst e))
+      (let Loop ((i n) (p lst))
+        (if (> i 1)
+            (Loop (- i 1) (cdr p))
+            (set-cdr! p (cons e (cdr p)))))))
+
+
+;; this regexp matches all possible format directives, and the result will be
+;; a pair of positions.
+;;
+;; the SRFI doesn't seem to allow that, but we let the user put negative numbers
+;; in the directive, so ~-1@* will work; that is why we have the minus sign in
+;; the character class [-[:digit:]].
+(define format-regexp
+  (string->regexp "\\~(?:(?:((?:[-[:digit:]])+)(?:@\\*|f|F))|(?i)[aswdxobcyf\\?])"))
+
+;; this matches the positional-directive of SRFI-29.
+(define positional-directive-regexp
+  (string->regexp "\\~([-[:digit:]])+@\\*"))
+
+;; Extracted from SRFI-1, with argument checking removed
+;; (it's not exposed and we know only (list number) will
+;; ever be passed to it).
+(define (take lis k)
+  (let recur ((lis lis) (k k))
+    (if (zero? k) '()
+        (cons (car lis)
+              (recur (cdr lis) (- k 1))))))
+
+
+
+(define (%srfi-29:format A . rest)
+  (let ((port (if (string? A) #f A))
+        (fmt  (if (string? A) A (car rest)))
+        (args (if (string? A) rest (cdr rest))))
+    
+    (if (null? args)
+        ;; just the string don't enter the rewriting loop:
+        (%stklos-format port fmt)
+
+        ;; there are arguments after the format string.
+        (let ((orig-args (list-copy args)))
+          (let ((n-args (let loop ((fmt fmt)
+                                   (arg-pos 0)) ;; we're processing the i-th argument
+                          
+                          (let ((m (regexp-match-positions format-regexp fmt)))
+                            (if m
+                                ;; m is ((A B) (C D)), where
+                                ;; (A B) delimit the full directive '~nnn@*'
+                                ;; (C D) delimit the number 'nnn' in ~nnn@*
+                                ;; So:
+                                ;; (caar m) is the start of the directive
+                                ;; (cadar m) is the end of the directive
+                                ;; (caadr m) is the start of the number
+                                ;; (cadadr m) is the end of the number
+                                (cond  ((not (equal? '(0 0) (cadr m)))
+                                        ;; positional directive
+                                        ;; get the number, then inser it in the args
+                                        ;; list *before* the current arg-pos (which
+                                        ;; is after the last non-positional directive).
+                                        (let ((num (string->number (substring fmt
+                                                                              (caadr m)
+                                                                              (cadadr m)))))
+                                          
+                                          ;; note: ~X@* means the X-th argument *after* the current
+                                          ;; position.
+
+                                          ;; the SRFI doesn't seem to allow that, but we let the user
+                                          ;; put negative numbers in the directive, so ~-1@* will work
+                                          ;; as expected. but no indices outside of the argument list
+                                          ;; are allowed, obviously.
+                                          (when (>= (+ arg-pos num) (length orig-args))
+                                            (error (%stklos-format #f
+                                                           "SRFI-29 directive ~[N]@* referenced index ~d after last index ~d"
+                                                           (+ arg-pos num)
+                                                           (- (length orig-args) 1))))
+                                          (when (< (+ arg-pos num) 0)
+                                            (error "SRFI-29 directive ~[N]@* referenced negative index "
+                                                   (+ arg-pos num)))
+
+                                          (insert-before (list-ref orig-args (+ arg-pos num)) args arg-pos)
+                                          (loop (substring fmt (cadar m) (string-length fmt))
+                                                arg-pos)))
+                                       (else
+                                        ;; single char directive
+                                        ;; just skip the appropriate number of arguments and loop.
+                                        (if (< (cadar m) (string-length fmt))
+                                            (if (eq? (string-ref fmt (+ (caar m) 1)) #\?)
+                                                (loop (substring fmt (cadar m) (string-length fmt)) (+ arg-pos 2))
+                                                (loop (substring fmt (cadar m) (string-length fmt)) (+ arg-pos 1)))
+                                            arg-pos)))
+                                arg-pos)))))
+            
+            ;; now remove all instances of '~nnn@*' from the format string
+            ;; and remove the extra arguments at the end of the list:
+            (let ((fmt (regexp-replace-all positional-directive-regexp fmt ""))
+                  (args (take args (+ 1 n-args))))
+              (apply %stklos-format (cons port (cons fmt args)))))))))
+
+);; END OF DEFINE-MODULE
+
+(select-module STklos)
+
+(import SRFI-29)
+
+(define %format (in-module SRFI-29 %srfi-29:format))
+
+(provide "srfi-29")

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -67,7 +67,7 @@
     (26 "Notation for Specializing Parameters without Currying" () "srfi-26")
     (27 "Source of random bits" (random) "srfi-27")
     (28 "Basic Format Strings")
-    ;;   29 Localization
+    (29 "Localization" () "srfi-29")
     (30 "Nested Multi-line Comments")
     (31 "A special form for recursive evaluation")
     ;;   32 ........ Withdrawn

--- a/tests/srfis/29.stk
+++ b/tests/srfis/29.stk
@@ -108,32 +108,32 @@
 
 (test "srfi-29 jp.format.1"
       "zero 0 one -2 two -1"
-      (%format "zero ~a one ~1@*~a two ~a" 0 -1 -2))
+      (format "zero ~a one ~1@*~a two ~a" 0 -1 -2))
 
 (test "srfi-29 jp.format.2"
       "zero 0 one -2 two -1 three -2 four -3"
-      (%format "zero ~a one ~1@*~a two ~a three ~a four ~a" 0 -1 -2 -3 -4))
+      (format "zero ~a one ~1@*~a two ~a three ~a four ~a" 0 -1 -2 -3 -4))
 
 (test "srfi-29 jp.format.3"
       "one -1 two -3 three b 12 four -3"
-      (%format "one ~a two ~2@*~a three ~? four ~a" -1 "~x ~d" '(11 12) -3))
+      (format "one ~a two ~2@*~a three ~? four ~a" -1 "~x ~d" '(11 12) -3))
 
 
 (test "srfi-29 jp.format.4"
       "zero 0 one -1 two -1 three -2 four -3"
-      (%format "zero ~a one ~a two ~-1@*~a three ~a four ~a" 0 -1 -2 -3 -4))
+      (format "zero ~a one ~a two ~-1@*~a three ~a four ~a" 0 -1 -2 -3 -4))
 
 (test "srfi-29 jp.format.5"
       "zero 0 one -1 two 0 three -2 four -3"
-      (%format "zero ~a one ~a two ~-2@*~a three ~a four ~a" 0 -1 -2 -3 -4))
+      (format "zero ~a one ~a two ~-2@*~a three ~a four ~a" 0 -1 -2 -3 -4))
 
 (test "srfi-29 jp.format.6"
       "zero 0 one -1 two -2 three -2 four -3"
-      (%format "zero ~a one ~a two ~0@*~a three ~a four ~a" 0 -1 -2 -3 -4))
+      (format "zero ~a one ~a two ~0@*~a three ~a four ~a" 0 -1 -2 -3 -4))
 
 
 (test/error "srfi-29 jp.format.7"
-            (%format "zero ~a one ~2*~a two ~a" 0 -1 -2))
+            (format "zero ~a one ~2*~a two ~a" 0 -1 -2))
 
 (test/error "srfi-29 jp.format.8"
-            (%format "zero ~a one ~-2@*~a two ~a" 0 -1 -2))
+            (format "zero ~a one ~-2@*~a two ~a" 0 -1 -2))

--- a/tests/srfis/29.stk
+++ b/tests/srfis/29.stk
@@ -1,0 +1,139 @@
+;;;;
+;;;; 29.stk         -- Tests for SRFI-29: Localization
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Scott G. Miller, it is copyrighted as:
+;;;;
+;;;;;; 
+;;;;;; Copyright (C) Scott G. Miller (2002). All Rights Reserved.
+;;;;;; 
+;;;;;; This document and translations of it may be copied and furnished to
+;;;;;; others, and derivative works that comment on or otherwise explain it
+;;;;;; or assist in its implementation may be prepared, copied, published and
+;;;;;; distributed, in whole or in part, without restriction of any kind,
+;;;;;; provided that the above copyright notice and this paragraph are
+;;;;;; included on all such copies and derivative works. However, this
+;;;;;; document itself may not be modified in any way, such as by removing
+;;;;;; the copyright notice or references to the Scheme Request For
+;;;;;; Implementation process or editors, except as needed for the purpose of
+;;;;;; developing SRFIs in which case the procedures for copyrights defined
+;;;;;; in the SRFI process must be followed, or as required to translate it
+;;;;;; into languages other than English.
+;;;;;; 
+;;;;;; The limited permissions granted above are perpetual and will not be
+;;;;;; revoked by the authors or their successors or assigns.
+;;;;;; 
+;;;;;; This document and the information contained herein is provided on
+;;;;;; an "AS IS" basis and THE AUTHOR AND THE SRFI EDITORS DISCLAIM ALL
+;;;;;; WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+;;;;;; WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY
+;;;;;; RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+;;;;;; PARTICULAR PURPOSE.
+;;;;;; 
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 07-Apr-2021 21:33
+;;;; Last file update: 07-Apr-2021 21:45 (jpellegrini)
+;;;;
+
+
+(test "srfi-29.1" #t (symbol? (current-language)))
+
+(let ((language (if (eq? (current-language) 'en) 'fr 'en)))
+  (parameterize ((current-language language))
+     (test "srfi-29.2" language (current-language))))
+
+(test "srfi-29.3" #t (symbol? (current-country)))
+
+(let ((country (if (eq? (current-country) 'us) 'ca 'us)))
+  (parameterize ((current-country country))
+    (test "srfi-29.4"  country (current-country))))
+
+(test "srfi-29.5" #t (list? (current-locale-details)))
+
+(let ((translations
+       '(((en) . ((time . "It's ~a, ~a.")
+                  (goodbye . "Goodbye, ~a.")))
+         ((fr) . (;(time . "~1@*~a, c'est ~a.")
+                  (time . "C'est ~a... ~a!")
+                  (goodbye . "Au revoir, ~a."))))))
+  (for-each (lambda (translation)
+              (let ((bundle-name (cons 'hello-program (car translation))))
+                (when (not (load-bundle! bundle-name))
+                  (declare-bundle! bundle-name (cdr translation))
+                  (store-bundle! bundle-name))))
+            translations))
+
+(current-language 'en)
+
+(test "srfi-29.6" #f (localized-template 'hello-program 'foobar))
+
+(define localized-message
+  (lambda (message-name . args)
+    (apply format (cons (localized-template 'hello-program message-name)
+                        args))))
+
+(let ((myname "Fred"))
+  (test "srfi-29.7.english"
+        '("It's 12:00, Fred." "Goodbye, Fred.")
+        (parameterize ((current-language 'en))
+          (list (localized-message 'time "12:00" myname)
+                (localized-message 'goodbye myname))))
+  
+  (test "srfi-29.7.french"
+        ;;'("Fred, c'est 12:00." "Au revoir, Fred.")
+        '("C'est 12:00... Fred!" "Au revoir, Fred.")
+        (parameterize ((current-language 'fr))
+          (list (localized-message 'time "12:00" myname)
+                (localized-message 'goodbye myname)))))
+
+
+(test "srfi-29 jp.format.1"
+      "zero 0 one -2 two -1"
+      (%format "zero ~a one ~1@*~a two ~a" 0 -1 -2))
+
+(test "srfi-29 jp.format.2"
+      "zero 0 one -2 two -1 three -2 four -3"
+      (%format "zero ~a one ~1@*~a two ~a three ~a four ~a" 0 -1 -2 -3 -4))
+
+(test "srfi-29 jp.format.3"
+      "one -1 two -3 three b 12 four -3"
+      (%format "one ~a two ~2@*~a three ~? four ~a" -1 "~x ~d" '(11 12) -3))
+
+
+(test "srfi-29 jp.format.4"
+      "zero 0 one -1 two -1 three -2 four -3"
+      (%format "zero ~a one ~a two ~-1@*~a three ~a four ~a" 0 -1 -2 -3 -4))
+
+(test "srfi-29 jp.format.5"
+      "zero 0 one -1 two 0 three -2 four -3"
+      (%format "zero ~a one ~a two ~-2@*~a three ~a four ~a" 0 -1 -2 -3 -4))
+
+(test "srfi-29 jp.format.6"
+      "zero 0 one -1 two -2 three -2 four -3"
+      (%format "zero ~a one ~a two ~0@*~a three ~a four ~a" 0 -1 -2 -3 -4))
+
+
+(test/error "srfi-29 jp.format.7"
+            (%format "zero ~a one ~2*~a two ~a" 0 -1 -2))
+
+(test/error "srfi-29 jp.format.8"
+            (%format "zero ~a one ~-2@*~a two ~a" 0 -1 -2))


### PR DESCRIPTION
Hi @egallesio !
One more.

This one has a small problem: Since it needs to change the `format` directives, I added a new `format` procedure, and shadowed the old one:

```
(define %stklos-format format)

(define-module SRFI-29
...

(define (%srfi-29:format A . rest)

);; END OF DEFINE-MODULE

(select-module STklos)
(import SRFI-29)

(define format (in-module SRFI-29 %srfi-29:format))

(provide "srfi-29")
```

But then tests seem to break in a way that's not easy to debug. If I change `format` to `%format`, in the SRFI andin the tests,then all tests pass:

```
(select-module STklos)
(import SRFI-29)

(define %format (in-module SRFI-29 %srfi-29:format))   ;; here, we don't override STklos format, just for testing

(provide "srfi-29")
```

I'm not sure why that happens.