### PR TITLE
Optimize do loops

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1437,9 +1437,9 @@ doc>
 
   ;; rewrite the body
   (let ((loop-name (new-label)))
-    `(let ,(map (lambda (init) (if (= (length init) 2)
-                              init
-                              (reverse (cdr (reverse init))))) inits)
+    `(letrec* ,(map (lambda (init) (if (= (length init) 2)
+                               init
+                               (reverse (cdr (reverse init))))) inits)
        (%%label ,loop-name)
        (if ,(car test)
            (begin ,@(if (null? (cdr test))

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1395,27 +1395,64 @@ doc>
 ;;
 ;; DO
 ;;
-(define (rewrite-do inits test body)
-  (let ((loop-name (gensym)))
-    `(letrec ((,loop-name
-       (lambda ,(map car inits)
-         (if ,(car test)
-             (begin ,@(if (null? (cdr test))
-                          (list (void))
-                          (cdr test)))
-             (begin ,@body
-                    (,loop-name ,@(map (lambda (init)
-                                         (if (< (length init) 2)
-                                             (compiler-error 'do
-                                                              init
-                                                              "bad binding ~S"
-                                                              init)
-                                             (if (null? (cddr init))
-                                                 (car init)
-                                                 (caddr init))))
-                                       inits)))))))
-       (,loop-name ,@(map cadr inits)))))
 
+;; Rewrite do loops
+;;
+;; (do inits test body)
+;; ->
+;; (let inits
+;;   (%%label L)
+;;   (if test
+;;       result
+;;       (begin body
+;;              (set! var-1 update-1)
+;;              ...
+;;              (%%goto L))))
+;;
+;; * 
+;; Vars with no update form are not updated.
+;;
+(define (rewrite-do inits test body)
+  ;; check inits
+  (for-each (lambda (init)
+              (when (< (length init) 2)
+                (compiler-error 'do
+                                init
+                                "not enough forms in binding ~S"
+                                init))
+              (when (> (length init) 3)
+                (compiler-error 'do
+                                init
+                                "too many forms in binding ~S"
+                                init)))
+            inits)
+
+  ;; check test-and-result form
+  (when (or (null? test)
+            (> (length test) 2))
+    (compiler-error 'do
+                    test
+                    "bad test-and-result form"
+                    test))
+
+  ;; rewrite the body
+  (let ((loop-name (new-label)))
+    `(let ,(map (lambda (init) (if (= (length init) 2)
+                              init
+                              (reverse (cdr (reverse init))))) inits)
+       (%%label ,loop-name)
+       (if ,(car test)
+           (begin ,@(if (null? (cdr test))
+                        (list (void))
+                        (cdr test)))
+           (begin ,@body
+                  ,@(filter (lambda (x) x) ; remove the useless '#f's
+                            (map (lambda (init)
+                                   (if (= (length init) 3)
+                                       (list 'set! (car init) (caddr init))
+                                       #f)) ;; will be removed
+                                 inits))
+                  (%%goto ,loop-name))))))
 
 (define (compile-do e env tail?)
   (if (>= (length e) 3)


### PR DESCRIPTION
# Description and remaining issue

Hi @egallesio --
I thought I'd try to optimize the translation of `do` forms, so they would not include a procedure call (and use goto instead).
So... It seems to work, it generates much shorter and faster code, but... It seems to have some issues that I don't understand -- it doesn't pass the tests, there seems to be some interaction with threads:

```
==== Testing Threads  ...                                        failed
Errors found in this section:
test thread-join! on (mt-fib 35) expected 14930352 but got #(fail)
==== Testing SRFIs  ...                                          
      1    2    4    5   13   25**** Error while executing file "do-test.stk"
```

If I enter the `mt-fib` procedure from `tests/test-threads.stk` and then call `(mt-fib 35)`, I get this:

```
stklos>  (mt-fib 35)
**** Error (in thread "thread189"):
thread-join!: cannot join on myself (deadlock will occur)
    (this error may be signaled again later)
**** Error:
thread-join!: cannot join on myself (deadlock will occur)
	(type ",help" for more information)
```

What did I miss?

Below is the explanation of what I've done.


# Optimize 'do' loops

Do not translate do into letrec, use goto instead

```
 (do inits test body)

 --- is rewritten to --->

 (let inits
   (%%label L)
   (if test
       result
       (begin body
              (set! var-1 update-1)
              (set! var-2 update-2)
              ...
              (%%goto L))))
```

This saves a procedure call in each iteration, and generates less
opcodes. The speedup is considerable:

```
(time
 (let ((sum 0))
   (do ((i 0 (+ i 1)))
       ((= i 100_000_000) sum)
     (set! sum (+ sum 1)))))
```

From 7221 with `LETREC` to 5614 with `GOTO`.
(NOT a real benchmark; just a quick test -- I've ran 10 times that
code with each do-translator, and those numbers are the average.

The number of opcodes also went from 32 to 20.

This commit also adds sanity checks to the do form:

* too many arguments in each binding (only <2 was checked before)

* number of elements in the test-and-result form
