### PR TITLE
Use + insted of fx+ in dotimes

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -871,7 +871,7 @@ doc>
            (let ((limit  (gensym))
                  (result (if (null? result) (list '(void)) result)))
              `(let ((,limit ,count))
-                (do ((,var 0 (fx+ ,var 1)))
+                (do ((,var 0 (+ ,var 1)))
                     ((>= ,var ,limit) ,@result)
                   ,@body))))
          bindings))


### PR DESCRIPTION
Hi @egallesio !

`dotimes` uses `fx+`, but the documentation says the index is "an integer", and `dotimes` also uses `>=` later to check the exit condition, so I suppose it should be `+` instead of `fx+`.
If not, then I can make another PR changing `>=` to `fx>=?`, and changing the documentation.
