### PR TITLE
Don't exit with nonzero status for "-h" option

### DIFF
--- a/utils/stklos-compile.stk
+++ b/utils/stklos-compile.stk
@@ -163,7 +163,7 @@
      (("no-time" :help "Don't display compilation time")
         (compiler:time-display #f))
      (("help" :alternate "h" :help "This help")
-        (arg-usage (current-error-port))
+        (arg-usage (current-output-port))
         (exit 0))
 
      (else

--- a/utils/stklos-compile.stk
+++ b/utils/stklos-compile.stk
@@ -164,7 +164,7 @@
         (compiler:time-display #f))
      (("help" :alternate "h" :help "This help")
         (arg-usage (current-error-port))
-        (exit 1))
+        (exit 0))
 
      (else
       (cond


### PR DESCRIPTION
If the user asked for help, we don't need to exit with -1 status. The intended action (help) was performed successfully.