### PR TITLE
Add SRFI-132: Sort Libraries

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -78,6 +78,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-128: Comparators (reduced)
     - SRFI-129: Titlecase procedures
     - SRFI-130: Cursor-based string library
+    - SRFI-132: Sort Libraries
     - SRFI-133: Vector Library (R7RS-compatible)
     - SRFI-134: Immutable Deques
     - SRFI-135: Immutable Texts

--- a/configure.ac
+++ b/configure.ac
@@ -596,6 +596,7 @@ AC_CONFIG_FILES([Makefile src/Makefile src/extraconf.h doc/Makefile
 
           lib/srfi-25/Makefile
           lib/srfi-27/Makefile
+          lib/srfi-132/Makefile
           lib/srfi-133/Makefile
           lib/srfi-144/Makefile
           lib/srfi-170/Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -23,7 +23,8 @@
 # Last file update:  8-Jun-2021 09:02 (eg)
 
 SUBDIRS = Match.d SILex.d Lalr.d ScmPkg.d \
-		  srfi-25 srfi-27 srfi-133 srfi-144 srfi-170 srfi-175
+		  srfi-25 srfi-27 srfi-132 srfi-133 \
+		  srfi-144 srfi-170 srfi-175
 
 COMP ?= ../utils/tmpcomp
 STKLOS_BINARY ?= ../src/stklos

--- a/lib/srfi-132/Makefile.am
+++ b/lib/srfi-132/Makefile.am
@@ -1,0 +1,73 @@
+# Makefile for STklos srfi-132 library
+#
+# Copyright © 2021 Jeronimo Pellegrini - j_p@aleph0.info
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
+#
+#           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+#    Creation date: 18-Aug-2021 17:24 (jpellegrini)
+# Last file update: 23-Aug-2021 16:15 (jpellegrini)
+
+SRFI=srfi-132
+
+#======================================================================
+OUT            = $(SRFI).@SH_SUFFIX@
+schemedir      = $(prefix)/share/@PACKAGE@/@VERSION@
+schemelibdir   = $(prefix)/lib/@PACKAGE@/@VERSION@
+schemelib_DATA = $(OUT)
+
+#======================================================================
+COMP ?= ../../utils/tmpcomp
+STKLOS_BINARY ?= ../../src/stklos
+STKLOS_FLAGS   = --no-init-file --case-sensitive
+# ======================================================================
+SOURCES=$(SRFI).c $(SRFI).stk
+DOCDB  = ../DOCDB
+BASEDIR= ../..
+
+SUFFIXES = .stk -incl.c .@SH_SUFFIX@ .c
+
+.stk-incl.c:
+	$(COMP) -C -o $*-incl.c $*.stk
+
+.c.@SH_SUFFIX@ :
+	@CC@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../../src @GCINC@ @GMPINC@ \
+	-c -o $*.o $*.c
+	@SH_LOADER@ @SH_LOAD_FLAGS@  $*.@SH_SUFFIX@ $*.o @DLLIBS@
+	/bin/rm -f $*.o
+
+
+all: $(OUT)
+
+$(OUT): $(SRFI)-incl.c $(SRFI).c
+
+
+$(SRFI)-incl.c: $(SRFI).stk
+
+# Scheme source is not complete => do not install
+install-sources:
+	@echo "No source file to install for $(SRFI)"
+
+doc:
+	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
+		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
+
+#install-exec-hook:
+#	install -d $(DESTDIR)$(schemelibdir)
+#	install $(OUT) $(DESTDIR)$(schemelibdir)
+
+clean:
+	rm -f $(OUT) $(SRFI)-incl.c *~

--- a/lib/srfi-132/srfi-132.c
+++ b/lib/srfi-132/srfi-132.c
@@ -1,0 +1,1147 @@
+/*
+ * srfi-25.c   -- Implementation of SRFI-132: Sort Libraries
+ *
+ * Copyright © 2021 Jerônimo Pellegrini <j_p@aleph0.info>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ *
+ *           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+ *    Creation date: 08-Aug-2021 13:40
+ * Last file update: 31-Aug-2021 21:41
+ */
+
+#include <stklos.h>
+#include "srfi-132-incl.c"
+
+static void error_bad_list(SCM x)
+{
+  STk_error("bad list ~W", x);
+}
+
+static void error_bad_proc(SCM x)
+{
+  STk_error("bad procedure ~S", x);
+}
+
+static void error_bad_vector(SCM v)
+{
+  STk_error("bad vector ~s", v);
+}
+
+
+/*************************************
+ *
+ * Predicates
+ *
+ *************************************/
+
+
+DEFINE_PRIMITIVE("list-sorted?", list_sorted, subr2, (SCM pred, SCM l))
+{
+    if (!(CONSP(l) || NULLP(l))) error_bad_list(l);
+    if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
+    if (NULLP(l)) return STk_true;
+
+    SCM original_car; /* for checking circular lists */
+    SCM car;
+    SCM cdr;
+    SCM cadr;
+
+    car = CAR(l);
+    original_car = car;
+    if (NULLP(CDR(l))) return STk_true;
+    if (!CONSP(CDR(l))) error_bad_list(l);
+    cdr = CDR(l);
+    cadr = CAR(cdr);
+
+    while(1) {
+        /* If cadr = original car, then (1) it's a circular list; and
+           (2) we checked the whole list already, and got back to the original car.
+           We should NOT compare these, as it would be comparing last to first;
+           just retrun true! */
+        if (cadr == original_car) return STk_true;
+
+        if (STk_C_apply(pred, 2,car, cadr) == STk_false) return STk_false;
+        
+        if (NULLP(CDR(cdr))) return STk_true; /* end of list */
+
+        /* move to next: */
+        car = cadr;
+        cdr = CDR(cdr);
+        if (!CONSP(cdr)) error_bad_list(l);
+        cadr = CAR(cdr);
+    }
+    return STk_void; /* never reached */
+}
+
+DEFINE_PRIMITIVE("vector-sorted?", vector_sorted, vsubr, (int argc, SCM *argv))
+{
+    if (argc < 2) STk_error ("requires at least 2 arguments");
+    if (argc > 4) STk_error ("requires at most 4 arguments");
+    SCM pred = *argv--;
+    SCM v = *argv--;
+    
+    if (!(VECTORP(v))) error_bad_vector(v);
+    if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
+
+    SCM start;
+    SCM end;
+    long cstart, cend;
+
+    if (argc>2) {
+        start = *argv--;
+        if (!INTP(start)) STk_error("bad integer");
+        cstart = INT_VAL(start);
+    } else cstart = 0;
+    
+    if (argc>3) {
+        end = *argv--;
+        if (!INTP(end)) STk_error("bad integer");
+        cend = INT_VAL(end);
+    } else cend = VECTOR_SIZE(v);
+
+    for (long i = cstart; i < (cend - 1); i++)
+        if (STk_C_apply(pred, 2, VECTOR_DATA(v)[i+1] , VECTOR_DATA(v)[i]) == STk_true)
+            return STk_false;
+
+    return STk_true;
+}
+
+
+/*************************************
+ *
+ * Merge procedures
+ *
+ *************************************/
+
+DEFINE_PRIMITIVE("list-merge", srfi_132_list_merge, subr3, (SCM less, SCM A, SCM B))
+{
+    if (STk_procedurep(less) != STk_true) error_bad_proc(less);
+
+    /* need to copy, cannot share storage with input:*/
+    if (NULLP(A)) return STk_list_copy(B);
+    if (NULLP(B)) return STk_list_copy(A);
+
+    if (!(CONSP(A))) error_bad_list(A);
+    if (!(CONSP(B))) error_bad_list(B);
+
+
+    SCM res, one, two;
+    if (STk_C_apply(less, 2, CAR(B), CAR(A)) == STk_true) {
+        res = LIST1(CAR(B));
+        one = CDR(B);
+        two = A;
+    } else {
+        res = LIST1(CAR(A));
+        one = CDR(A);
+        two = B;
+    }
+    SCM cur = res;
+
+    while (CONSP(one) && CONSP(two) ) {
+        if ( STk_C_apply(less, 2, CAR(two), CAR(one)) == STk_true ) {
+            CDR(cur) = LIST1(CAR(two));
+            two = CDR(two);
+        } else {
+            CDR(cur) = LIST1(CAR(one));
+            one = CDR(one);
+        }
+        cur = CDR(cur);
+    }
+
+    if (CONSP(two))
+        CDR(cur) = STk_list_copy(two);
+    if (CONSP(one))
+        CDR(cur) = STk_list_copy(one);
+
+    return res;
+}
+
+SCM
+list_merge_aux(SCM less, SCM A, SCM B)
+{
+    if (NULLP(A)) return B;
+    if (NULLP(B)) return A;
+
+    if (!(CONSP(A))) error_bad_list(A);
+    if (!(CONSP(B))) error_bad_list(B);
+
+    /*
+      cur   one
+      |     |
+      v     v      
+      a1 -> a2 -> a3 -> ...
+
+      b1 -> b2 -> b3 -> ...
+      ^
+      |
+      two
+
+      cur points to the last element separated into the resulting list.
+      one and two are the next two candidates.
+
+      Works in linear time.
+     */
+
+    /* res points to the one with the smallest head (will be returned
+       as result) */
+    SCM res = (STk_C_apply(less, 2, CAR(B), CAR(A)) == STk_true) ? B : A;
+
+    SCM cur = res;
+    SCM one;
+    SCM two;
+    if (cur == A) {
+        one = CDR(A);
+        two = B;
+    } else {
+        one = A;
+        two = CDR(B);
+    }
+
+    while (CONSP(one) && CONSP(two)) {
+
+        if ( STk_C_apply(less, 2, CAR(two), CAR(one)) == STk_true ) {
+            CDR(cur) = two;
+            cur = two;
+            two = CDR(two);
+        } else {
+            CDR(cur) = one;
+            cur = one;
+            one = CDR(one);
+        }
+    }
+
+    if (CONSP(two)) 
+        CDR(cur) = two;
+    
+    if (CONSP(one)) 
+        CDR(cur) = one;
+    
+    return res;
+}
+
+DEFINE_PRIMITIVE("list-merge!", srfi_132_nlist_merge, subr3, (SCM less, SCM A, SCM B))
+{
+    if (STk_procedurep(less) != STk_true) error_bad_proc(less);
+    return list_merge_aux(less, A, B);
+}
+
+
+/*
+  returns the NUMBER of skipped items
+  also copies that number from A to TO.
+*/
+long gallop(SCM pred, SCM to,
+            SCM a, SCM b,
+            long start,
+            long starta, long enda,
+            long startb, long endb)
+{
+     /*
+      a[starta] <= b[cstartb] so now instead of proceeding linearly,
+      use "galloping": search for the position where b[startb] would fit
+      but proceed exponentially:
+      
+      a[starta]      <= b[startb]
+      a[starta + 1]  <= b[startb]
+      a[starta + 3]  <= b[startb]
+      a[starta + 5]  <= b[startb]
+      a[starta + 7]  <= b[startb]
+      a[starta + 15] <= b[startb]
+                       .
+                       .
+                       .
+      The index growing is starta + (2^k)-1.
+      
+      As per the remarks on "galloping" in the CPython implementation of Timsort,
+      https://github.com/python/cpython/blob/main/Objects/listsort.txt
+
+      We use galloping for runs with more than 20 elements.
+     */
+     if ( (enda - starta) > 20) {
+         long saved_starta = starta;
+         long tmp = starta;
+         long i = 2;
+         while (starta == tmp && starta < enda) {
+             tmp = starta + i - 1;
+             if (tmp < enda &&
+                 STk_C_apply(pred,2,
+                             VECTOR_DATA(a)[tmp],
+                             VECTOR_DATA(b)[startb]) == STk_true) {
+                 starta = tmp;
+                 i = i*2;
+             }
+         }
+
+         long skipped = starta - saved_starta;
+         
+         /* TODO: binary search to find the EXACT place */
+         
+
+         /* copy the beginning of A, which only has elements lesser than
+            all elements in B. */
+         memcpy( &VECTOR_DATA(to)[start],
+                 &VECTOR_DATA(a)[saved_starta],
+                 skipped * sizeof(SCM));
+         return skipped;
+     }
+     return 0;
+}
+
+
+void vector_merge_aux(SCM pred, SCM to, SCM v1, SCM v2,
+                      long start,
+                      long cstart1, long cend1,
+                      long cstart2, long cend2)
+{
+
+    long skipped;
+    if (cstart1 < cend1 &&
+        cstart2 < cend2 &&
+        STk_C_apply(pred,2,
+                    VECTOR_DATA(v1)[cstart1],
+                    VECTOR_DATA(v2)[cstart2]) == STk_true) {
+        skipped = gallop(pred, to, v1, v2, start, cstart1, cend1, cstart2, cend2);
+        cstart1 += skipped;
+    } else {
+        skipped = gallop(pred, to, v2, v1, start, cstart2, cend2, cstart1, cend1);
+        cstart2 += skipped;
+    }
+    start += skipped;
+    
+     /* do the proper merge: */
+     int i = start;
+     while ((cstart1 < cend1) || (cstart2 < cend2)) {
+         if ((cstart1 < cend1) && (cstart2 < cend2)) {
+             
+             if (STk_C_apply(pred,2,
+                             VECTOR_DATA(v2)[cstart2],
+                             VECTOR_DATA(v1)[cstart1]) == STk_true) {
+                 VECTOR_DATA(to)[i] = VECTOR_DATA(v2)[cstart2];
+                 cstart2++;
+             } else {
+                 VECTOR_DATA(to)[i] = VECTOR_DATA(v1)[cstart1];
+                 cstart1++;
+             }
+             i++;
+         } else break;
+    }
+
+    /* when there are elements left in one of the chunks, copy them */
+     if (cstart1 < cend1) {
+        memcpy(&VECTOR_DATA(to)[i],
+               &VECTOR_DATA(v1)[cstart1],
+               (cend1-cstart1) * sizeof(SCM));
+     }
+     if (cstart2 < cend2) {
+         memcpy(&VECTOR_DATA(to)[i],
+                &VECTOR_DATA(v2)[cstart2],
+                (cend2-cstart2) * sizeof(SCM));
+     }
+}
+
+void check_index(long size, long start, long end)
+{
+    if (start < 0) STk_error("negative index %d", start);
+    if (end > size) STk_error("index too high: %d > %d", end, size);
+}
+
+
+int
+vec_init_args(long *cstart1, long *cend1,
+                   int argc, SCM *argv,
+                   long size1) {
+    SCM start1;
+    SCM end1;
+    int res = 0;
+
+    if (argc>0) {
+        start1 = *argv--;
+        res++;
+        if (!INTP(start1)) STk_error("bad integer for start index");
+        *cstart1 = INT_VAL(start1);
+    } else *cstart1 = 0;
+    
+    if (argc>1) {
+        end1 = *argv--;
+        res++;
+        if (!INTP(end1)) STk_error("bad integer  for end index");
+        *cend1 = INT_VAL(end1);
+    } else *cend1 = size1;
+
+    check_index(size1,*cstart1,*cend1);
+    
+    return res;
+}
+
+DEFINE_PRIMITIVE("vector-merge",vector_merge,vsubr, (int argc, SCM *argv))
+{
+    if (argc < 3) STk_error ("requires at least 3 arguments");
+    if (argc > 7) STk_error ("requires at most 7 arguments");
+    SCM pred = *argv--;
+    SCM v1 = *argv--;
+    SCM v2 = *argv--;
+    
+    if (!(VECTORP(v1))) error_bad_vector(v1);
+    if (!(VECTORP(v2))) error_bad_vector(v2);
+    if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
+
+    long cstart1, cend1, cstart2, cend2;
+
+    argc -= 3;
+    int a;
+    
+    a = vec_init_args(&cstart1, &cend1,
+                      argc, argv,
+                      VECTOR_SIZE(v1));
+    argc -= a;
+    argv -= a;
+    
+    vec_init_args(&cstart2, &cend2,
+                  argc, argv,
+                  VECTOR_SIZE(v2));
+
+    SCM v3 = STk_makevect ( (cend1 - cstart1) + (cend2 - cstart2), MAKE_INT(-1));
+                            //(SCM) NULL );
+
+    vector_merge_aux(pred,v3,v1,v2,0,cstart1,cend1,cstart2,cend2);
+    
+    return v3;
+}
+
+void check_overlap(SCM to,int start,int max, SCM v,int start1,int end1)
+{
+    if ( ((&VECTOR_DATA(v)[end1] >   &VECTOR_DATA(to)[start]) &&
+          (&VECTOR_DATA(v)[start1] < &VECTOR_DATA(to)[max]))
+         ||
+         ((&VECTOR_DATA(to)[max] >   &VECTOR_DATA(v)[start1]) &&
+          (&VECTOR_DATA(to)[start] < &VECTOR_DATA(v)[end1])) )
+        STk_error("slices overlap with destination vector");
+}
+
+
+DEFINE_PRIMITIVE("vector-merge!",nvector_merge,vsubr, (int argc, SCM *argv))
+{
+    if (argc < 4) STk_error ("requires at least 4 arguments");
+    if (argc > 9) STk_error ("requires at most 8 arguments");
+    SCM pred = *argv--;
+    SCM to = *argv--;
+    SCM v1 = *argv--;
+    SCM v2 = *argv--;
+    argc -= 4;
+    
+    if (!(VECTORP(to))) error_bad_vector(to);
+    if (!(VECTORP(v1))) error_bad_vector(v1);
+    if (!(VECTORP(v2))) error_bad_vector(v2);
+    if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
+
+    SCM start;
+    long cstart, cstart1, cend1, cstart2, cend2;
+
+    if (argc>0) {
+        start = *argv--;
+        argc--;
+        if (!INTP(start)) STk_error("bad integer ~S", start);
+        cstart = INT_VAL(start);
+    } else cstart = 0;
+
+    int a = vec_init_args(&cstart1, &cend1,
+                          argc, argv,
+                          VECTOR_SIZE(v1));
+
+    argc -= a;
+    argv -= a;
+    
+    vec_init_args(&cstart2, &cend2,
+                  argc, argv,
+                  VECTOR_SIZE(v2));
+
+    /* to_max is the maximum index on the destination vector.
+       its current*/
+    long to_max = cstart + (cend1 - cstart1) + (cend2 - cstart2);
+    if (to_max > VECTOR_SIZE(to))
+        STk_error("merged vector would exceed length of destination");
+    
+    check_overlap(to,cstart,to_max, v1,cstart1,cend1);
+    check_overlap(to,cstart,to_max, v2,cstart2,cend2);
+
+    if (to_max - cstart > 0)
+        vector_merge_aux(pred,to,v1,v2,cstart,cstart1,cend1,cstart2,cend2);
+    
+    return STk_void;
+}
+
+
+void merge(SCM v, SCM aux,
+           SCM less,
+           long *runs,
+           long i
+           )
+{
+    memcpy( VECTOR_DATA(aux),
+            &(VECTOR_DATA(v)[runs[i-2]]),
+            (runs[i-1] - runs[i-2])* sizeof(SCM));
+    
+    vector_merge_aux(less,
+                     v,                        /* result is in v */
+                     aux, v,                   /* the two sections to merge */
+                     runs[i-2],                /* where to merge in v */
+                     0L,runs[i-1] - runs[i-2], /* one run (in aux) */
+                     runs[i-1],runs[i]);       /* one run (in v) */
+}
+
+/*************************************
+ *
+ * Sort procedures
+ *
+ *************************************/
+
+void insertion_sort(SCM *vec, SCM less, long start, long end)
+{
+    int r;
+    int q = start + 1;
+    SCM swap_aux;
+    
+    /* TODO: use binary insertion sort */
+    while (q < end) {
+        r = q;
+        while (r > start &&
+               STk_C_apply(less, 2, vec[r], vec[r-1] ) == STk_true) {
+            swap_aux = vec[r];
+            vec[r] = vec[r-1];
+            vec[r-1] = swap_aux;
+            r--;
+        }
+        q++;
+    }
+}
+
+DEFINE_PRIMITIVE("list-stable-sort!",
+                 srfi_132_nlist_stable_sort,
+                 subr2,
+                 (SCM less, SCM list))
+{
+    /* If someone is using this procedure and not list-stable-sort,
+       it is likely to be due to memory constraints (not willing to
+       create a full copy of the list). So we will sacrifice performance
+       in order to avoid, as much as possible, allocating more memory.
+
+       We will do something similar to timsort.
+
+       1. Find a run.
+       2. If it's too short, copy the next M list pointers it onto a vector,
+          sort the vector using insertion sort, and we have a run of length
+          M.
+       3. Push the run (start pointer + size) onto a list. We will need to
+          cons here, but it will be a very small list.
+       4. Use the timsort criteria for merging the top runs.
+       5. Go back to (1).
+    */
+    if (!(CONSP(list) || NULLP(list))) STk_error("bad list ~S", list);
+    if (NULLP(list) || NULLP(CDR(list))) return list;
+    
+    SCM runs = STk_nil;
+    SCM start = list;
+    SCM end   = start;
+    long run_len;
+    SCM one, two;
+    long size1, size2;
+    SCM x;
+    long len = STk_int_length(start);
+    SCM *tmp_vec = STk_must_malloc(min_run * sizeof(SCM));
+
+    /* We need to go through all the list in order to calculate its length --
+       and the elements may be scattered all around. However, doing that once
+       doesn't seem to hurt in practice. */
+    long min_run = len & 0x3f; /* 6 first bits */
+    if ( (min_run >> 6) != 0)
+        min_run++;
+    if (min_run == 0)
+        min_run++;
+
+    while (!NULLP(start) && !NULLP(end)) {
+        if (!CONSP(end)) STk_error("improper list ~S", list);
+
+        run_len = 1;
+        end = start;
+
+        while (!NULLP(CDR(end)) &&
+               STk_C_apply(less, 2, CAR(end), CAR(CDR(end))) == STk_true) {
+            run_len++;
+            end = CDR(end);
+        }
+        /* end points to the LAST element in a run (NOT to the element after it) */
+
+        
+        /*
+          if size of this run is less than min_run:
+             extend the list so as to have min_run length,
+             COPY it into vector (do not use vector2lis, don't cons)
+             use insertion sort on the vector,
+             COPY back into list, with set-car!
+        */
+        if (run_len < min_run) {
+            SCM old_start = start;
+
+            /* copy remaining unordered items on a vector */
+            int j;
+            for (j=0; j < min_run - run_len; j++) {
+                tmp_vec[j] = CAR(start);
+                if (NULLP(CDR(start))) { j++; break; } /* j should point to one AFTER the last */
+                start = CDR(start);
+            }
+
+            /* sort tmp_vec using insertion sort */
+            insertion_sort(tmp_vec, less, 0, j);
+
+            /* copy back to the list */
+            start = old_start;
+            for (int i=0; i < j; i++) {
+                CAR(start) = tmp_vec[i];
+                start = CDR(start);
+            }
+
+            start = old_start;
+            run_len = j;
+
+        }
+
+        runs = STk_cons(LIST2(start, MAKE_INT(run_len)), runs);
+        start = CDR(end);
+        CDR(end) = STk_nil;
+
+        /* The following is the heard of timsort. Look at the runs stack and
+           decide if it's time to merge. */
+        /* BEGIN of the merging done after each run is queued. */
+
+        int merged;
+        do {
+
+            merged = 0;
+            if (!NULLP(CDR(runs)) &&                            /* at least three runs on the stack */
+                !NULLP(CDR(CDR(runs))) &&
+                !NULLP(CDR(CDR(CDR(runs)))) &&
+                   INT_VAL(CAR(CDR( CAR(runs) )))               /*    C */
+                +  INT_VAL(CAR(CDR( CAR(CDR(runs)) )))          /* +  B */
+                >= INT_VAL(CAR(CDR( CAR(CDR(CDR(runs))) )))) {  /* >= A */
+                
+                if(   INT_VAL(CAR(CDR( CAR(CDR(CDR(runs))) )))  /*   A */
+                   <  INT_VAL(CAR(CDR( CAR(runs) )))) {         /* < C */
+
+                    merged = 1;
+                    one = CAR(CDR(runs));       /* B */
+                    two = CAR(CDR(CDR(runs)));  /* A */
+                    
+                    size1 = INT_VAL(CAR(CDR(one)));
+                    size2 = INT_VAL(CAR(CDR(two)));
+                    
+                    x = list_merge_aux(less,
+                                       CAR(two),
+                                       CAR(one));
+                    
+                    CDR(runs) = STk_cons(LIST2(x, MAKE_INT(size1 + size2)),
+                                         CDR(CDR(CDR(runs))));  /* discard the two runs we merged */
+                } else {
+                    /* merge BC */
+                    merged = 1;
+                    one = CAR(runs);
+                    two = CAR(CDR(runs));
+                    
+                    size1 = INT_VAL(CAR(CDR(one)));
+                    size2 = INT_VAL(CAR(CDR(two)));
+                    
+                    x = list_merge_aux(less,
+                                       CAR(two),
+                                       CAR(one));
+                    
+                    runs = STk_cons(LIST2(x, MAKE_INT(size1 + size2)),
+                                    CDR(CDR(runs))); /* discard the two runs we merged */
+                }
+            }
+            
+            if (!NULLP(CDR(runs)) &&                        /* at least two runs on the stack */
+                !NULLP(CDR(CDR(runs))) &&
+                   INT_VAL(CAR(CDR( CAR(runs) )))           /*    C */
+                >= INT_VAL(CAR(CDR( CAR(CDR(runs)) )))) {   /* >= B */
+                
+                merged = 1;
+                one = CAR(runs);
+                two = CAR(CDR(runs));
+                
+                size1 = INT_VAL(CAR(CDR(one)));
+                size2 = INT_VAL(CAR(CDR(two)));
+                
+                x = list_merge_aux(less,
+                                   CAR(two),
+                                   CAR(one));
+                
+                runs = STk_cons(LIST2(x, MAKE_INT(size1 + size2)),
+                                CDR(CDR(runs))); /* discard the two runs we merged */
+            }
+        } while (merged == 1);
+        /* END of the merging done after each run is queued. */
+
+    }
+
+    /* merge all remaining runs on the stack, two at a time */
+    while (!NULLP(CDR(runs))){
+
+        one = CAR(runs);
+        two = CAR(CDR(runs));
+
+        size1 = INT_VAL(CAR(CDR(one)));
+        size2 = INT_VAL(CAR(CDR(two)));
+
+        x = list_merge_aux(less,
+                           CAR(two),     /* pointer to first run  */
+                           CAR(one));    /* pointer to second run */
+
+        runs = STk_cons(LIST2(x, MAKE_INT(size1 + size2)),
+                        CDR(CDR(runs))); /* discard the two runs we merged */
+    }
+
+    return CAR(CAR(runs));
+}
+
+void reverse_vector(SCM *vec, long start, long end)
+{
+    long a = start;
+    long b = end - 1;
+    SCM swap_aux;
+    while (a<b) {
+        swap_aux = vec[a];
+        vec[a] = vec[b];
+        vec[b] = swap_aux;
+        a++;
+        b--;
+    }
+}
+
+
+DEFINE_PRIMITIVE("vector-stable-sort!",
+                 srfi_132_nvector_stable_sort,
+                 vsubr,
+                 (int argc, SCM *argv))
+{
+    if (argc < 2) STk_error ("requires at least 2 arguments");
+    if (argc > 4) STk_error ("requires at most 4 arguments");
+    SCM less = *argv--;
+    SCM v = *argv--;
+
+    if (!(VECTORP(v))) error_bad_vector(v);
+    if (STk_procedurep(less) != STk_true) error_bad_proc(less);
+
+    SCM start;
+    SCM end;
+    long cstart, cend;
+
+    if (argc>2) {
+        start = *argv--;
+        if (!INTP(start)) STk_error("bad integer ~S for start index", start);
+        cstart = INT_VAL(start);
+    } else cstart = 0;
+    
+    if (argc>3) {
+        end = *argv--;
+        if (!INTP(end)) STk_error("bad integer ~S for end index", end);
+        cend = INT_VAL(end);
+    } else cend = VECTOR_SIZE(v);
+
+    long size = cend - cstart;
+
+    /* Rule for computing minrun from timsort,
+       https://github.com/python/cpython/blob/main/Objects/listsort.txt */
+    long min_timsort_run = size & 0x3f; /* 6 first bits */
+    if ( (min_timsort_run >> 6) != 0)
+        min_timsort_run++;
+    if (min_timsort_run == 0)
+        min_timsort_run++;
+        
+        
+    /* The following is an implementation of Timsort.
+       We find "runs" (portions of the array that are already
+       sorted), store their indices in a list (actually an array),
+       then merge the list.
+       If a run is too short, we take a larger portion of the array
+       (which is not sorted) and perform insertion sort on it. */
+    
+    SCM aux = STk_makevect(size, STk_void);
+
+    SCM *vec = &VECTOR_DATA(v)[0];
+    
+    /* "runs" is an array of long and not int because it stores
+       the end indices of runs */
+    long runs_size = 1 + (size+1) / min_timsort_run;
+    long *runs = STk_must_malloc(sizeof(long) * runs_size); 
+    
+    /*
+      i  points to the beginning of the current run
+      j  starts at i+1 and moves forward, and will end up one position AFTER the
+         last position of the run
+      k  is the sequential index of the run (1st run, 2nd run, etc).
+     */
+    
+    long i = cstart;
+    long j;
+    long s;
+    long k = 1; /* index of the current run */
+    long run_end = i+1;
+    
+    runs[0]=cstart;
+    
+    
+    while (run_end <= cend) {
+        /* Find a run. Try forward, then backward. One of these will immediately fail,
+           unless the user has been kind enough to call this procedure with `=` as a
+           comparison predicate (which won't hurt anyway). */
+
+        j = s = run_end;
+        
+        /* forward */
+        while ( (j < cend) &&
+                STk_C_apply(less, 2, vec[j-1], vec[j] ) == STk_true) {
+            j++;
+        }
+
+        /* backward */
+        while ( (s < cend) &&
+                STk_C_apply(less, 2, vec[s], vec[s-1] ) == STk_true) {
+            s++;
+        }
+
+        run_end = (s > j) ? s : j;
+
+        /* un-reverse the reversed run, regardless of its size: */
+        if (s > j) reverse_vector(vec, i, run_end);
+
+        
+        /* if the run is too short, create a long one with insertion sort
+           (cannot be shell, mnust be a stable sort): */
+        if ( (run_end - i) < min_timsort_run && run_end < cend) {
+
+            if (i + min_timsort_run >= cend)
+                run_end = cend;
+            else
+                run_end =  i + min_timsort_run;
+            
+            insertion_sort(vec, less, i, run_end);
+        }
+
+        
+        /* include the end of the run into the list of runs to merge. */
+        runs[k] = run_end;
+
+
+        /* The following is the heard of timsort. Look at the runs stack and
+           decide if it's time to merge. */
+        /* BEGIN of the merging done after each run is queued. */
+        long kk;
+        do {
+            kk = k;
+            if (k > 3 &&
+                   runs[k] - runs[k-1]    /*    C */
+                +  runs[k-1] - runs[k-2]  /*  + B */
+                >= runs[k-2] - runs[k-3]) /* >= A */
+                {
+                    if (  runs[k-2] - runs[k-3]   /*   A */
+                          < runs[k] - runs[k-1])  /* < C */
+                        {
+                            /* merge AB */
+                            merge(v, aux, less, runs, k-1);
+                            runs[k-2] = runs[k-1];
+                            runs[k-1] = runs[k];
+                        k--;
+                        } else
+                        {
+                            /* merge BC */
+                            merge(v, aux, less, runs, k);
+                            runs[k-1] = runs[k];
+                            k--;
+                        }
+                }
+            if (k > 2 &&
+                    runs[k] - runs[k-1]    /*    C */
+                 >= runs[k-1] - runs[k-2]) /* >= B */
+                {
+                    merge(v, aux, less, runs, k);
+                    runs[k-1] = runs[k];
+                    k--;
+                }
+        } while (kk != k); /* k was decreased, some merge was made */
+        /* END of the merging done after each run is queued. */
+        
+        i = run_end;
+        run_end++;
+        k++;
+    }
+
+    /* if either j was already >= end when we started, or the vector
+       was already sorted, then we return void. */
+    if (k <= 1) return STk_void;
+
+    /* merge all remaining runs on the stack, two at a time */
+    for (i = k-1; i > 1; i--) {
+        /* merge two runs */
+        merge(v, aux, less, runs, i);
+        runs[i-1] = runs[i];
+    }
+
+    return STk_void;
+}
+
+DEFINE_PRIMITIVE("vector-stable-sort",
+                 srfi_132_vector_stable_sort,
+                 vsubr,
+                 (int argc, SCM *argv))
+{
+    SCM *original_argv = argv;
+    
+    if (argc < 2) STk_error ("requires at least 2 arguments");
+    if (argc > 4) STk_error ("requires at most 4 arguments");
+    
+    argv--; /* the predicate */
+    
+    SCM v = *argv--;
+    
+    if (!(VECTORP(v))) error_bad_vector(v);
+
+    SCM start;
+    SCM end;
+    long cstart, cend;
+
+    if (argc>2) {
+        start = *argv--;
+        if (!INTP(start)) STk_error("bad integer ~S for start index", start);
+        cstart = INT_VAL(start);
+    } else cstart = 0;
+    
+    if (argc>3) {
+        end = *argv--;
+        if (!INTP(end)) STk_error("bad integer ~S for end index", end);
+        cend = INT_VAL(end);
+    } else cend = VECTOR_SIZE(v);
+
+    long size = cend - cstart;
+
+    SCM w = STk_makevect(size, NULL);
+
+    if (size == 0) return w;
+        
+    memcpy(&VECTOR_DATA(w)[0],&VECTOR_DATA(v)[cstart], size * sizeof(SCM));
+
+    /* TODO: we're unboxing-then-boxing-then-unboxing. */
+    *(original_argv-1) = w;
+    *(original_argv-2) = MAKE_INT(0);    /* new start */
+    *(original_argv-3) = MAKE_INT(size); /* new end */
+    /* TODO: indices will be unnecessarily checked again! */
+    STk_srfi_132_nvector_stable_sort(argc, original_argv);
+
+    return w;
+}
+
+/*************************************
+ *
+ * Deleting duplicate neighbors
+ *
+ *************************************/
+
+
+/* Tried to make these efficient, and they should also work with
+   improper lists - but the last CDR is ignored when comparing:
+   (list-delete-neighbor-dups = '(2 2 3 2 . 2))
+   => (2 3 2 . 2)
+*/
+
+DEFINE_PRIMITIVE("list-delete-neighbor-dups",
+                 srfi_132_list_delete_neighbor_dups,
+                 subr2,
+                 (SCM eq, SCM lst))
+{
+    if (!(CONSP(lst) || NULLP(lst))) error_bad_list(lst);
+    if (STk_procedurep(eq) != STk_true) error_bad_proc(eq);
+
+    if (NULLP(lst) || !CONSP(CDR(lst))) return lst;
+
+    SCM new = LIST1(CAR(lst));
+    SCM ptr = new;
+    lst = CDR(lst);
+
+    while (  ( ! NULLP(CDR(lst))  ) &&
+             (   CONSP(CDR(lst))  ) )
+        if (STk_C_apply(eq, 2, CAR(lst), CAR(ptr)) == STk_true)
+            lst = CDR(lst);
+        else {
+            CDR(ptr) = LIST1(CAR(lst));
+            ptr = CDR(ptr);
+            lst = CDR(lst);
+        }
+
+    if (STk_C_apply(eq, 2, CAR(lst), CAR(ptr)) == STk_false)
+        CDR(ptr) = lst;
+    else
+        CDR(ptr) = CDR(lst);
+
+    return new;
+}
+
+
+DEFINE_PRIMITIVE("list-delete-neighbor-dups!",
+                 srfi_132_nlist_delete_neighbor_dups,
+                 subr2,
+                 (SCM eq, SCM lst))
+{
+    if (!(CONSP(lst) || NULLP(lst))) error_bad_list(lst);
+    if (STk_procedurep(eq) != STk_true) error_bad_proc(eq);
+
+    if (NULLP(lst)) return lst;
+
+    SCM ptr = lst;
+    while ( (! NULLP(CDR(ptr))) && CONSP(CDR(ptr)) )
+        if (STk_C_apply(eq, 2, CAR(CDR(ptr)), CAR(ptr)) == STk_true)
+            CDR(ptr)=CDR(CDR(ptr));
+        else
+            ptr = CDR(ptr);    
+    
+    return lst;
+}
+
+
+/* Returns the number of duplicates */
+long
+srfi_132_vector_del_dups_aux(SCM v, SCM eq, long start, long end)
+{
+    long dups = 0;
+    long i = start ;
+    long j = start + 1;
+
+    while (i < end-1 && j < end) {
+        /* find next different */
+        while (j < end &&
+               STk_C_apply(eq, 2,
+                           VECTOR_DATA(v)[i],
+                           VECTOR_DATA(v)[j]) == STk_true) {
+            j++;
+            dups++;
+        }
+        
+        /* advance i and copy next different */
+        if ( j < end ) {
+            i++;
+            VECTOR_DATA(v)[i] = VECTOR_DATA(v)[j];
+            j++;
+        }
+    }
+    return dups;
+}
+
+DEFINE_PRIMITIVE("vector-delete-neighbor-dups!",
+                 srfi_132_nvector_delete_neighbor_dups,
+                 vsubr,
+                 (int argc, SCM* argv))
+{
+    if (argc < 2) STk_error ("requires at least 2 arguments");
+    if (argc > 4) STk_error ("requires at most 4 arguments");
+    SCM eq = *argv--;
+    SCM v = *argv--;
+
+    if (!(VECTORP(v))) error_bad_vector(v);
+    if (STk_procedurep(eq) != STk_true) error_bad_proc(eq);
+
+    if (VECTOR_SIZE(v)<2) return MAKE_INT(VECTOR_SIZE(v));
+    
+    long cstart, cend;
+
+    argc -= 2;
+    vec_init_args(&cstart, &cend,
+                  argc, argv,
+                  VECTOR_SIZE(v));
+
+    long dups = srfi_132_vector_del_dups_aux(v, eq, cstart, cend);
+
+    return MAKE_INT(cend - dups);
+}
+
+DEFINE_PRIMITIVE("vector-delete-neighbor-dups",
+                 srfi_132_vector_delete_neighbor_dups,
+                 vsubr,
+                 (int argc, SCM* argv))
+{
+    if (argc < 2) STk_error ("requires at least 2 arguments");
+    if (argc > 4) STk_error ("requires at most 4 arguments");
+    SCM eq = *argv--;
+    SCM v = *argv--;
+
+    if (!(VECTORP(v))) error_bad_vector(v);
+    if (STk_procedurep(eq) != STk_true) error_bad_proc(eq);
+
+   
+    long cstart, cend;
+    
+    argc -= 2;
+    vec_init_args(&cstart, &cend,
+                  argc, argv,
+                  VECTOR_SIZE(v));
+
+    SCM w = STk_makevect(cend - cstart, NULL);
+
+    memcpy (&VECTOR_DATA(w)[0],
+            &VECTOR_DATA(v)[cstart],
+            (cend-cstart) * sizeof(SCM));
+    
+    if (VECTOR_SIZE(v)<2) return w;
+
+    long dups = srfi_132_vector_del_dups_aux(w, eq, 0, cend-cstart);
+
+    /* Oh no! We can't realoc VECTOR_DATA, so we need to make yet
+       another copy of the vector! */
+    SCM u = STk_makevect(VECTOR_SIZE(w) - dups, NULL);
+    memcpy (&VECTOR_DATA(u)[0],
+            &VECTOR_DATA(w)[0],
+            VECTOR_SIZE(u) * sizeof(SCM));
+    return u;
+}
+
+MODULE_ENTRY_START("srfi-132")
+{
+    SCM module =  STk_create_module(STk_intern("SRFI-132"));
+    
+    ADD_PRIMITIVE_IN_MODULE(list_sorted,module);
+    ADD_PRIMITIVE_IN_MODULE(vector_sorted,module);
+
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_nlist_stable_sort,module);
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_nvector_stable_sort,module);
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_vector_stable_sort,module);
+
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_list_merge, module);
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_nlist_merge, module);
+    ADD_PRIMITIVE_IN_MODULE(vector_merge,module);
+    ADD_PRIMITIVE_IN_MODULE(nvector_merge,module);
+
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_nlist_delete_neighbor_dups, module);
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_list_delete_neighbor_dups, module);
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_vector_delete_neighbor_dups, module);
+    ADD_PRIMITIVE_IN_MODULE(srfi_132_nvector_delete_neighbor_dups, module);
+
+    /* Export all the symbols we have just defined */
+    STk_export_all_symbols(module);
+    
+   /* Execute Scheme code */
+    STk_execute_C_bytecode(__module_consts, __module_code);
+}
+MODULE_ENTRY_END
+
+DEFINE_MODULE_INFO

--- a/lib/srfi-132/srfi-132.stk
+++ b/lib/srfi-132/srfi-132.stk
@@ -1,0 +1,224 @@
+;;;;
+;;;; srfi-132.stk         -- SRFI-132: Sort Libraries
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 08-Aug-2021 13:31
+;;;; Last file update: 31-Aug-2021 22:15
+
+
+(select-module SRFI-132)
+
+(export list-sort
+        list-sort!
+        list-stable-sort
+        vector-sort
+        vector-sort!
+        vector-find-median!
+        vector-find-median
+        vector-select!
+        vector-separate! )
+
+;;;;
+;;;; Predicates
+;;;;
+
+;; (list-sorted? < lis)                  implemented as primitive
+;; (vector-sorted? < v [start [ end ] ]) implemented as primitive
+
+;;;;
+;;;; General sort procedures
+;;;;
+
+;; We do the list => vector => sort => list thing here,
+;; since we have a good vector sorting algorithm.
+(define (list-stable-sort p l)
+  (vector->list (vector-stable-sort p (list->vector l))))
+
+(define list-sort list-stable-sort)
+
+;; (define list-stable-sort! p l) implemented as primitive
+
+(define list-sort! list-stable-sort!)
+
+;; (vector-stable-sort! p v)    implemented as primitive
+;; (vector-stable-sort p v)     implemented as primitive
+
+
+;; TODO: should we use a different algorithm for unstable sort?
+;;       is introsort faster than timsort?
+(define vector-sort vector-stable-sort)
+(define vector-sort! vector-stable-sort!)
+
+
+;;;;
+;;;; Merge procedures
+;;;;
+
+
+;; all implemented as primitives:
+
+;; (list-merge < lst)
+;; (list-merge! < lst)
+;; (vector-merge < v1 v2 [ start1 [ end1 [ start2 [ end2 ] ] ] ])
+;; (vector-merge! < to from1 from2 [ start [ start1 [ end1 [ start2 [ end2 ] ] ] ] ]) 
+
+
+;;;;
+;;;; Deleting duplicate neighbors
+;;;;
+
+;; (list-delete-neighbor-dups = lis)                       ; implemented as primitive
+;; (list-delete-neighbor-dups! = lis)                      ; implemented as primitive
+;; (vector-delete-neighbor-dups = lis [ start [ end ] ])   ; implemented as primitive
+;; (vector-delete-neighbor-dups! = lis [ start [ end ] ])  ; implemented as primitive
+
+;;;;
+;;;; Finding the median
+;;;;
+
+;; (vector-find-median < v knil [ mean ])
+;; (vector-find-median! < v knil [ mean ])
+
+
+
+;;;; There are some procedures ahead that have been adapted from Chibi Scheme.
+;;;; They have the following license:
+;;;;;;;;
+;;;;;;;; Copyright (c) 2009-2021 Alex Shinn
+;;;;;;;; All rights reserved.
+
+;;;;;;;; Redistribution and use in source and binary forms, with or without
+;;;;;;;; modification, are permitted provided that the following conditions
+;;;;;;;; are met:
+;;;;;;;; 1. Redistributions of source code must retain the above copyright
+;;;;;;;;    notice, this list of conditions and the following disclaimer.
+;;;;;;;; 2. Redistributions in binary form must reproduce the above copyright
+;;;;;;;;    notice, this list of conditions and the following disclaimer in the
+;;;;;;;;    documentation and/or other materials provided with the distribution.
+;;;;;;;; 3. The name of the author may not be used to endorse or promote products
+;;;;;;;;    derived from this software without specific prior written permission.
+
+;;;;;;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+;;;;;;;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;;;;;;;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;;;;;;;; IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+;;;;;;;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;;;;;;;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;;;;;;;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;;;;;;;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;;;;;;;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;;;;;;;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+;; From Chibi:
+(define (vector-find-median! < vec knil :optional mean)
+  (vector-sort! < vec)
+  (let* ((len (vector-length vec))
+         (mid (quotient len 2))
+         (mean (or mean (lambda (a b) (/ (+ a b) 2)))))
+    (cond
+     ((zero? len) knil)
+     ((odd? len) (vector-ref vec mid))
+     (else (mean (vector-ref vec (- mid 1))
+                 (vector-ref vec mid))))))
+
+(define (vector-max less vec lo hi largest)
+  (cond
+   ((>= lo hi) largest) 
+   ((less largest (vector-ref vec lo))
+    (vector-max less vec (+ lo 1) hi (vector-ref vec lo)))
+   (else
+    (vector-max less vec (+ lo 1) hi largest))))
+
+(define (vector-find-median < vec knil :optional mean)
+  (let* ((vec (vector-copy vec))
+         (len (vector-length vec))
+         (mid (quotient len 2))
+         (mean (or mean (lambda (a b) (/ (+ a b) 2)))))
+    (cond
+     ((zero? len) knil)
+     (else
+      (let ((mid-elt (vector-select! < vec mid)))
+        (cond
+         ((odd? len) mid-elt)
+         (else
+          (mean (vector-max < vec 0 (- mid 1) (vector-ref vec (- mid 1)))
+                mid-elt))))))))
+
+;;;;
+;;;; Selection
+;;;;
+
+;; From Chibi:
+(define (choose-pivot < vec left right)
+  (let* ((mid (quotient (+ left right) 2))
+         (a (vector-ref vec left))
+         (b (vector-ref vec mid))
+         (c (vector-ref vec right)))
+    (if (< a b)
+        (if (< b c) mid (if (< a c) right left))
+        (if (< a c) left (if (< b c) right mid)))))
+
+;; From Chibi:
+(define (vector-partition! < vec left right pivot)
+  (define (swap! i j)
+    (let ((tmp (vector-ref vec i)))
+      (vector-set! vec i (vector-ref vec j))
+      (vector-set! vec j tmp)))
+  (let ((elt (vector-ref vec pivot)))
+    (swap! pivot right)
+    (let lp ((i left)
+             (j left))
+      (cond
+       ((= i right)
+        (swap! i j)
+        j)
+       ((< (vector-ref vec i) elt)
+        (swap! i j)
+        (lp (+ i 1) (+ j 1)))
+       (else
+        (lp (+ i 1) j))))))
+
+;; From Chibi:
+(define (vector-select! less vec k :optional (start 0) end)
+   (let* ((k (+ k start)))
+     (if (not (<= 0 k (vector-length vec)))
+         (error "index out of range" vec k))
+     (let select ((start start)
+                  (end (- (or end (vector-length vec)) 1)))
+       (if (>= start end)
+           (vector-ref vec start)
+           (let* ((pivot (choose-pivot less vec start end))
+                  (pivot-index (vector-partition! less vec start end pivot)))
+             (cond
+              ((= k pivot-index)
+               (vector-ref vec k))
+              ((< k pivot-index)
+               (select start (- pivot-index 1)))
+              (else
+               (select (+ pivot-index 1) end))))))))
+
+(define (vector-separate! . args)
+  (apply vector-select! args)
+  #void)
+
+(select-module STklos)
+(import SRFI-132)
+(provide "srfi-132")

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -170,7 +170,7 @@
     (129 "Titlecase procedures" (titlecase) "srfi-129")
     (130 "Cursor-based string library" () "srfi-130")
     ;; 131  ERR5RS Record Syntax (reduced)
-    ;; 132  Sort Libraries
+    (132 "Sort Libraries" (sort) "srfi-132")
     (133  "Vector Library (R7RS-compatible)" (vector) "srfi-133")
     (134  "Immutable Deques" (immutable-deques) "srfi-134")
     (135  "Immutable Texts" (immutable-texts) "srfi-135")

--- a/tests/srfis/132.stk
+++ b/tests/srfis/132.stk
@@ -1,0 +1,1381 @@
+(require "srfi-27")
+
+(define (writeln . xs)
+  (for-each display xs)
+  (newline))
+
+(define-syntax fail
+  (syntax-rules ()
+    ((_ token)
+     token)))
+
+
+(define r7rs-vector-copy vector-copy)
+
+(define-syntax x-test
+  (syntax-rules (equal?)
+    ((_ (equal? expr res) msg)
+     (test msg res expr))
+    ((_ expr msg)
+     (test msg #t (not (not expr))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Additional tests written specifically for SRFI 132.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (list-sorted? > '())
+    (fail 'list-sorted?:empty-list))
+
+(x-test (list-sorted? > '(987))
+    (fail 'list-sorted?:singleton))
+
+(x-test (list-sorted? > '(9 8 7))
+    (fail 'list-sorted?:non-empty-list))
+
+(x-test (vector-sorted? > '#())
+    (fail 'vector-sorted?:empty-vector))
+
+(x-test (vector-sorted? > '#(987))
+    (fail 'vector-sorted?:singleton))
+
+(x-test (vector-sorted? > '#(9 8 7 6 5))
+    (fail 'vector-sorted?:non-empty-vector))
+
+(x-test (vector-sorted? > '#() 0)
+    (fail 'vector-sorted?:empty-vector:0))
+
+(x-test (vector-sorted? > '#(987) 1)
+    (fail 'vector-sorted?:singleton:1))
+
+(x-test (vector-sorted? > '#(9 8 7 6 5) 1)
+    (fail 'vector-sorted?:non-empty-vector:1))
+
+(x-test (vector-sorted? > '#() 0 0)
+    (fail 'vector-sorted?:empty-vector:0:0))
+
+(x-test (vector-sorted? > '#(987) 1 1)
+    (fail 'vector-sorted?:singleton:1:1))
+
+(x-test (vector-sorted? > '#(9 8 7 6 5) 1 2)
+    (fail 'vector-sorted?:non-empty-vector:1:2))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (equal? (list-sort > (list))
+            '())
+    (fail 'list-sort:empty-list))
+
+(x-test (equal? (list-sort > (list 987))
+            '(987))
+    (fail 'list-sort:singleton))
+
+(x-test (equal? (list-sort > (list 987 654))
+            '(987 654))
+    (fail 'list-sort:doubleton))
+
+(x-test (equal? (list-sort > (list 9 8 6 3 0 4 2 5 7 1))
+            '(9 8 7 6 5 4 3 2 1 0))
+    (fail 'list-sort:iota10))
+
+(x-test (equal? (list-stable-sort > (list))
+            '())
+    (fail 'list-stable-sort:empty-list))
+
+(x-test (equal? (list-stable-sort > (list 987))
+            '(987))
+    (fail 'list-stable-sort:singleton))
+
+(x-test (equal? (list-stable-sort > (list 987 654))
+            '(987 654))
+    (fail 'list-stable-sort:doubleton))
+
+(x-test (equal? (list-stable-sort > (list 9 8 6 3 0 4 2 5 7 1))
+            '(9 8 7 6 5 4 3 2 1 0))
+    (fail 'list-stable-sort:iota10))
+
+(x-test (equal? (list-stable-sort (lambda (x y)
+                                 (> (quotient x 2)
+                                    (quotient y 2)))
+                               (list 9 8 6 3 0 4 2 5 7 1))
+            '(9 8 6 7 4 5 3 2 0 1))
+    (fail 'list-stable-sort:iota10-quotient2))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-sort > v))
+            '#())
+    (fail 'vector-sort:empty-vector))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-sort > (vector 987)))
+            '#(987))
+    (fail 'vector-sort:singleton))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-sort > v))
+            '#(987 654))
+    (fail 'vector-sort:doubleton))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-sort > v))
+            '#(9 8 7 6 5 4 3 2 1 0))
+    (fail 'vector-sort:iota10))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-stable-sort > v))
+            '#())
+    (fail 'vector-stable-sort:empty-vector))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-stable-sort > (vector 987)))
+            '#(987))
+    (fail 'vector-stable-sort:singleton))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-stable-sort > v))
+            '#(987 654))
+    (fail 'vector-stable-sort:doubleton))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort > v))
+            '#(9 8 7 6 5 4 3 2 1 0))
+    (fail 'vector-stable-sort:iota10))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort (lambda (x y)
+                                     (> (quotient x 2)
+                                        (quotient y 2)))
+                                   v))
+            '#(9 8 6 7 4 5 3 2 0 1))
+    (fail 'vector-stable-sort:iota10-quotient2))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-sort > v 0))
+            '#())
+    (fail 'vector-sort:empty-vector:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-sort > (vector 987) 1))
+            '#())
+    (fail 'vector-sort:singleton:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-sort > v 1))
+            '#(654))
+    (fail 'vector-sort:doubleton:1))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-sort > v 3))
+            '#(7 5 4 3 2 1 0))
+    (fail 'vector-sort:iota10:3))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-stable-sort > v 0))
+            '#())
+    (fail 'vector-stable-sort:empty-vector:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-stable-sort > (vector 987) 1))
+            '#())
+    (fail 'vector-stable-sort:singleton:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-stable-sort < v 0 2))
+            '#(654 987))
+    (fail 'vector-stable-sort:doubleton:0:2))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort > v 3))
+            '#(7 5 4 3 2 1 0))
+    (fail 'vector-stable-sort:iota10:3))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort (lambda (x y)
+                                     (> (quotient x 2)
+                                        (quotient y 2)))
+                                   v
+                                   3))
+            '#(7 4 5 3 2 0 1))
+    (fail 'vector-stable-sort:iota10-quotient2:3))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-sort > v 0 0))
+            '#())
+    (fail 'vector-sort:empty-vector:0:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-sort > (vector 987) 1 1))
+            '#())
+    (fail 'vector-sort:singleton:1:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-sort > v 1 2))
+            '#(654))
+    (fail 'vector-sort:doubleton:1:2))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-sort > v 4 8))
+            '#(5 4 2 0))
+    (fail 'vector-sort:iota10:4:8))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-stable-sort > v 0 0))
+            '#())
+    (fail 'vector-stable-sort:empty-vector:0:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-stable-sort > (vector 987) 1 1))
+            '#())
+    (fail 'vector-stable-sort:singleton:1:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-stable-sort > v 1 2))
+            '#(654))
+    (fail 'vector-stable-sort:doubleton:1:2))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort > v 2 6))
+            '#(6 4 3 0))
+    (fail 'vector-stable-sort:iota10:2:6))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort (lambda (x y)
+                                     (> (quotient x 2)
+                                        (quotient y 2)))
+                                   v
+                                   1
+                                   8))
+            '#(8 6 4 5 3 2 0))
+    (fail 'vector-stable-sort:iota10-quotient2:1:8))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (equal? (list-sort! > (list))
+            '())
+    (fail 'list-sort!:empty-list))
+
+(x-test (equal? (list-sort! > (list 987))
+            '(987))
+    (fail 'list-sort!:singleton))
+
+(x-test (equal? (list-sort! > (list 987 654))
+            '(987 654))
+    (fail 'list-sort!:doubleton))
+
+(x-test (equal? (list-sort! > (list 9 8 6 3 0 4 2 5 7 1))
+            '(9 8 7 6 5 4 3 2 1 0))
+    (fail 'list-sort!:iota10))
+
+(x-test (equal? (list-stable-sort! > (list))
+            '())
+    (fail 'list-stable-sort!:empty-list))
+
+(x-test (equal? (list-stable-sort! > (list 987))
+            '(987))
+    (fail 'list-stable-sort!:singleton))
+
+(x-test (equal? (list-stable-sort! > (list 987 654))
+            '(987 654))
+    (fail 'list-stable-sort!:doubleton))
+
+(x-test (equal? (list-stable-sort! > (list 9 8 6 3 0 4 2 5 7 1))
+            '(9 8 7 6 5 4 3 2 1 0))
+    (fail 'list-stable-sort!:iota10))
+
+(x-test (equal? (list-stable-sort! (lambda (x y)
+                                 (> (quotient x 2)
+                                    (quotient y 2)))
+                               (list 9 8 6 3 0 4 2 5 7 1))
+            '(9 8 6 7 4 5 3 2 0 1))
+    (fail 'list-stable-sort!:iota10-quotient2))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-sort! > v)
+              v)
+            '#())
+    (fail 'vector-sort!:empty-vector))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-sort! > (vector 987))
+              v)
+            '#(987))
+    (fail 'vector-sort!:singleton))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-sort! > v)
+              v)
+            '#(987 654))
+    (fail 'vector-sort!:doubleton))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-sort! > v)
+              v)
+            '#(9 8 7 6 5 4 3 2 1 0))
+    (fail 'vector-sort!:iota10))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-stable-sort! > v)
+              v)
+            '#())
+    (fail 'vector-stable-sort!:empty-vector))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-stable-sort! > (vector 987))
+              v)
+            '#(987))
+    (fail 'vector-stable-sort!:singleton))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-stable-sort! > v)
+              v)
+            '#(987 654))
+    (fail 'vector-stable-sort!:doubleton))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort! > v)
+              v)
+            '#(9 8 7 6 5 4 3 2 1 0))
+    (fail 'vector-stable-sort!:iota10))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort! (lambda (x y)
+                                     (> (quotient x 2)
+                                        (quotient y 2)))
+                                   v)
+              v)
+            '#(9 8 6 7 4 5 3 2 0 1))
+    (fail 'vector-stable-sort!:iota10-quotient2))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-sort! > v 0)
+              v)
+            '#())
+    (fail 'vector-sort!:empty-vector:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-sort! > (vector 987) 1)
+              v)
+            '#(987))
+    (fail 'vector-sort!:singleton:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-sort! > v 1)
+              v)
+            '#(987 654))
+    (fail 'vector-sort!:doubleton:1))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-sort! > v 3)
+              v)
+            '#(9 8 6 7 5 4 3 2 1 0))
+    (fail 'vector-sort!:iota10:3))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-stable-sort! > v 0)
+              v)
+            '#())
+    (fail 'vector-stable-sort!:empty-vector:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-stable-sort! > (vector 987) 1)
+              v)
+            '#(987))
+    (fail 'vector-stable-sort!:singleton:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-stable-sort! < v 0 2)
+              v)
+            '#(654 987))
+    (fail 'vector-stable-sort!:doubleton:0:2))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort! > v 3)
+              v)
+            '#(9 8 6 7 5 4 3 2 1 0))
+    (fail 'vector-stable-sort!:iota10:3))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort! (lambda (x y)
+                                     (> (quotient x 2)
+                                        (quotient y 2)))
+                                   v
+                                   3)
+              v)
+            '#(9 8 6 7 4 5 3 2 0 1))
+    (fail 'vector-stable-sort!:iota10-quotient2:3))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-sort! > v 0 0)
+              v)
+            '#())
+    (fail 'vector-sort!:empty-vector:0:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-sort! > (vector 987) 1 1)
+              v)
+            '#(987))
+    (fail 'vector-sort!:singleton:1:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-sort! > v 1 2)
+              v)
+            '#(987 654))
+    (fail 'vector-sort!:doubleton:1:2))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-sort! > v 4 8)
+              v)
+            '#(9 8 6 3 5 4 2 0 7 1))
+    (fail 'vector-sort!:iota10:4:8))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-stable-sort! > v 0 0)
+              v)
+            '#())
+    (fail 'vector-stable-sort!:empty-vector:0:0))
+
+(x-test (equal? (let ((v (vector 987)))
+              (vector-stable-sort! > (vector 987) 1 1)
+              v)
+            '#(987))
+    (fail 'vector-stable-sort!:singleton:1:1))
+
+(x-test (equal? (let ((v (vector 987 654)))
+              (vector-stable-sort! > v 1 2)
+              v)
+            '#(987 654))
+    (fail 'vector-stable-sort!:doubleton:1:2))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort! > v 2 6)
+              v)
+            '#(9 8 6 4 3 0 2 5 7 1))
+    (fail 'vector-stable-sort!:iota10:2:6))
+
+(x-test (equal? (let ((v (vector 9 8 6 3 0 4 2 5 7 1)))
+              (vector-stable-sort! (lambda (x y)
+                                     (> (quotient x 2)
+                                        (quotient y 2)))
+                                   v
+                                   1
+                                   8)
+              v)
+            '#(9 8 6 4 5 3 2 0 7 1))
+    (fail 'vector-stable-sort!:iota10-quotient2:1:8))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (equal? (list-merge > (list) (list))
+            '())
+    (fail 'list-merge:empty:empty))
+
+(x-test (equal? (list-merge > (list) (list 9 6 3 0))
+            '(9 6 3 0))
+    (fail 'list-merge:empty:nonempty))
+
+(x-test (equal? (list-merge > (list 9 7 5 3 1) (list))
+            '(9 7 5 3 1))
+    (fail 'list-merge:nonempty:empty))
+
+(x-test (equal? (list-merge > (list 9 7 5 3 1) (list 9 6 3 0))
+            '(9 9 7 6 5 3 3 1 0))
+    (fail 'list-merge:nonempty:nonempty))
+
+(x-test (equal? (list-merge! > (list) (list))
+            '())
+    (fail 'list-merge!:empty:empty))
+
+(x-test (equal? (list-merge! > (list) (list 9 6 3 0))
+            '(9 6 3 0))
+    (fail 'list-merge!:empty:nonempty))
+
+(x-test (equal? (list-merge! > (list 9 7 5 3 1) (list))
+            '(9 7 5 3 1))
+    (fail 'list-merge!:nonempty:empty))
+
+(x-test (equal? (list-merge! > (list 9 7 5 3 1) (list 9 6 3 0))
+            '(9 9 7 6 5 3 3 1 0))
+    (fail 'list-merge!:nonempty:nonempty))
+
+(x-test (equal? (vector-merge > (vector) (vector))
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0))
+            '#(9 6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector))
+            '#(9 7 5 3 1))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0))
+            '#(9 9 7 6 5 3 3 1 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector))
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0))
+              v)
+            '#( 9  6  3  0 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector))
+              v)
+            '#( 9  7  5  3  1 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0))
+              v)
+            '#( 9  9  7  6  5  3  3  1  0 #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:0))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 0)
+              v)
+            '#( 9  6  3  0 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:0))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 0)
+              v)
+            '#( 9  7  5  3  1 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:0))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 0)
+              v)
+            '#( 9  9  7  6  5  3  3  1  0 #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:0))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2)
+              v)
+            '#(#f #f 9  6  3  0 #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2)
+              v)
+            '#(#f #f  9  7  5  3  1 #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2)
+              v)
+            '#(#f #f 9  9  7  6  5  3  3  1  0 #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+(x-test (equal? (vector-merge > (vector) (vector) 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0)
+            '#(9 6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2)
+            '#(5 3 1))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2)
+            '#(9 6 5 3 3 1 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0)
+              v)
+            '#(#f #f 9  6  3  0 #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2)
+              v)
+            '#(#f #f 5  3  1 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2)
+              v)
+            '#(#f #f  9   6  5  3  3  1  0 #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+(x-test (equal? (vector-merge > (vector) (vector) 0 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0 0)
+            '#(9 6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2 5)
+            '#(5 3 1))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2 5)
+            '#(9 6 5 3 3 1 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0 0)
+              v)
+            '#(#f #f 9  6  3  0 #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2 5)
+              v)
+            '#(#f #f 5  3  1 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2 5)
+              v)
+            '#(#f #f  9  6  5  3  3  1  0 #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+;;; Some tests are duplicated to make the pattern easier to discern.
+
+(x-test (equal? (vector-merge > (vector) (vector) 0 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0 0)
+            '#(9 6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2 4)
+            '#(5 3))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2 4)
+            '#(9 6 5 3 3 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0 0)
+              v)
+            '#(#f #f 9  6  3  0 #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2 4)
+              v)
+            '#(#f #f 5  3 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2 4)
+              v)
+            '#(#f #f  9  6  5  3  3  0 #f #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+(x-test (equal? (vector-merge > (vector) (vector) 0 0 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0 0 0)
+            '#(9 6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2 4 0)
+            '#(5 3))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2 4 0)
+            '#(9 6 5 3 3 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0 0 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0 0 0)
+              v)
+            '#(#f #f  9  6  3  0 #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2 4 0)
+              v)
+            '#(#f #f  5  3 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2 4 0)
+              v)
+            '#(#f #f  9  6  5  3  3  0 #f #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+(x-test (equal? (vector-merge > (vector) (vector) 0 0 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0 0 1)
+            '#(6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2 4 0)
+            '#(5 3))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2 4 1)
+            '#(6 5 3 3 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0 0 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0 0 1)
+              v)
+            '#(#f #f  6  3  0 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2 4 0)
+              v)
+            '#(#f #f  5  3 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2 4 1)
+              v)
+            '#(#f #f  6  5  3  3  0 #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+(x-test (equal? (vector-merge > (vector) (vector) 0 0 0 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0 0 1 4)
+            '#(6 3 0))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2 4 0 0)
+            '#(5 3))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2 4 1 4)
+            '#(6 5 3 3 0))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0 0 0 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0 0 1 4)
+              v)
+            '#(#f #f  6  3  0 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2 4 0 0)
+              v)
+            '#(#f #f  5  3 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2 4 1 4)
+              v)
+            '#(#f #f  6  5  3  3  0 #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+(x-test (equal? (vector-merge > (vector) (vector) 0 0 0 0)
+            '#())
+    (fail 'vector-merge:empty:empty))
+
+(x-test (equal? (vector-merge > (vector) (vector 9 6 3 0) 0 0 1 2)
+            '#(6))
+    (fail 'vector-merge:empty:nonempty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector) 2 4 0 0)
+            '#(5 3))
+    (fail 'vector-merge:nonempty:empty))
+
+(x-test (equal? (vector-merge > (vector 9 7 5 3 1) (vector 9 6 3 0) 2 4 1 2)
+            '#(6 5 3))
+    (fail 'vector-merge:nonempty:nonempty))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector) 2 0 0 0 0)
+              v)
+            '#(#f #f #f #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector) (vector 9 6 3 0) 2 0 0 1 2)
+              v)
+            '#(#f #f  6 #f #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:empty:nonempty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector) 2 2 4 0 0)
+              v)
+            '#(#f #f  5  3 #f #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:empty:2))
+
+(x-test (equal? (let ((v (make-vector 12 #f)))
+              (vector-merge! > v (vector 9 7 5 3 1) (vector 9 6 3 0) 2 2 4 1 2)
+              v)
+            '#(#f #f  6  5  3 #f #f #f #f #f #f #f))
+    (fail 'vector-merge!:nonempty:nonempty:2))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (equal? (list-delete-neighbor-dups char=? (list))
+            '())
+    (fail 'list-delete-neighbor-dups:empty))
+
+(x-test (equal? (list-delete-neighbor-dups char=? (list #\a))
+            '(#\a))
+    (fail 'list-delete-neighbor-dups:singleton))
+
+(x-test (equal? (list-delete-neighbor-dups char=? (list #\a #\a #\a #\b #\b #\a))
+            '(#\a #\b #\a))
+    (fail 'list-delete-neighbor-dups:nonempty))
+
+(x-test (equal? (list-delete-neighbor-dups! char=? (list))
+            '())
+    (fail 'list-delete-neighbor-dups!:empty))
+
+(x-test (equal? (list-delete-neighbor-dups! char=? (list #\a))
+            '(#\a))
+    (fail 'list-delete-neighbor-dups!:singleton))
+
+(x-test (equal? (list-delete-neighbor-dups! char=? (list #\a #\a #\a #\b #\b #\a))
+            '(#\a #\b #\a))
+    (fail 'list-delete-neighbor-dups!:nonempty))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-delete-neighbor-dups char=? v))
+            '#())
+    (fail 'vector-delete-neighbor-dups:empty))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (vector-delete-neighbor-dups char=? v))
+            '#(#\a))
+    (fail 'vector-delete-neighbor-dups:singleton))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (vector-delete-neighbor-dups char=? v))
+            '#(#\a #\b #\a))
+    (fail 'vector-delete-neighbor-dups:nonempty))
+
+(x-test (equal? (let ((v (vector)))
+              (list (vector-delete-neighbor-dups! char=? v) v))
+            '(0 #()))
+    (fail 'vector-delete-neighbor-dups!:empty))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (list (vector-delete-neighbor-dups! char=? v) v))
+            '(1 #(#\a)))
+    (fail 'vector-delete-neighbor-dups!:singleton))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (list (vector-delete-neighbor-dups! char=? v) v))
+            '(3 #(#\a #\b #\a #\b #\b #\a)))
+    (fail 'vector-delete-neighbor-dups!:nonempty))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-delete-neighbor-dups char=? v 0))
+            '#())
+    (fail 'vector-delete-neighbor-dups:empty:0))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (vector-delete-neighbor-dups char=? v 0))
+            '#(#\a))
+    (fail 'vector-delete-neighbor-dups:singleton:0))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (vector-delete-neighbor-dups char=? v 0))
+            '#(#\a #\b #\a))
+    (fail 'vector-delete-neighbor-dups:nonempty:0))
+
+(x-test (equal? (let ((v (vector)))
+              (list (vector-delete-neighbor-dups! char=? v 0) v))
+            '(0 #()))
+    (fail 'vector-delete-neighbor-dups!:empty:0))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 0) v))
+            '(1 #(#\a)))
+    (fail 'vector-delete-neighbor-dups!:singleton:0))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 0) v))
+            '(3 #(#\a #\b #\a #\b #\b #\a)))
+    (fail 'vector-delete-neighbor-dups!:nonempty:0))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-delete-neighbor-dups char=? v 0))
+            '#())
+    (fail 'vector-delete-neighbor-dups:empty:0))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (vector-delete-neighbor-dups char=? v 1))
+            '#())
+    (fail 'vector-delete-neighbor-dups:singleton:1))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (vector-delete-neighbor-dups char=? v 3))
+            '#(#\b #\a))
+    (fail 'vector-delete-neighbor-dups:nonempty:3))
+
+(x-test (equal? (let ((v (vector)))
+              (list (vector-delete-neighbor-dups! char=? v 0) v))
+            '(0 #()))
+    (fail 'vector-delete-neighbor-dups!:empty:0))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 1) v))
+            '(1 #(#\a)))
+    (fail 'vector-delete-neighbor-dups!:singleton:1))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 3) v))
+            '(5 #(#\a #\a #\a #\b #\a #\a)))
+    (fail 'vector-delete-neighbor-dups!:nonempty:3))
+
+(x-test (equal? (let ((v (vector)))
+              (vector-delete-neighbor-dups char=? v 0 0))
+            '#())
+    (fail 'vector-delete-neighbor-dups:empty:0:0))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (vector-delete-neighbor-dups char=? v 1 1))
+            '#())
+    (fail 'vector-delete-neighbor-dups:singleton:1:1))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (vector-delete-neighbor-dups char=? v 3 5))
+            '#(#\b))
+    (fail 'vector-delete-neighbor-dups:nonempty:3:5))
+
+(x-test (equal? (let ((v (vector)))
+              (list (vector-delete-neighbor-dups! char=? v 0 0) v))
+            '(0 #()))
+    (fail 'vector-delete-neighbor-dups!:empty:0:0))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 0 1) v))
+            '(1 #(#\a)))
+    (fail 'vector-delete-neighbor-dups!:singleton:0:1))
+
+(x-test (equal? (let ((v (vector #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 1 1) v))
+            '(1 #(#\a)))
+    (fail 'vector-delete-neighbor-dups!:singleton:1:1))
+
+(x-test (equal? (let ((v (vector #\a #\a #\a #\b #\b #\a)))
+              (list (vector-delete-neighbor-dups! char=? v 3 5) v))
+            '(4 #(#\a #\a #\a #\b #\b #\a)))
+    (fail 'vector-delete-neighbor-dups!:nonempty:3:5))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (equal? (vector-find-median < (vector) "knil")
+            "knil")
+    (fail 'vector-find-median:empty))
+
+(x-test (equal? (vector-find-median < (vector 17) "knil")
+            17)
+    (fail 'vector-find-median:singleton))
+
+(x-test (equal? (vector-find-median < (vector 18 1 12 14 12 5 18 2) "knil")
+            12)
+    (fail 'vector-find-median:8same))
+
+(x-test (equal? (vector-find-median < (vector 18 1 11 14 12 5 18 2) "knil")
+            23/2)
+    (fail 'vector-find-median:8diff))
+
+(x-test (equal? (vector-find-median < (vector 18 1 12 14 12 5 18 2) "knil" list)
+            (list 12 12))
+    (fail 'vector-find-median:8samelist))
+
+(x-test (equal? (vector-find-median < (vector 18 1 11 14 12 5 18 2) "knil" list)
+            (list 11 12))
+    (fail 'vector-find-median:8difflist))
+
+(x-test (equal? (vector-find-median < (vector 7 6 9 3 1 18 15 7 8) "knil")
+            7)
+    (fail 'vector-find-median:9))
+
+(x-test (equal? (vector-find-median < (vector 7 6 9 3 1 18 15 7 8) "knil" list)
+            7)
+    (fail 'vector-find-median:9list))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-select! < v 0))
+            19)
+    (fail 'vector-select!:singleton:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 0))
+            3)
+    (fail 'vector-select!:ten:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 2))
+            9)
+    (fail 'vector-select!:ten:2))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 8))
+            22)
+    (fail 'vector-select!:ten:8))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 9))
+            23)
+    (fail 'vector-select!:ten:9))
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-select! < v 0 0))
+            19)
+    (fail 'vector-select!:singleton:0:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 0 0))
+            3)
+    (fail 'vector-select!:ten:0:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 2 0))
+            9)
+    (fail 'vector-select!:ten:2:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 8 0))
+            22)
+    (fail 'vector-select!:ten:8:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 9 0))
+            23)
+    (fail 'vector-select!:ten:9:0))
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-select! < v 0 0 1))
+            19)
+    (fail 'vector-select!:singleton:0:0:1))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 0 0 10))
+            3)
+    (fail 'vector-select!:ten:0:0:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 2 0 10))
+            9)
+    (fail 'vector-select!:ten:2:0:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 8 0 10))
+            22)
+    (fail 'vector-select!:ten:8:0:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 9 0 10))
+            23)
+    (fail 'vector-select!:ten:9:0:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 0 4 10))
+            3)
+    (fail 'vector-select!:ten:0:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 2 4 10))
+            13)
+    (fail 'vector-select!:ten:2:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 4 4 10))
+            21)
+    (fail 'vector-select!:ten:4:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 5 4 10))
+            23)
+    (fail 'vector-select!:ten:5:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 0 4 10))
+            3)
+    (fail 'vector-select!:ten:0:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 2 4 10))
+            13)
+    (fail 'vector-select!:ten:2:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 3 4 10))
+            13)
+    (fail 'vector-select!:ten:3:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 4 4 10))
+            21)
+    (fail 'vector-select!:ten:4:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 5 4 10))
+            23)
+    (fail 'vector-select!:ten:9:4:10))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 0 4 8))
+            9)
+    (fail 'vector-select!:ten:0:4:8))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 1 4 8))
+            13)
+    (fail 'vector-select!:ten:1:4:8))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 2 4 8))
+            13)
+    (fail 'vector-select!:ten:2:4:8))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-select! < v 3 4 8))
+            21)
+    (fail 'vector-select!:ten:3:4:8))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; this breaks in Chibi and Gauche, and it seems to be an interpretation of
+;; "This procedure places the smallest k elements ...", with k=0.
+;; We signal an error, just as the mentioned implementations,
+;;
+;; (x-test (equal? (let ((v (vector)))
+;;               (vector-separate! < v 0)
+;;               (vector-sort < (r7rs-vector-copy v 0 0)))
+;;             '#())
+;;     (fail 'vector-separate!:empty:0))
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-separate! < v 0)
+              (vector-sort < (r7rs-vector-copy v 0 0)))
+            '#())
+    (fail 'vector-separate!:singleton:0))
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-separate! < v 1)
+              (vector-sort < (r7rs-vector-copy v 0 1)))
+            '#(19))
+    (fail 'vector-separate!:singleton:1))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 0)
+              (vector-sort < (r7rs-vector-copy v 0 0)))
+            '#())
+    (fail 'vector-separate!:ten:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 3)
+              (vector-sort < (r7rs-vector-copy v 0 3)))
+            '#(3 8 9))
+    (fail 'vector-separate!:ten:3))
+
+;; this breaks in Chibi and Gauche, and it seems to be an interpretation of
+;; "This procedure places the smallest k elements ...", with k=0.
+;; We signal an error, just as the mentioned implementations,
+;;
+;; (x-test (equal? (let ((v (vector)))
+;;               (vector-separate! < v 0 0)
+;;               (vector-sort < (r7rs-vector-copy v 0 0)))
+;;             '#())
+;;     (fail 'vector-separate!:empty:0:0))
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-separate! < v 0 0)
+              (vector-sort < (r7rs-vector-copy v 0 0)))
+            '#())
+    (fail 'vector-separate!:singleton:0:0))
+
+(x-test (equal? (let ((v (vector 19)))
+              (vector-separate! < v 1 0)
+              (vector-sort < (r7rs-vector-copy v 0 1)))
+            '#(19))
+    (fail 'vector-separate!:singleton:1:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 0 0)
+              (vector-sort < (r7rs-vector-copy v 0 0)))
+            '#())
+    (fail 'vector-separate!:ten:0:0))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 3 0)
+              (vector-sort < (r7rs-vector-copy v 0 3)))
+            '#(3 8 9))
+    (fail 'vector-separate!:ten:3:0))
+
+;; this breaks in Chibi and Gauche, and it seems to be an interpretation of
+;; "This procedure places the smallest k elements ...", with k=0.
+;; We signal an error, just as the mentioned implementations,
+;;
+;; (x-test (equal? (let ((v (vector 19)))
+;;               (vector-separate! < v 0 1)
+;;               (vector-sort < (r7rs-vector-copy v 1 1)))
+;;             '#())
+;;     (fail 'vector-separate!:singleton:0:1))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 0 2)
+              (vector-sort < (r7rs-vector-copy v 2 2)))
+            '#())
+    (fail 'vector-separate!:ten:0:2))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 3 2)
+              (vector-sort < (r7rs-vector-copy v 2 5)))
+            '#(3 9 13))
+    (fail 'vector-separate!:ten:3:2))
+
+;; this breaks in Chibi and Gauche, and it seems to be an interpretation of
+;; "This procedure places the smallest k elements ...", with k=0.
+;; We signal an error, just as the mentioned implementations,
+;;
+;; (x-test (equal? (let ((v (vector)))
+;;               (vector-separate! < v 0 0 0)
+;;               (vector-sort < (r7rs-vector-copy v 0 0)))
+;;             '#())
+;;     (fail 'vector-separate!:empty:0:0:0))
+
+;; (x-test (equal? (let ((v (vector 19)))
+;;               (vector-separate! < v 0 1 1)
+;;               (vector-sort < (r7rs-vector-copy v 1 1)))
+;;             '#())
+;;     (fail 'vector-separate!:singleton:0:1:1))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 0 2 8)
+              (vector-sort < (r7rs-vector-copy v 2 2)))
+            '#())
+    (fail 'vector-separate!:ten:0:2:8))
+
+(x-test (equal? (let ((v (vector 8 22 19 19 13 9 21 13 3 23)))
+              (vector-separate! < v 3 2 8)
+              (vector-sort < (r7rs-vector-copy v 2 5)))
+            '#(9 13 13))
+    (fail 'vector-separate!:ten:3:2:8))
+
+
+
+
+(define (random-vector size)
+  (let ((v (make-vector size)))
+    (fill-vector-randomly! v (* 10 size))
+    v))
+
+
+(define (fill-vector-randomly! v range)
+  (let ((half (quotient range 2)))
+    (do ((i (- (vector-length v) 1) (- i 1)))
+	((< i 0))
+      (vector-set! v i (- (random-integer range) half)))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Sorting routines often have internal boundary cases or
+;;; randomness, so it's prudent to run a lot of tests with
+;;; different lengths.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (all-sorts-okay? m n)
+  (if (> m 0)
+      (let* ((v (random-vector n))
+             (v2 (vector-copy v))
+             (lst (vector->list v))
+             (ans (vector-sort < v2))
+             (med (cond ((= n 0) -97)
+                        ((odd? n)
+                         (vector-ref ans (quotient n 2)))
+                        (else
+                         (/ (+ (vector-ref ans (- (quotient n 2) 1))
+                               (vector-ref ans (quotient n 2)))
+                            2)))))
+        (define (dsort vsort!)
+          (let ((v2 (vector-copy v)))
+            (vsort! < v2)
+            v2))
+        (and (equal? ans (list->vector (list-sort < lst)))
+             (equal? ans (list->vector (list-stable-sort < lst)))
+             (equal? ans (list->vector (list-sort! < (list-copy lst))))
+             (equal? ans (list->vector (list-stable-sort! < (list-copy lst))))
+             (equal? ans (vector-sort < v2))
+             (equal? ans (vector-stable-sort < v2))
+             (equal? ans (dsort vector-sort!))
+             (equal? ans (dsort vector-stable-sort!))
+             (equal? med (vector-find-median < v2 -97))
+             (equal? v v2)
+             (equal? lst (vector->list v))
+             (equal? med (vector-find-median! < v2 -97))
+             (equal? ans v2)
+             (all-sorts-okay? (- m 1) n)))
+      #t))
+
+(define (test-all-sorts m n)
+  (x-test (all-sorts-okay? m n)
+      (fail (list 'test-all-sorts m n))))
+
+(for-each test-all-sorts
+          '( 3  5 10 10 10 20 20 10 10 10 10 10  10  10  10  10  10)
+          '( 0  1  2  3  4  5 10 20 30 40 50 99 100 101 499 500 501))


### PR DESCRIPTION
Hello @egallesio !

Here's SRFI-132.

Some highlights:

* core of the SRFI (merging and sorting) written in C
* vector sorting uses [timsort](https://github.com/python/cpython/blob/main/Objects/listsort.txt)
  - Seems more efficient than "quicksort reverting to insertion when n<16", for both random and totally ordered vectors (I have done some basic experiments)
* destructive list sorting uses almost no extra memory (only one tiny vector and a small stack);
  Naive merge sort is too slow to be practical
* vector merging uses galloping (explained in the link about timsort above)


Remarks:

* `vector-stable-sort!` uses timsort , with most of the small optimizations.
* `list-stable-sort` runs `list->vector`, then `vector-stable-sort!`, then `vector->list`. Easy, and it's very fast.
* `list-stable-sort!` -- this one was tricky. I thought that if someone is using an in-place sorting procedure, then maybe we shouldn't waste memory, so I did not do the "copy to vector, sort, then copy to a new list" thing. I have implemented timsort for lists (works quite well, since timsort is a variant of mergesort) but it still uses O(n) extra memory in the worst case.
* for the unstable variants, I didn't use anything different. I have tried, for example, quicksort for vectors (reverting to shellsort when n<16, n<32), but it isn't much better than timsort, at least for the data sets I used. So the "unstable" procedures actually perform a stable sort!
* The SRFI lists some procedures related to partitioning, selection etc at the end. Since these are not used in our implementation of sorting and there wasn't anything that would really need to be very fast, I adapted Scheme code from Chibi.

Some timings:

I have done experiments with almost-sorted, strangely-distributed, sorted, and  random vectors and lists.
For the random vector case, I have some timings here, that I collected just to make sure that what I was doing was not too slow, and it seems that the result isn't bad.

(I already knew heapsort would perform bad, but I wanted to know how much).

sort a random VECTOR of length 10_000_000:

| system/algorithm | time (s) | remark |
| --- | --- | --- |
| STklos heapsort  (pure)       | 25.1 | |
| STklos quicksort (pure)           | 14.7 | |
| STklos quicksort (+shell when <16)  | 12.3 | |
| STklos quicksort (+shell when <32)  | 12.1 | |
| | | |
| STklos timsort (destructive)    | 12.5 |   |
| | | |
| Chibi  (destructive)      | 3.5 | fastest! |
| Chibi  (non-destructive)      | 4.4 | fastest! |
| Chicken (destructive)         | 27.5  | (REPL, interpreted) |
| Chicken (destructive)         | 22.8  | (compiled) |
| Chicken (non-destructive)         | 26.7  | (REPL, interpreted) |
| Chicken (non-destructive)         | 29.2  | (compiled) |
| Gambit  (destructive)      | 25.6 | |
| Gambit  (non-destructive)      | 25.6 | |
| Gauche  (destructive)  | 71.6 | |
| Gauche  (non-destructive)  | 70.2 | |
| Racket | 10.1 | `vector-sort`, not SRFI-132 |
| Sagittarius (destructive) |  56.7 | |
| Sagittarius (non-destructive) | 58.3 | |
| SBCL `sort` | 11.2|  REPL, not optimized |
| SBCL `stable-sort` | 4.2 | REPL, not optimized. stable faster than unstable sort! (for a random vector) |

The Chibi timing is impressive - it's not that much faster than others with complex comparison predicates like `(lambda (a b) ...)`, but even then it's faster than all others.

sort a random LIST of length 10_000_000:

| system/algorithm | time (s) | remark |
| --- | --- | --- |
| STklos mergesort   (find all runs first, then merge) | >1h | |
| | |
| STklos `list-stable-sort` (non-destructive) |       13 | |
| STklos timsort  (destructive)                          | 19 |  |
| | | |
| Chibi  (destructive)      | 4.1  | fastest! |
| Chibi  (non-destructive)      | 7.3  | fastest! |
| Chicken (destructive)         | 20.4  | (REPL, interpreted) |
| Chicken (non-destructive)         | 178.1  | (REPL, interpreted) |
| Chicken (destructive)         | 19.1  | (compiled) |
| Chicken (non-destructive)         | 157  | (compiled) |
| Gambit (descructive)    | 31.4 | |
| Gambit (non-descructive)    | 31.2 | |
| Gauche                             | 65 | |
| Gauche  (non-destructive)  | 67.7 | |
| Racket | 11.3 | `sort` |
| Sagittarius (destructive) | 53.1 | |
| Sagittarius (non-destructive) | 57.2 | |
| SBCL `sort` | 8.7 | REPL, not optimized |
| SBCL `stable-sort` | 8.6 | REPL, not optimized |

And this SRFI comes with extensive tests (and passes all of them!)

