### PR TITLE
NaN flonums are not finite [ R7RS ]

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -49,7 +49,7 @@ static int use_srfi_169 = 1; /* do we allow the use of underscores in numbers? *
 static int real_precision = REAL_FORMAT_SIZE;
 static unsigned int log10_maxint;
 
-#define FINITE_REALP(n) ((REAL_VAL(n) != minus_inf) && (REAL_VAL(n) != plus_inf))
+#define FINITE_REALP(n) isfinite(REAL_VAL(n))
 
 
 
@@ -1482,6 +1482,19 @@ static int finitep(SCM n)
   return FALSE; /* never reached */
 }
 
+static int infinitep(SCM n)
+{
+  switch (TYPEOF(n)) {
+    case tc_real:     return (isinf(REAL_VAL(n)));
+    case tc_rational:
+    case tc_bignum:
+    case tc_integer:  return FALSE;
+    case tc_complex:  return (infinitep(COMPLEX_REAL(n)) ||
+                              infinitep(COMPLEX_IMAG(n)));
+    default:          error_bad_number(n);
+  }
+  return FALSE; /* never reached */
+}
 
 DEFINE_PRIMITIVE("finite?", finitep, subr1, (SCM n))
 {
@@ -1491,7 +1504,7 @@ DEFINE_PRIMITIVE("finite?", finitep, subr1, (SCM n))
 
 DEFINE_PRIMITIVE("infinite?", infinitep, subr1, (SCM n))
 {
-  return MAKE_BOOLEAN(!finitep(n));
+  return MAKE_BOOLEAN(infinitep(n));
 }
 
 

--- a/tests/test-r7rs.stk
+++ b/tests/test-r7rs.stk
@@ -648,7 +648,8 @@
 (test "finite?.1" #t (finite? 3))
 (test "finite?.2" #f (finite? +inf.0))
 (test "finite?.3" #f (finite? -inf.0))
-(test "finite?.4" #f (finite? (make-rectangular 3.0 +inf.0)))
+(test "finite?.4" #f (finite? +nan.0))
+(test "finite?.5" #f (finite? (make-rectangular 3.0 +inf.0)))
 
 (test "infinite?.1" #f (infinite? 3))
 (test "infinite?.2" #t (infinite? +inf.0))


### PR DESCRIPTION
Hi @egallesio !
Currently STklos returns `#t` for `(finite? +nan.0)`, but R7RS says that

_"The finite? procedure returns #t on all real numbers except +inf.0, -inf.0, and +nan.0, ..."_

This PR changes `FINITE_REALP` so as to be R7RS compliant!