### PR TITLE
Add SRFI-221: Generator/accumulator sub-library

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -110,4 +110,5 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-216: SICP Prerequisites (Portable)
     - SRFI-217: Integer Sets
     - SRFI-219: Define higher-order lambda
+    - SRFI-221: Generator/accumulator sub-library
     - SRFI-223: Generalized binary search procedures

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -138,6 +138,7 @@ SRC_STK = bigloo-support.stk  \
           srfi-207.stk        \
           srfi-216.stk        \
           srfi-217.stk        \
+          srfi-221.stk        \
           srfi-223.stk        \
           trie.stk            \
           tar.stk             \
@@ -216,6 +217,7 @@ scheme_OBJS = compfile.ostk     \
           srfi-207.ostk         \
           srfi-216.ostk         \
           srfi-217.ostk         \
+          srfi-221.ostk         \
           srfi-223.ostk         \
           trie.ostk             \
           tar.ostk              \

--- a/lib/srfi-221.stk
+++ b/lib/srfi-221.stk
@@ -1,0 +1,178 @@
+;;;;
+;;;; srfi-221.stk	        -- Implementation of SRFI-221
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Arvydas Silanskas, it is copyrighted as:
+;;;;
+;;;;;; © 2020 Arvydas Silanskas (implementation).
+;;;;;;
+;;;;;; Permission is hereby granted, free of charge, to any person obtaining
+;;;;;; a copy of this software and associated documentation
+;;;;;; files (the "Software"), to deal in the Software without restriction,
+;;;;;; including without limitation the rights to use, copy, modify, merge,
+;;;;;; publish, distribute, sublicense, and/or sell copies of the Software,
+;;;;;; and to permit persons to whom the Software is furnished to do so,
+;;;;;; subject to the following conditions:
+;;;;;;
+;;;;;; The above copyright notice and this permission notice (including the
+;;;;;; next paragraph) shall be included in all copies or substantial
+;;;;;; portions of the Software.
+;;;;;;
+;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;;;;;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;;;;;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;;;;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 29-May-2021 09:49 (jpellegrini)
+;;;; Last file update: 29-May-2021 11:12 (jpellegrini)
+
+(require "srfi-41")
+(require "srfi-158")
+
+
+(define-module SRFI-221
+  (import SRFI-41)
+  (import SRFI-158)
+  
+  (export
+    accumulate-generated-values
+    genumerate
+    gcompose-right
+    gcompose-left
+    gchoice
+    generator->stream
+    stream->generator)
+
+  (define (accumulate-generated-values acc gen)
+  (let ((value (gen)))
+   (if (eof-object? value)
+       (acc value)
+       (begin
+         (acc value)
+         (accumulate-generated-values acc gen)))))
+
+(define gdelete-duplicates
+  (case-lambda
+    ((gen) (gdelete-duplicates* gen equal?))
+    ((gen =) (gdelete-duplicates* gen =))))
+
+(define (gdelete-duplicates* gen =)
+  (define seen '())
+  ;; first parameter should be older value than second. However in `member` it's other way around.
+  ;; as such function is changed to switch parameters in places
+  (define (=* a b) (= b a))
+  (define (seen? value)
+    (member value seen =*))
+  (lambda ()
+    (let loop ((value (gen)))
+     (cond
+       ((eof-object? value)
+        value)
+       ((seen? value)
+        (loop (gen)))
+       (else
+         (begin
+           (set! seen (cons value seen))
+           value))))))
+
+(define (genumerate gen)
+  (gmap
+    cons
+    (make-range-generator 0)
+    gen))
+
+(define (gcompose-left constr . ops)
+  (let loop ((gen (constr))
+             (ops ops))
+   (if (null? ops)
+       gen
+       (let* ((op (car ops))
+              (new-gen (op gen)))
+         (loop new-gen (cdr ops))))))
+
+(define (gcompose-right . args)
+  (apply gcompose-left (reverse args)))
+
+(define (gchoice choice-gen . source-gens)
+  (define source-gens-v (list->vector source-gens))
+  (define l (vector-length source-gens-v))
+  (define exhausted-count 0)
+  (unless (procedure? choice-gen)
+    (error "choice-gen must be a generator"))
+  (for-each
+    (lambda (g)
+      (unless (procedure? g)
+        (error "source-gens must be generators")))
+    source-gens)
+  (lambda ()
+    (let loop ((i (choice-gen)))
+     (cond
+      ;; all source-gens have been exhausted
+      ((= exhausted-count l) (eof-object))
+      ;; choice-gen have been exhausted
+      ((eof-object? i) (eof-object))
+      ;; source-gen returned bad value
+      ((or (not (integer? i))
+           (< i 0)
+           (>= i l))
+       (error (string-append "choice-gen didn't return an integer in range 0 to "
+                             (number->string (- l 1)))))
+      (else
+        (let ((gen (vector-ref source-gens-v i)))
+         (if (not gen)
+             ;; we picked exhausted generator -- pick again
+             (loop (choice-gen))
+             (let ((value (gen)))
+              (if (eof-object? value)
+                  ;; picked generator was exhausted on this iteration -- mark it and pick again
+                  (begin
+                    (vector-set! source-gens-v i #f)
+                    (set! exhausted-count (+ 1 exhausted-count))
+                    (loop (choice-gen)))
+                  value)))))))))
+
+(define (generator->stream gen)
+  (define gen-stream
+    (stream-lambda ()
+      (stream-cons (gen) (gen-stream))))
+  (stream-take-while
+    (lambda (value) (not (eof-object? value)))
+    (gen-stream)))
+
+(define (stream->generator stream)
+  (lambda ()
+    (if (stream-null? stream)
+        (eof-object)
+        (let ((value (stream-car stream)))
+         (set! stream (stream-cdr stream))
+         value))))
+
+)
+
+(select-module STklos)
+(import SRFI-221)
+
+(provide "srfi-221")
+

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -260,8 +260,8 @@
     ;; 218 ...... withdrawn
     (219 "Define higher-order lambda")
     ;; 220 ...... withdrawn
-    ;; 221 Generator/accumulator sub-library
-    ;; 222 Compound objexts
+    (221 "Generator/accumulator sub-library" () "srfi-221")
+    ;; 222 Compound objects
     (223 "Generalized binary search procedures" () "srfi-223")
     ;; 224 Integer Mappings
     ;; 225 Dictionaries (draft)

--- a/tests/srfis/221.stk
+++ b/tests/srfis/221.stk
@@ -1,0 +1,133 @@
+(require "srfi-41")
+
+(define srfi-221-test-name "")
+
+(define test-g-equal
+  (case-lambda
+    ((g-expect g-actual)
+     (test (format #f "srfi-221 ~a" srfi-221-test-name)
+       (generator->list g-expect)
+       (generator->list g-actual)))
+    ((g-expect g-actual take-count)
+     (test-g-equal
+       (gtake g-expect take-count)
+       (gtake g-actual take-count)))))
+
+;; "accumulate-generated-values"
+
+(define expect '(1 2 3 4))
+
+(define actual
+  (accumulate-generated-values
+   (list-accumulator)
+   (generator 1 2 3 4)))
+
+(test "srfi-221 accumulate-generated-values 1" expect actual)
+
+;; "genumerate"
+
+(set! srfi-221-test-name "genumerate 1")
+      
+  (test-g-equal (generator '(0 . a) '(1 . b) '(2 . c))
+                (genumerate (generator 'a 'b 'c)))
+
+(set! srfi-221-test-name "genumerate 2")
+
+  ;; test empty
+  (test-g-equal (generator)
+                (genumerate (generator)))
+
+(set! srfi-221-test-name "genumerate 3")
+  ;; infinite case with take
+  (test-g-equal (generator '(0 . a) '(1 . b) '(2 . c))
+                (genumerate (circular-generator 'a 'b 'c))
+                3)
+
+;;  "gcompose-left"
+
+(set! srfi-221-test-name "gcompose-left 1")
+  (test-g-equal
+    (generator 1 2 3 4)
+    (gcompose-left
+      (lambda () (make-range-generator 1))
+      (lambda (g) (gtake g 4))))
+
+(set! srfi-221-test-name "gcompose-left 2")
+  (test-g-equal
+    (generator 1 2 3 4)
+    (gcompose-left
+      (lambda () (generator 1 2 3 4))))
+
+;;  "gcompose-right"
+
+(set! srfi-221-test-name "gcompose-right 1")
+  (test-g-equal
+    (generator 1 2 3 4)
+    (gcompose-right
+      (lambda (g) (gtake g 4))
+      (lambda () (make-range-generator 1))))
+
+(set! srfi-221-test-name "gcompose-right 2")
+  (test-g-equal
+    (generator 1 2 3 4)
+    (gcompose-right
+      (lambda () (generator 1 2 3 4))))
+
+;;  "gchoice"
+
+(set! srfi-221-test-name "gchoice 1")
+  ;; test normal
+  (test-g-equal
+    (generator 1 2 1 3)
+    (gchoice
+      (generator 0 1 0 2)
+      (circular-generator 1)
+      (circular-generator 2)
+      (circular-generator 3)))
+
+(set! srfi-221-test-name "gchoice 2")
+  ;; test exhausted source
+  (test-g-equal
+    (generator 1 2 3)
+    (gchoice
+      (generator 0 0 0 0 0 1 1 2)
+      (generator 1)
+      (generator 2)
+      (generator 3)))
+
+;;  "generator->stream"
+
+(define (test-stream-equal str1 str2)
+  (if (stream-null? str1)
+      (test "srfi-221 assert stream null" #t (stream-null? str2))
+      (begin
+        (test (format #f "srfi-221 ~a" test-name)
+              (stream-car str1) (stream-car str2))
+        (test-stream-equal (stream-cdr str1) (stream-cdr str2)))))
+
+(set! srfi-221-test-name "gstream 1")
+  ;; test normal
+  (test-stream-equal
+    (stream 1 2 3)
+    (generator->stream (generator 1 2 3)))
+
+(set! srfi-221-test-name "gstream 2")
+  ;; test infinite with take
+  (test-stream-equal
+    (stream 1 2 3)
+    (stream-take 3 (generator->stream (circular-generator 1 2 3))))
+
+;;  "stream->generator"
+
+(set! srfi-221-test-name "stream->generator 1")
+  ;; test normal
+  (test-g-equal
+    (generator 1 2 3)
+    (stream->generator (stream 1 2 3)))
+
+(set! srfi-221-test-name "stream->generator 2")
+  ;; test infinite with take
+  (test-g-equal
+    (circular-generator 1 2 3)
+    (stream->generator (stream-constant 1 2 3))
+    20)


### PR DESCRIPTION
Hello @egallesio !
SRFI-221 was finalized today, so I ported it.

However, something isn't working, I can't tell why:

SRFi-221 uses SRFI-41. So this is in thebeginning of srfi-221.stk:

```
(require "srfi-41")
(require "srfi-158")

(define-module SRFI-221
  (import SRFI-41)
  (import SRFI-158)
  
  (export
    accumulate-generated-values
    genumerate
    gcompose-right
    gcompose-left
    gchoice
    generator->stream
    stream->generator)

```

But then,

```
stklos> (require "srfi-221")
"srfi-221"
stklos> (define g-expect (circular-generator 1 2 3))
;; g-expect
stklos> (define g-actual (stream->generator (stream-constant 1 2 3)))
;; g-actual
stklos> (generator->list (gtake g-expect 20))
(1 2 3 1 2 3 1 2 3 1 2 3 1 2 3 1 2 3 1 2)
stklos> (generator->list (gtake g-actual 20))
**** Error:
g-actual: variable `stream-null?' unbound
	(type ",help" for more information)
stklos> stream-null?
#[closure stream-null?]            ;; see, srfi-41 does export that! but srfi-221 procedures can't see it, why?
stklos> (stream-null? 1)
#f
```

What could be happening?
