### PR TITLE
SRFI 25: add shape checking when creating shared arrays

### DIFF
--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -556,7 +556,7 @@
 (test "srfi-25 jp 17.share.2" 0  (array-share-count orig))
 (define one (share-array orig
                          (shape 1 3 1 4)
-                         (lambda (x y) (values y x))))
+                         (lambda (x y) (values (- x 1) (- y 1)))))
 (test "srfi-25 jp 17.share.3" #t (shared-array? orig))
 (test "srfi-25 jp 17.share.4" 1  (array-share-count orig))
 (test "srfi-25 jp 17.share.5" #t (shared-array? one))
@@ -572,7 +572,7 @@
 (test "srfi-25 jp 17.share.12" -1 (array-share-count two))
 (define three (share-array one
                            (shape 0 2 0 3)
-                           (lambda (x y) (values y y))))
+                           (lambda (x y) (values 2 (+ y 1)))))
 (test "srfi-25 jp 17.share.13" #t (shared-array? orig))
 (test "srfi-25 jp 17.share.14" 3  (array-share-count orig))
 (test "srfi-25 jp 17.share.15" #t (shared-array? one))

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -930,3 +930,15 @@
 
 (test "srfi-25 eg.class-of" <array> (class-of (make-array (shape 0 2  1 2 1 2) 0.)))
 
+
+(let ((arr (array (shape 0 2 0 3 0 2)
+                  -1 -2 -3 -4 -5 -6
+                  -7 -8 -9 -10 -11 -12)))
+  (test/error "srfi-25 jp.wrong-shape.1"
+              (share-array arr (shape 0 12) (lambda (x) (values x x x))))
+  (test/error "srfi-25 jp.wrong-shape.2"
+              (share-array arr (shape 0 3) (lambda (x) (values (- x) x x))))
+  (test/error "srfi-25 jp.wrong-shape.3"
+              (share-array arr (shape 0 2 0 3 0 2) (lambda (x y) (- x 1) y)))
+  (test/error "srfi-25 jp.wrong-shape.4"
+              (share-array arr (shape 0 2 0 3 0 2) (lambda (x y) (+ x 1) y))))


### PR DESCRIPTION
Now the user cannot create shared arrays that are incompatible with the original array shape (leading to out of bound indices).

* I have made functions to show sequences of numbers and to show the mapping as strings. Then, I used `math.h` (and `-lm`, which STklos would already use anyway) to calculate the needed space for them. Is that OK?
* Added some tests for wrong shapes
* I have tried to make a reeeealy informative message. see:

```
stklos> (require "srfi-25")
"srfi-25"
stklos> (define a (make-array (shape 0 2 0 3) 'z))

stklos> (share-array a (shape 0 3) (lambda (x) (values x x)))
**** Error:
share-array: Shape (0 3) does not map to shape (0 2 0 3) under mapping x_0 -> 1y_0; x_1 -> 1y_0. Index (2) for the new array goes out of bounds in the original array.

stklos> (share-array a (shape 0 2 0 3) (lambda (x y) (values y x)))
**** Error:
share-array: Shape (0 2 0 3) does not map to shape (0 2 0 3) under mapping x_0 -> + 1y_1; x_1 -> 1y_0. Index (0 2) for the new array goes out of bounds in the original array.
```

Racket does something similar, but they don't tell the user the last bit (which index goes out of bounds).

Gauche does not check this on shared array creation; it does later during referencing.