### PR TITLE
Advertise SRFI-15 (fluid-let)

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -29,6 +29,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-11: Syntax for receiving multiple values
     - SRFI-13: String Library
     - SRFI-14: Character-Set Library
+    - SRFI-15: Syntax for dynamic scoping
     - SRFI-16: Syntax for procedures of variable arity
     - SRFI-17: Generalized set!
     - SRFI-18: Multithreading support

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -53,7 +53,7 @@
     ;    12 ........ Withdrawn
     (13 "String Library" () "srfi-13")
     (14 "Character-Set Library" () "srfi-14")
-    ;;  15 ........ Withdrawn
+    (15 "Syntax for dynamic scoping") ;; ........ Withdrawn, but supported nevertheless
     (16 "Syntax for procedures of variable arity" (case-lambda))
     (17 "Generalized set!")
     (18 "Multithreading support")

--- a/tests/srfis/15.stk
+++ b/tests/srfis/15.stk
@@ -1,0 +1,61 @@
+
+;;; The example from the SRFI text:
+;;;
+(define v 1)
+(define again #f)
+
+(define (test1)
+  (display v)
+  (fluid-let ((v 2))
+    (call-with-current-continuation
+     (lambda (k)
+       (set! again (lambda () 
+                     (set! again #f)
+                     (k #t)))))
+    (test2)
+    (set! v 3))
+  (display v)
+  (set! v 4)
+  (if again (again)))
+
+(define (test2) (display v))       
+
+(test "fluid-let 1"
+      "12121"
+      (with-output-to-string
+        (lambda ()
+          (test1))))    
+
+
+;;; From Chez users' guide
+;;;
+(test "fluid-let 2"
+      8
+      (let ((x 3))
+        (+ (fluid-let ((x 5))
+             x)
+           x)))
+
+(test "fluid-let 3"
+      'a
+      (let ((x 'a))
+        (call/cc
+         (lambda (k)
+           (fluid-let ((x 'b))
+             (letrec ((f (lambda (y) (k '*))))
+               (f '*)))))
+        x))
+
+;;; Another test
+;;;
+
+(test "fluid-let 4"
+      -6
+      (let ((a 2)
+            (b 3)
+            (c 5))
+        (let ((sum (lambda () (+ a b c))))
+          (fluid-let ((a -1))
+            (fluid-let ((b (* a 2)))
+              (fluid-let ((c (+ a b)))
+                (sum)))))))


### PR DESCRIPTION
Although withdrawn, it is supported and even used by the STklos compiler!
Some other implementations do support it also (Chez, Loko, Chicken, Iron)...

But I see you may not want to advertise it since it's been withdrawn.