### PR TITLE
Extra procedures with SRFI-25

### DIFF
--- a/lib/srfi-25.stk
+++ b/lib/srfi-25.stk
@@ -29,6 +29,23 @@
 
 (select-module SRFI-25)
 
+(export array-for-each-index
+        array->vector
+        array->list
+        array-map!
+        array-map
+        array-copy
+        tabulate-array
+        tabulate-array!
+
+        array-retabulate!
+        share-row
+        share-column
+        share-array/origin
+        array-append
+        transpose
+        share-nths)
+
 ;;
 ;;  Finish array type constuction:
 ;;    - plug a function to describe arrays
@@ -55,7 +72,9 @@
   (lambda args
     (apply array (apply shape (car args)) (cdr args))))
 
-;; extra:
+
+;; EXTRA: almost all procdures in arlib.scm, not part of the
+;;        SRFI spec but included with the reference implementation.
 ;;
 ;;; (array-shape arr)
 ;;; (array-length arr dim)
@@ -67,16 +86,19 @@
 ;;; (tabulate-array! shp proc ind)
 ;;; (array-map [shp] proc arr0 arr1 ...)
 ;;; (array-map! arr [shp] proc arr0 arr1 ...)
-;;; (array->vector arr) (array->list arr)
-
-;;; NOT implemented:
-;;; (share-array/prefix arr k ...) (share-row arr k) (share-column arr k)
-;;; (share-array/origin arr k ...) (share-array/origin arr ind)
-;;; (array-append dim arr0 arr1 ...)
-;;; (transpose arr dim ...)
+;;; (array->vector arr)
+;;; (array->list arr)
+;;; (share-row arr k)
+;;; (share-column arr k)
+;;; (share-array/origin arr k ...)
+;;; (share-array/origin arr ind)
 ;;; (share-nths arr dim n)
+;;; (transpose arr dim ...)
+;;; (array-append dim arr0 arr1 ...)
 ;;; (array-retabulate! arr shp proc [ind])
 
+;; NOT implemented:
+;;; (share-array/prefix arr k ...) 
 
 #|
 <doc EXT array-length
@@ -288,14 +310,349 @@ doc>
 (define (tabulate-array! shape proc ind)
   (tabulate-array shape proc ind))
 
-(export array-for-each-index
-        array->vector
-        array->list
-        array-map!
-        array-map
-        array-copy
-        tabulate-array
-        tabulate-array!)
+
+
+
+
+
+
+#|
+<doc EXT array-retabulate!
+ * (array-retabulate! arr shp proc [index-object])
+ *
+ * Sets the elements of |arr| in |shape| to the value of |proc| at that
+ * index, using |index-object| if provided. This is similar to
+ * |tabulate-array!|, except that the array is given by the user.
+ *
+ * @lisp
+ * (define arr (array (shape 0 2 0 2) 'a 'b 'c 'd))
+ * (array-retabulate! arr (shape 0 2 0 2) (lambda (x y) (+ 1 x y)))
+ * arr => #,(<array> (0 2 0 2) 1 2 2 3)
+ * @end lisp
+doc>
+|#
+(define (array-retabulate! arr shape proc :optional (ind #f))
+  ;; we use vector index objects always, regardless of what the
+  ;; user gave us.
+  (when (not (shape? shape)) (error "bad shape ~S" shape))
+  (when (not (procedure? proc)) (error "bad procedure ~S" proc))
+  (cond ((or (vector? ind) (array? ind))
+         (lambda (idx) (array-set! arr idx (proc idx)))
+         (shape-for-each shape (lambda (idx) (array-set! arr
+                                                    idx
+                                                    (proc idx)))
+                         ind))
+        
+        ((not ind)
+         (shape-for-each shape (lambda idx (array-set! arr
+                                                  (list->vector idx)
+                                                  (apply proc idx)))))
+        
+        (else
+         (error "index object ~S is none of vector, array or #f" ind)))
+  arr)
+
+#|
+<doc EXT share-row
+ * (share-row arr k)
+ *
+ * Shares whatever the first index is about. The result has one dimension less.
+ *
+ * @lisp
+ * (define a (array (shape 0 2 0 2 0 2) -1 -2 -3 -4 -5 -6 -7 -8))
+ *
+ * (share-row a 0) => #,(<array> (0 2 0 2) -1 -2 -3 -4)
+ * (share-row a 1) => #,(<array> (0 2 0 2) -5 -6 -7 -8)
+ * @end lisp
+doc>
+|#
+(define (share-row arr k)
+  (share-array
+   arr
+   (let ((bounds (array->list (array-shape arr))))
+     (apply shape (cddr bounds)))
+   (lambda ks
+     (apply values k ks))))
+
+#|
+<doc EXT share-column
+ * (share-column arr k)
+ *
+ * Shares whatever the second index is about. The result has one dimension less.
+ *
+ * @lisp
+ * (define a (array (shape 0 2 0 2 0 2) -1 -2 -3 -4 -5 -6 -7 -8))
+ *
+ * (share-column a 0) =>
+
+ * (share-column a 1) => #,(<array> (0 2 0 2) -3 -4 -7 -8)
+ * @end lisp
+doc>
+|#
+(define (share-column arr k)
+  (share-array
+   arr
+   (let ((bounds (array->list (array-shape arr))))
+     (apply shape
+            (car bounds) (cadr bounds)
+            (cddddr bounds)))
+   (lambda ks
+     (apply values (car ks) k (cdr ks)))))
+
+#|
+<doc EXT share-array/origin
+ * (share-array/origin arr k ...)
+ * (share-array/origin arr index)
+ *
+ * change the origin of |arr| to |k| ..., with |index| a vector or zero-based
+ * one-dimensional array that contains k ...
+ *
+ * @lisp
+ * (define a (array (shape 0 2 0 2 ) -1 -2 -3 -4))
+ *
+ * (share-array/origin  a 1 1) => #,(<array> (1 3 1 3) -1 -2 -3 -4)
+ * @end lisp
+doc>
+|#
+(define (share-array/origin arr . xs)
+  (let ((new (if (or (null? xs)
+                     (integer? (car xs)))
+                 xs
+                 (apply (lambda (x)
+                          (if (vector? x)
+                              (vector->list x)
+                              (if (array? x)
+                                  (array->list x)
+                                  (error "share-array/origin: bad thing"))))
+                        xs))))
+    (do ((k (array-rank arr) (- k 1))
+         (old '() (cons (array-start arr (- k 1)) old)))
+      ((= k 0)
+       (let ((ds (map - new old)))
+         (share-array
+          arr
+          (tabulate-array
+           (shape 0 (array-rank arr) 0 2)
+           (lambda (r k)
+             (case k
+               ((0) (+ (array-start arr r) (list-ref ds r)))
+               ((1) (+ (array-end arr r) (list-ref ds r))))))
+          (lambda ks
+            (apply values (map - ks ds)))))))))
+
+
+#|
+<doc EXT array-append
+ * (array-append dim arr1 arr2 ...)
+ *
+ * Appends arrays |arr1|, |arr2|, ... along the specified dimension |dim|.
+ * The arrays must have equally many dimensions and all other dimensions
+ * equally long.
+ *
+ * @lisp
+ * (define a (array (shape 0 2 0 3) 11 22 33 44 55 66))
+ * (define b (array (shape 0 3 0 3) -11 -22 -33 -44 -55 -66 -77 -88 -99))
+ * (define c (array (shape 0 1 0 3) 'a 'b 'c))
+ *
+ * (array-append 0 a b c) =>  #,(<array> (0 6 0 3)
+ *                                        11  22  33
+ *                                        44  55  66
+ *                                       -11 -22 -33
+ *                                       -44 -55 -66
+ *                                       -77 -88 -99
+ *                                         a   b   c)
+ * @end lisp
+doc>
+|#
+(define (array-append dim arr . ars)
+  (let* ((total (do ((m (array-length arr dim)
+                        (+ m (array-length (car r) dim)))
+                     (r ars (cdr r)))
+                  ((null? r) m)))
+         (common (array-shape arr))
+         (origin (array->vector (share-column common 0)))
+         (index (make-vector (array-rank arr))))
+    (array-set! common dim 1 (+ (array-start arr dim) total))
+    (let ((result (make-array common)))
+      (array-set! common dim 1 (array-start arr dim))
+      (let wok ((arr arr)
+                (ars ars))
+        (vector-set! origin dim (array-ref common dim 1))
+        (let ((arr1 (share-array/origin arr origin)))
+          (array-set! common dim 0 (array-start arr1 dim))
+          (array-set! common dim 1 (array-end arr1 dim))
+          (shape-for-each
+           common
+           (lambda (index)
+             (array-set! result index (array-ref arr1 index)))
+           index))
+        (if (pair? ars)
+            (wok (car ars) (cdr ars))))
+      result)))
+
+
+(define (matrix-times a b)
+  (or (and (= (array-rank a) 2)
+           (= (array-rank b) 2))
+      (error "matrix-times: arrays are not matrices"))
+  (let ((r0 (array-start a 0))  (rn (array-end a 0))
+        (t0 (array-start a 1))  (tn (array-end a 1))
+        (u0 (array-start b 0))  (un (array-end b 0)) 
+        (k0 (array-start b 1))  (kn (array-end b 1)))
+    (or (= (- tn t0) (- un u0))
+        (error "matrix-times: matrices are not compatible"))
+    (let ((ab (make-array (shape r0 rn k0 kn))))
+      (do ((r r0 (+ r 1)))
+        ((= r rn))
+        (do ((k k0 (+ k 1)))
+          ((= k kn))
+          (do ((t t0 (+ t 1))
+               (u u0 (+ u 1))
+               (s 0 (+ s (* (array-ref a r t)
+                            (array-ref b u k)))))
+            ((and (= t tn)
+                  (= u un))
+             (array-set! ab r k s)))))
+      ab)))
+
+#|
+<doc EXT transpose
+ * (transpose arr k ...)
+ *
+ * Shares |arr| with permuted dimensions. Each dimension from 0
+ * inclusive to rank exclusive must appear once in |k| ...
+ *
+ * This is a generalized transpose. It can permute the dimensions any which 
+ * way. The permutation is provided by a permutation matrix: a square matrix
+ * of zeros and ones, with exactly one one in each row and column, or a
+ * permutation of the rows of an identity matrix; the size of the matrix
+ * must match the number of dimensions of the array.
+ *
+ * The default permutation is |[ 0 1 | 1 0 ]| of course, but any permutation
+ * array can be specified, and the shape array of the original array is then
+ * multiplied with it, and index column vectors of the new array with its
+ * inverse, from left, to permute the rows appropriately.
+ * @lisp
+ * (define a (array (shape 0 4 0 4)
+ *                  -1  -2   -3  -4
+ *                  -5  -6   -7  -8
+ *                  -9  -10 -11 -12
+ *                  -13 -14 -15 -16))
+ *
+ * (transpose a)
+ *  => #,(<array> (0 4 0 4)
+ *                 -1 -5  -9 -13
+ *                 -2 -6 -10 -14
+ *                 -3 -7 -11 -15
+ *                 -4 -8 -12 -16)
+ * (define a (array (shape 0 3 0 3 0 2)
+ *                  -1 -2
+ *                  -3 -4
+ *                  -5 -6
+ *
+ *                  -7 -8
+ *                  -9 -10 
+ *                  -11 -12
+ *
+ *                  -13 -14
+ *                  -15 -16
+ *                  -17 -18))
+ *
+ * (transpose a)
+ *  => #,(<array> (0 2 0 3 0 3)
+ *                 -1  -7 -13
+ *                 -3  -9 -15
+ *                 -5 -11 -17
+ *
+ *                 -2  -8 -14
+ *                 -4 -10 -16
+ *                 -6 -12 -18)
+ * @end lisp
+doc>
+|#
+(define (permutation-matrix . ds)
+  (let* ((n (length ds))
+         (arr (make-array (shape 0 n 0 n) 0)))
+    (do ((k 0 (+ k 1))
+         (ds ds (cdr ds)))
+      ((= k n))
+      (array-set! arr k (car ds) 1))
+    arr))
+
+(define (transpose a . p0)
+  (let* ((r (array-rank a))
+         (permutation (apply permutation-matrix
+                             (if (pair? p0)
+                                 p0
+                                 (do ((ds '() (cons d ds))
+                                      (d 0 (+ d 1)))
+                                   ((= d r)
+                                    ;; reverse dimensions
+                                    ds)))))
+         (inverse-permutation (share-array permutation
+                                           (array-shape permutation)
+                                           (lambda (r k)
+                                             ;; transpose
+                                             (values k r)))))
+    (share-array
+     a
+     (matrix-times permutation (array-shape a))
+     (lambda ks0
+       (apply values
+              (array->list
+               (matrix-times
+                inverse-permutation
+                (apply array (shape 0 r 0 1) ks0))))))))
+
+
+
+#|
+<doc EXT share-nths
+ * (share-nths a d n)
+ *
+ * |Share-nths| takes every |n|th slice along dimension |d| into a shared array.
+ * This preserves the origin.
+ *
+ * Example:
+ *
+ * @lisp
+ * (define a (array (shape 0 4 0 4)
+ *                  -1 -2 -3 -4
+ *                  -5 -6 -7 -8
+ *                  -9 -10 -11 -12
+ *                  -13 -14 -15 -16))
+ * a
+ *  => #,(<array> (0 4 0 4)
+ *                 -1 -2 -3 -4
+ *                 -5 -6 -7 -8
+ *                 -9 -10 -11 -12
+ *                 -13 -14 -15 -16)
+ * 
+ * (share-nths a 0 2)
+ *  => #,(<array> (0 2 0 4) -1  -2  -3  -4
+ *                          -9 -10 -11 -12)
+ * 
+ * (share-nths a 1 2)
+ *  => #,(<array> (0 4 0 2) -1  -3  -5  -7
+ *                          -9 -11 -13 -15)
+ * @end lisp
+doc>
+|#
+(define (share-nths arr d n)
+  (let* ((bounds (array->vector (array-shape arr)))
+         (b (vector-ref bounds (* 2 d)))
+         (e (vector-ref bounds (+ (* 2 d) 1))))
+    (vector-set! bounds (+ (* 2 d) 1) (+ b (quotient (+ n (- e b 1)) n)))
+    (share-array
+     arr
+     (apply shape (vector->list bounds))
+     (lambda ks
+       (apply values
+              (let d/nk ((u 0) (ks ks))
+                (if (= u d)
+                    (cons (+ b (* n (- (car ks) b))) (cdr ks))
+                    (cons (car ks) (d/nk (+ u 1) (cdr ks))))))))))
+
 
 (select-module STklos)
 (import SRFI-25)

--- a/lib/srfi-25.stk
+++ b/lib/srfi-25.stk
@@ -19,9 +19,34 @@
 ;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
 ;;;; USA.
 ;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by  Shiro Kawai, adapted by John Cowan, Kevin Wortman (2015)
+;;;; it is copyrighted as:
+;;;;
+;;;;;; Copyright (C) Jussi Piitulainen (2001). All Rights Reserved.
+;;;;;;
+;;;;;; Permission is hereby granted, free of charge, to any person obtaining
+;;;;;; a copy of this software and associated documentation files (the
+;;;;;; "Software"), to deal in the Software without restriction, including
+;;;;;; without limitation the rights to use, copy, modify, merge, publish,
+;;;;;; distribute, sublicense, and/or sell copies of the Software, and to
+;;;;;; permit persons to whom the Software is furnished to do so, subject to
+;;;;;; the following conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice shall be
+;;;;;; included in all copies or substantial portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;;;;;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;;;;;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;;;;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;;;;
 ;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
 ;;;;    Creation date: 27-Mar-2021 02:33
-;;;; Last file update: 16-Apr-2021 14:27 (eg)
+;;;; Last file update: 18-Apr-2021 18:34 (jpellegrini)
 ;;;;
 
 

--- a/tests/srfis/25.stk
+++ b/tests/srfis/25.stk
@@ -930,3 +930,98 @@
 
 (test "srfi-25 eg.class-of" <array> (class-of (make-array (shape 0 2  1 2 1 2) 0.)))
 
+
+(let ((arr (array (shape 0 2 0 2) 'a 'b 'c 'd)))
+  (array-retabulate! arr (shape 0 2 0 2) (lambda (x y) (+ 1 x y)))
+  (test "srfi-25 jp.array-retabulate!"
+        #,(<array> (0 2 0 2) 1 2 2 3)
+        arr))
+
+(let ((a (array (shape 0 2 0 2 0 2) -1 -2 -3 -4 -5 -6 -7 -8)))
+  (test "srfi-25 jp.share-row.1"
+        #,(<array> (0 2 0 2) -1 -2 -3 -4)
+        (share-row a 0))
+  
+  (test "srfi-25 jp.share-row.2"
+        #,(<array> (0 2 0 2) -5 -6 -7 -8)
+        (share-row a 1))
+
+  (test "srfi-25 jp.share-col.1"
+        (share-column a 0)
+        #,(<array> (0 2 0 2) -1 -2 -5 -6))
+
+  (test "srfi-25 jp.share-col.2"
+        (share-column a 1)
+        #,(<array> (0 2 0 2) -3 -4 -7 -8)))
+
+(let ((a (array (shape 0 2 0 2 ) -1 -2 -3 -4)))
+  (test "srfi-25 jp.share-array/origin"
+        #,(<array> (1 3 1 3) -1 -2 -3 -4)
+        (share-array/origin  a 1 1)))
+
+
+(let ((a (array (shape 0 2 0 3) 11 22 33 44 55 66))
+      (b (array (shape 0 3 0 3) -11 -22 -33 -44 -55 -66 -77 -88 -99))
+      (c (array (shape 0 1 0 3) 'a 'b 'c)))
+  (test "srfi-25 jp.array-append"
+        #,(<array> (0 6 0 3)
+                   11  22  33
+                   44  55  66
+                   -11 -22 -33
+                   -44 -55 -66
+                   -77 -88 -99
+                   a   b   c)
+        (array-append 0 a b c)))
+
+(let ((a (array (shape 0 4 0 4)
+                -1  -2   -3  -4
+                -5  -6   -7  -8
+                -9  -10 -11 -12
+                -13 -14 -15 -16)))
+  (test "srfi-25 jp.transpose.1"
+        #,(<array> (0 4 0 4)
+                   -1 -5  -9 -13
+                   -2 -6 -10 -14
+                   -3 -7 -11 -15
+                   -4 -8 -12 -16)
+        (transpose a)))
+
+  
+(let ((a (array (shape 0 3 0 3 0 2)
+                -1 -2
+                -3 -4
+                -5 -6
+                
+                -7 -8
+                -9 -10 
+                -11 -12
+                
+                -13 -14
+                -15 -16
+                -17 -18)))
+  (test "srfi-25 jp.transpose.2"
+        #,(<array> (0 2 0 3 0 3)
+                   -1  -7 -13
+                   -3  -9 -15
+                   -5 -11 -17
+                   
+                   -2  -8 -14
+                   -4 -10 -16
+                   -6 -12 -18)
+        (transpose a)))
+
+(let ((a (array (shape 0 4 0 4)
+                -1 -2 -3 -4
+                -5 -6 -7 -8
+                -9 -10 -11 -12
+                -13 -14 -15 -16)))
+  (test "srfi-25 jp.share-nths.1"
+        #,(<array> (0 2 0 4)
+                   -1  -2  -3  -4
+                   -9 -10 -11 -12)
+            (share-nths a 0 2))
+  (test  "srfi-25 jp.share-nths.2"
+         #,(<array> (0 4 0 2)
+                    -1  -3  -5  -7
+                    -9 -11 -13 -15)
+         (share-nths a 1 2)))


### PR DESCRIPTION
Hi @egallesio !

Remember I told you there were some extra procedures that could be implemented, but I didn't?
So - I took almost all of the missing ones from the SRFI repository, and wrote some tests for them.

Only one is missing, because it does some weird things -- `share-array/prefix` uses an internal procedure of which even the SRFI author (Jussi Piitulainen) expressed his dislike ( in the comments).

I have included some documentation for these procedures.