### PR TITLE
let-values: accept single variable in binding

### DIFF
--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -139,7 +139,8 @@ is
       ;; Verify that the binding seem correct
       (unless (and (list? binding)
                    (= (length binding) 2)
-                   (pair? (car binding)))
+                   (or (pair? (car binding))
+                       (symbol? (car binding))))
         (error 'let-values "incorrect binding ~S" binding))
       ;; Verify that the defined variables are unique
       (for-each* (lambda (x)


### PR DESCRIPTION
Just as one can do

(let-values (( (a . b) (values 1 2 3 4) )) b)
 => (2 3 4)

It should be possible to do

(let-values ((x (values 1 2 3))) x)

which should bind x to (1 2 3), similar to what we have in lambda formals, ((lambda x x) 1 2 3) => (1 2 3).

This PR seems to fix it, and doesn't break anything (tests still pass).