### PR TITLE
Add SRFI-46: Basic Syntax-rules Extensions (actually part of R7RS small)

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -52,6 +52,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-41: Streams
     - SRFI-43: Vector library
     - SRFI-45: Primitives for Expressing Iterative Lazy Algorithms
+    - SRFI-46: Basic Syntax-rules Extensions
     - SRFI-48: Intermediate Format Strings
     - SRFI-51: Handling rest list
     - SRFI-54: Formatting

--- a/lib/mbe.stk
+++ b/lib/mbe.stk
@@ -135,7 +135,7 @@ doc>
 
   (define-macro (letrec-syntax . args)(%not-implemented 'letrec-syntax ',args))
 
-  
+
 
 ;;;
 ;;; Scheme utilities
@@ -204,17 +204,17 @@ doc>
 ;; (hyg:tag 1          '(fun x fun oh) '()) => (1)
 ;; (hyg:tag '(f a b c) '(a c)          '((G-something . y))) => ((G1333 a G1334 c) (G1334 . b) (G1333 . f) (G-something . y))
 (define hyg:tag
-  (lambda (e kk al)
+  (lambda (e kk al ellipsis)
     (cond ((pair? e)
-            (let* ((a-te-al (hyg:tag (car e) kk al))
-                    (d-te-al (hyg:tag (cdr e) kk (cdr a-te-al))))
+            (let* ((a-te-al (hyg:tag (car e) kk al ellipsis))
+                    (d-te-al (hyg:tag (cdr e) kk (cdr a-te-al) ellipsis)))
               (cons (cons (car a-te-al) (car d-te-al))
                 (cdr d-te-al))))
       ((vector? e)
         (list->vector
-          (hyg:tag (vector->list e) kk al)))
+          (hyg:tag (vector->list e) kk al ellipsis)))
       ((symbol? e)
-        (cond ((eq? e '...) (cons '... al))
+        (cond ((eq? e ellipsis) (cons ellipsis al))
           ((memq e kk) (cons e al))
           ((hyg:rassq e al) =>
             (lambda (c)
@@ -468,79 +468,80 @@ doc>
 ;; (mbe:matches-pattern? '(f a x b) '(* 2 x 4) '(x)) => #t
 ;; (mbe:matches-pattern? '(f a x b) '(* 2 3 4) '(x)) => #f
 (define mbe:matches-pattern?
-  (lambda (p e k)
-    (cond ((mbe:ellipsis? p)
-           (and (or (null? e) (pair? e))
-                (let* ((p-head (car p))
-                       (p-tail (cddr p))
-                       (e-head=e-tail (mbe:split-at-ellipsis e p-tail)))
-                  (and e-head=e-tail
-                       (not (memq '... p-tail)) ; fail on multiple ellipses
-                       (let ((e-head (car e-head=e-tail))
-                             (e-tail (cdr e-head=e-tail)))
-                         (and (every
-                               (lambda (x) (mbe:matches-pattern? p-head x k))
-                               e-head)
-                              (mbe:matches-pattern? p-tail e-tail k)))))))
-          ((pair? p)
-           (and (pair? e)
-                (mbe:matches-pattern? (car p) (car e) k)
-                (mbe:matches-pattern? (cdr p) (cdr e) k)))
-          ((symbol? p) (if (memq p k) (eq? p e) #t))
-          (else (equal? p e)))))
+  (lambda (p e k ellipsis)
+    (cond ((mbe:ellipsis? p ellipsis)
+	   (and (or (null? e) (pair? e))
+		    (let* ((p-head (car p))
+		           (p-tail (cddr p))
+		           (e-head=e-tail (mbe:split-at-ellipsis e p-tail)))
+		      (and e-head=e-tail
+		           (not (memq ellipsis p-tail)) ; fail on multiple ellipses
+		           (let ((e-head (car e-head=e-tail))
+			             (e-tail (cdr e-head=e-tail)))
+			         (and (every
+			               (lambda (x) (mbe:matches-pattern? p-head x k ellipsis))
+			               e-head)
+			              (mbe:matches-pattern? p-tail e-tail k ellipsis)))))))
+	      ((pair? p)
+	       (and (pair? e)
+		        (mbe:matches-pattern? (car p) (car e) k ellipsis)
+		        (mbe:matches-pattern? (cdr p) (cdr e) k ellipsis)))
+	      ((symbol? p) (if (memq p k) (eq? p e) #t))
+	      (else (equal? p e)))))
+
 
 ;;; gets the bindings of pattern variables of pattern p for
 ;;; expression e;
 ;;; k is the list of keywords
 (define mbe:get-bindings
-  (lambda (p e k)
-    (cond ((mbe:ellipsis? p)
-           (let* ((p-head (car p))
-                  (p-tail (cddr p))
-                  (e-head=e-tail (mbe:split-at-ellipsis e p-tail))
-                  (e-head (car e-head=e-tail))
-                  (e-tail (cdr e-head=e-tail)))
-             (cons (cons (mbe:get-ellipsis-nestings p-head k)
-                     (map (lambda (x) (mbe:get-bindings p-head x k))
-                          e-head))
-               (mbe:get-bindings p-tail e-tail k))))
-          ((pair? p)
-           (append (mbe:get-bindings (car p) (car e) k)
-             (mbe:get-bindings (cdr p) (cdr e) k)))
-          ((symbol? p)
-           (if (memq p k) '() (list (cons p e))))
-          (else '()))))
+  (lambda (p e k ellipsis)
+    (cond ((mbe:ellipsis? p ellipsis)
+	       (let* ((p-head (car p))
+		          (p-tail (cddr p))
+		          (e-head=e-tail (mbe:split-at-ellipsis e p-tail))
+		          (e-head (car e-head=e-tail))
+		          (e-tail (cdr e-head=e-tail)))
+	         (cons (cons (mbe:get-ellipsis-nestings p-head k ellipsis)
+		                 (map (lambda (x) (mbe:get-bindings p-head x k ellipsis))
+			                  e-head))
+	               (mbe:get-bindings p-tail e-tail k ellipsis))))
+	      ((pair? p)
+	       (append (mbe:get-bindings (car p) (car e) k ellipsis)
+	               (mbe:get-bindings (cdr p) (cdr e) k ellipsis)))
+	      ((symbol? p)
+	       (if (memq p k) '() (list (cons p e))))
+	      (else '()))))
 
 ;;; expands pattern p using environment r;
 ;;; k is the list of keywords
 (define mbe:expand-pattern
-  (lambda (p r k)
-    (cond ((mbe:ellipsis? p)
-           (append (let* ((p-head (car p))
-                          (nestings (mbe:get-ellipsis-nestings p-head k))
-                          (rr (mbe:ellipsis-sub-envs nestings r)))
-                     (map (lambda (r1)
-                            (mbe:expand-pattern p-head (append r1 r) k))
-                          rr))
-             (mbe:expand-pattern (cddr p) r k)))
-          ((pair? p)
-           (cons (mbe:expand-pattern (car p) r k)
-             (mbe:expand-pattern (cdr p) r k)))
-          ((symbol? p)
-           (if (memq p k) p
-             (let ((x (assq p r)))
-               (if x (cdr x) p))))
-          (else p))))
+  (lambda (p r k ellipsis)
+    (cond ((mbe:ellipsis? p ellipsis)
+	       (append (let* ((p-head (car p))
+			              (nestings (mbe:get-ellipsis-nestings p-head k ellipsis))
+			              (rr (mbe:ellipsis-sub-envs nestings r)))
+		             (map (lambda (r1)
+			                (mbe:expand-pattern p-head (append r1 r) k ellipsis))
+			              rr))
+	               (mbe:expand-pattern (cddr p) r k ellipsis)))
+	      ((pair? p)
+	       (cons (mbe:expand-pattern (car p) r k ellipsis)
+	             (mbe:expand-pattern (cdr p) r k ellipsis)))
+	      ((symbol? p)
+	       (if (memq p k) p
+	           (let ((x (assq p r)))
+	             (if x (cdr x) p))))
+	      (else p))))
 
 ;;; returns a list that nests a pattern variable as deeply as it
 ;;; is ellipsed
 (define mbe:get-ellipsis-nestings
-  (lambda (p k)
+  (lambda (p k ellipsis)
     (let sub ((p p))
-      (cond ((mbe:ellipsis? p) (cons (sub (car p)) (sub (cddr p))))
-            ((pair? p) (append (sub (car p)) (sub (cdr p))))
-            ((symbol? p) (if (memq p k) '() (list p)))
-            (else '())))))
+      (cond ((mbe:ellipsis? p ellipsis) (cons (sub (car p)) (sub (cddr p))))
+	        ((pair? p) (append (sub (car p)) (sub (cdr p))))
+	        ((symbol? p) (if (memq p k) '() (list p)))
+	        (else '())))))
 
 ;;; finds the subenvironments in r corresponding to the ellipsed
 ;;; variables in nestings
@@ -584,8 +585,8 @@ doc>
 ;;; tests if x is an ellipsing pattern, i.e., of the form
 ;;; (blah ... . blah2)
 (define mbe:ellipsis?
-  (lambda (x)
-    (and (pair? x) (pair? (cdr x)) (eq? (cadr x) '...))))
+  (lambda (x ellipsis)
+    (and (pair? x) (pair? (cdr x)) (eq? (cadr x) ellipsis))))
 
 
 #|
@@ -628,9 +629,9 @@ doc>
 
 
 ;; find-clause will find the clause to be used in order to expand a macro.
-;; 
+;;
 ;; Example:
-;; 
+;;
 ;; (define-syntax2 f
 ;;   (syntax-rules ()
 ;;     ((f a b)   (+ a b))
@@ -641,29 +642,32 @@ doc>
 ;;
 ;; (find-clause 'f '(1 2 3) '() '( ((f a b)   (+ a b)) ((f a b c) (* b c))))
 ;; => (* 2 3)
-(define (find-clause macro-name macro-args keywords clauses)
+(define (find-clause macro-name macro-args keywords clauses ellipsis)
   (let ((macro-form (cons macro-name macro-args)))
     (let Loop ((l clauses))
       (if (null? l)
           (error macro-name "no matching clause for ~S" macro-form)
           (let ((in-pattern  (caar  l))
                 (out-pattern (cadar l)))
-            (if (mbe:matches-pattern? in-pattern macro-form keywords)
+            (if (mbe:matches-pattern? in-pattern macro-form keywords ellipsis)
                 (let ((tmp (hyg:tag out-pattern
                                     (append! (hyg:flatten in-pattern) keywords)
-                                    '())))
+                                    '()
+                                    ellipsis)))
                   (hyg:untag (mbe:expand-pattern (car tmp)
                                                  (mbe:get-bindings in-pattern
                                                                    macro-form
-                                                                   keywords)
-                                                 keywords)
+                                                                   keywords
+                                                                   ellipsis)
+                                                 keywords
+                                                 ellipsis)
                              (cdr tmp)
                              '()))
                 (Loop (cdr l))))))))
 
 
 ;;
-;; A very simple implementation od let-syntax. 
+;; A very simple implementation od let-syntax.
 ;; FIXME: Need some work
 ;;
 (define-macro (let-syntax bindings . body)
@@ -684,6 +688,7 @@ doc>
 )       ;;; end of module definition of MBE
 
 
+
 (define %find-macro-clause (symbol-value 'find-clause (find-module 'MBE)))
 
 
@@ -695,7 +700,7 @@ doc>
 ;;MAC   (if (or (not (pair? syn-rules))
 ;;MAC           (not (eq? (car syn-rules) 'syntax-rules)))
 ;;MAC     (error 'define-syntax "in `~S', bad syntax-rules ~S" macro-name syn-rules)
-;;MAC 
+;;MAC
 ;;MAC     (let ((keywords    (cons macro-name (cadr syn-rules)))
 ;;MAC           (clauses     (cddr syn-rules))
 ;;MAC           (find-clause (symbol-value 'find-clause (find-module 'MBE))))

--- a/lib/runtime-macros.stk
+++ b/lib/runtime-macros.stk
@@ -32,7 +32,7 @@
 
 ;;;;
 ;;;; WHEN/UNLESS
-;;;; 
+;;;;
 (define-macro (when . args)
   (if (<= (length args) 1)
       (syntax-error 'when "bad syntax in ~S" `(when ,@args))
@@ -86,8 +86,24 @@
           (not (eq? (car syn-rules) 'syntax-rules)))
       (error 'define-syntax "in `~S', bad syntax-rules ~S" macro-name syn-rules)
 
-      (let ((keywords    (cons macro-name (cadr syn-rules)))
-            (clauses     (cddr syn-rules))
-            (find-clause (symbol-value 'find-clause (find-module 'MBE))))
-        `(define-macro (,macro-name . args)
-           (%find-macro-clause ',macro-name args ',keywords ',clauses)))))
+      ;; SRFI-46:
+      ;; Let the user pick the ellipsis symbol. Since STklos does not recognize
+      ;; symbols starting with ":", we test for symbol and keyword here.
+      ;; If we find that the user included a symbol or keyword instead of a list
+      ;; after "SYNTAX-RULES", then it's the ellipsis marker to be used,
+      ;; (SYNTAX-RULES ::: () ((_ (f x :::)) (do-something x :::)))
+      (let ((ellipsis '...))
+        (when (or (symbol?  (cadr syn-rules))
+                  (keyword? (cadr syn-rules)))
+          (set! ellipsis (cadr syn-rules))
+          (set! syn-rules (cdr syn-rules)))
+
+
+        (let ((keywords    (cons macro-name (cadr syn-rules)))
+              (clauses     (cddr syn-rules))
+              (find-clause (symbol-value 'find-clause (find-module 'MBE))))
+          `(define-macro (,macro-name . args)
+             (%find-macro-clause ',macro-name args
+                                 ',keywords
+                                 ',clauses
+                                 ',ellipsis))))))

--- a/lib/srfi/46.stk
+++ b/lib/srfi/46.stk
@@ -1,0 +1,26 @@
+;;;; 46.stk 				-- SRFI-46
+;;;;
+;;;; Copyright © 2023 jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_paleph0.info]
+;;;;    Creation date: 12-Feb-2023 12:13 (jpellegrini)
+;;;; Last file update: 12-Feb-2023 12:20 (jpellegrini)
+
+(define-module srfi/46)
+
+(provide "srfi/46")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -65,6 +65,7 @@ SRC_STK   = 1.stk   \
             41.stk  \
             43.stk  \
             45.stk  \
+            46.stk  \
             48.stk  \
             51.stk  \
             54.stk  \
@@ -172,6 +173,7 @@ SRC_OSTK =  1.ostk   \
             41.ostk  \
             43.ostk  \
             45.ostk  \
+            46.ostk  \
             48.ostk  \
             51.ostk  \
             54.ostk  \
@@ -311,7 +313,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 152.ostk: 13.ostk
 154.ostk: 9.ostk
 158.ostk: ../scheme/generator.ostk
-160.ostk: 4.ostk 128.ostk 
+160.ostk: 4.ostk 128.ostk
 161.ostk: 9.ostk
 171.ostk: 1.ostk 9.ostk 69.ostk
 173.ostk: 9.ostk

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -84,7 +84,7 @@
     (43 "Vector library" () "srfi-43")
     ;; 44  Collections
     (45 "Primitives for Expressing Iterative Lazy Algorithms")
-    ;; 46 Basic Syntax-rules Extensions
+    (46 "Basic Syntax-rules Extensions")
     ;; 47 Array
     (48 "Intermediate Format Strings" () "srfi-48")
     ;; 49 Indentation-sensitive syntax (NEVER)

--- a/tests/srfis/46.stk
+++ b/tests/srfis/46.stk
@@ -1,0 +1,111 @@
+;; ----------------------------------------------------------------------
+;;  SRFI 46 ...
+;; ----------------------------------------------------------------------
+
+;;; Macros created here begin with "s46:test:", so as to not interfere
+;;; with other tests. I have tried including these tests in a module,
+;;; but the macros were still visible in other SRFI tests (127, for example,
+;;; which uses the identifier "g").
+
+;;; First, testing the configurable ellipsis:
+
+;; with symbol, "_"
+(define-syntax s46:test:g
+  (syntax-rules _ ()
+    ((_ x _) (format #f x _))))
+
+(test "srfi-46 ellipsis.1"
+      "[x]"
+      (s46:test:g "[~a]" 'x))
+
+;; with keyword, "..."
+(define-syntax s46:test:h
+  (syntax-rules ::: ()
+    ((_ x :::) (format #f x :::))))
+
+(test "srfi-46 ellipsis.2"
+      "[x]"
+      (s46:test:h "[~a]" 'x))
+
+
+;; with unicode horizontal ellipsis, "…"
+(define-syntax s46:test:i
+  (syntax-rules … ()
+    ((i x …) (format #f x …))))
+(test "srfi-46 ellipsis.3"
+      "[x]"
+      (s46:test:i "[~a]" 'x))
+
+
+(define-syntax s46:test:my-and
+  (syntax-rules :... ()
+    ((_) #t)
+    ((_ e) e)
+    ((_ e1 e2 :...)
+     (if e1
+	 (s46:test:my-and e2 :...)
+	 #f))))
+
+(test "srfi-46 ellipsis 4"
+      #f
+      (s46:test:my-and #f #f 2 #f))
+
+(test "srfi-46 ellipsis 5"
+      40
+      (s46:test:my-and 10 20 30 40))
+
+(define-syntax s46:test:my-or
+  (syntax-rules /// ()
+    ((_) #f)
+    ((_ e) e)
+    ((_ e1 e2 /// )
+     (let ((t e1))
+       (if t t (s46:test:my-or e2 ///))))))
+
+(test "srfi-46 ellipsis 6"
+      2
+      (s46:test:my-or #f #f 2 #f))
+
+(test "srfi-46 ellipsis 7"
+      #f
+      (s46:test:my-or #f #f #f #f))
+
+;; Two unicode chars.
+(define-syntax s46:test:my-cond
+  (syntax-rules ⋱⋰ (else)
+    ((_ (else e1 ⋱⋰))
+     (begin e1 ⋱⋰))
+    ((_ (e1 e2 ⋱⋰))
+     (when e1 e2 ⋱⋰))
+    ((_ (e1 e2 ⋱⋰) c1 ⋱⋰)
+     (if e1 
+	 (begin e2 ⋱⋰)
+	 (cond c1 ⋱⋰)))))
+
+(test "srfi-46 sllipsis 8"
+      4
+      (s46:test:my-cond (#f 1) (#f 2) (#f 3) (#t 4) (#f 5)))
+
+;;; Now, testing tail patterns:
+
+
+;; From the SRFI text:
+(define-syntax s46:test:fake-begin
+  (syntax-rules ()
+    ((s46:test:fake-begin ?body ... ?tail)
+     (let* ((ignored ?body) ...) ?tail))))
+
+;; We check for this:
+;;
+;; (macro-expand '(s46:test:fake-begin (f) (g)))
+;; => (let* ((ignored138 (f))) (g))
+;;
+;; Since gensym is used, we cannot check for the exact "ignoreNNN" symbol,
+;; but we verify everything else:
+(let ((e (macro-expand
+          '(s46:test:fake-begin (f) (g)))))
+  (test "srfi-46 tail.1" 'let* (car e))
+  (test "srfi-46 tail.2" '(g) (caddr e))
+  (test "srfi-46 tail.3" '(g) (caddr e))
+  (test "srfi-46 tail.4" '((f)) (cdaadr e))
+  (test "srfi-46 tail.5" "ignored" (substring (symbol->string (caaadr e)) 0 7)))


### PR DESCRIPTION
Hi @egallesio !

I noticed this was actually easy to implement, so here it is! SRFi-46.
This one is nice because several reference implementations of later SRFIs use the configurable ellipsis, which this one brings.

The commit message:

STklos already has half of this SRFI implemented: mbe.stk
does understand the tail patterns defined in the SRFI text.
The only missing part was the configurable ellipsis symbol,
which this commit brings.

Since STklos does not recognize symbols beginning with ":",
we check for symbols or keywords in front of the SYNTAX-RULES
symbol. This seems to work, and does not break any tests.

This also includes some basic tests.