### PR TITLE
Do not use mpz_import when using provided bignums

### DIFF
--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -38,7 +38,7 @@
   with 32 bits (conversion to/from string). This is slow, but it works.
 
   We know that we have a 64 bits value when the value is ouside the
-  range [MIN32_SI, MAX32_SI]. In this case, we pass by the deciaml
+  range [MIN32_SI, MAX32_SI]. In this case, we pass by the decimal
   representation of the number in a string
  */
 

--- a/lib/srfi-27/srfi-27.c
+++ b/lib/srfi-27/srfi-27.c
@@ -434,8 +434,8 @@ DEFINE_PRIMITIVE("%random-integer-from-source-mt", srfi_27_rnd_int_src_mt, subr2
          */
 #ifdef HAVE_GMP
         uint64_t *buf = STk_must_malloc_atomic(size*sizeof(uint64_t));
+        mpz_init(x);
         do {
-            mpz_init(x);
             for (size_t i=0; i<size; i++)
                 buf[i] = genrand64_int64((state_mt *)state);
             mpz_import(x,size,1,8,0,0,buf);


### PR DESCRIPTION
Hi @egallesio !

It's fixed!

This patch works around that problem...

As to the mini-gmp I had told you about... Well, depending on the usage, it may be faster or slower.

* For generating random integers, mini-gmp is faster (almost as fast as system gmp)
* For usual bignum arithmetic, the STklos-included MPI-MGP is faster

I'm not sure I have a preference. mini-gmp would free us from maintaining a wrapper, but may be generally slow.

Anyway, there are two alternatives:

* This PR has a patch to SRFI-27 *only* (does not change STklos' lib for bignums)
* My "mini-gmp" branch does *not* touch SRFI-27, but replaces the bignum-lib with mini-gmp. If you want I may make a PR for that one too, then you pick one.

