### PR TITLE
Be more precise when turning rationals into doubles

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -472,7 +472,15 @@ static double rational2double(SCM r)
 
   switch (convert(&num, &den)) {
     case tc_integer: return ((double) INT_VAL(num)) / ((double) INT_VAL(den));
-    case tc_bignum:  return scheme_bignum2double(num) / scheme_bignum2double(den);
+    case tc_bignum: {
+        mpq_t a, b;
+        mpq_init(a);
+        mpq_init(b);
+        mpq_set_z(a,BIGNUM_VAL(num));
+        mpq_set_z(b,BIGNUM_VAL(den));
+        mpq_div(a,a,b);
+        return mpq_get_d(a);
+    }
     default:         STk_panic("bad rational ~S", r);
   }
   return 0.0; /* never reached */


### PR DESCRIPTION
`(inexact (expt 2 -1073))` should be 4.94065645841247e-324,
but STklos returns zero. This patch makes the process of
turning rationals into doubles more precise, and STklos
will now return 4.94065645841247e-324.

This helps with the tests for SRFI-144 (PR #222 ), but I think it's an enhancement per se.
Unless we're willling to sacrifice some precision for speed (and I'd say this patch probably makes the whole process a lot slower, since we'll be using bignum division (`mpq_div`) instead of native double division).

