### PR TITLE
Add missing line continuation in Makefiles

### DIFF
--- a/lib/srfi-133/Makefile.am
+++ b/lib/srfi-133/Makefile.am
@@ -60,7 +60,7 @@ install-sources:
 	cp $(SRFI).stk $(DESTDIR)/$(schemedir)
 
 doc:
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img
+	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
 		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
 
 install-exec-hook:

--- a/lib/srfi-170/Makefile.am
+++ b/lib/srfi-170/Makefile.am
@@ -60,7 +60,7 @@ install-sources:
 	cp $(SRFI).stk $(DESTDIR)/$(schemedir)
 
 doc:
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img
+	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
 		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
 
 install-exec-hook:

--- a/lib/srfi-175/Makefile.am
+++ b/lib/srfi-175/Makefile.am
@@ -60,7 +60,7 @@ install-sources:
 	cp $(SRFI).stk $(DESTDIR)/$(schemedir)
 
 doc:
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img
+	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
 		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
 
 install-exec-hook:

--- a/lib/srfi-25/Makefile.am
+++ b/lib/srfi-25/Makefile.am
@@ -60,7 +60,7 @@ install-sources:
 	cp $(SRFI).stk $(DESTDIR)/$(schemedir)
 
 doc:
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img
+	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
 		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
 
 install-exec-hook:


### PR DESCRIPTION
Hi @egallesio !
I see you have split the mixed C/Scheme libs in different directories - that's nice, it will be more organized.

This PR adds some missing "\" at the end of the `Makefile.am` files in those subdirs. Without them the documentation is not generated, but the make process returns 0 anyway so it might not be obvious at first glance that it is happening:

```
make[3]: Entering directory '/home/jeronimo/pkg/scheme/STklos-github/lib/srfi-133'
../../src/stklos --no-init-file --case-sensitive -b ../../src/boot.img

f ../../doc/extract-doc srfi-133.c srfi-133.stk >> ../DOCDB
/bin/bash: line 1: f: command not found
make[3]: [Makefile:574: doc] Error 127 (ignored)
make[3]: Leaving directory '/home/jeronimo/pkg/scheme/STklos-github/lib/srfi-133'
make[3]: Entering directory '/home/jeronimo/pkg/scheme/STklos-github/lib/srfi-170'
../../src/stklos --no-init-file --case-sensitive -b ../../src/boot.img

f ../../doc/extract-doc srfi-170.c srfi-170.stk >> ../DOCDB
/bin/bash: line 1: f: command not found
```