### PR TITLE
printlist_star: don't access CDR if it's not a cons

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -351,7 +351,7 @@ static void printlist_star(SCM exp, SCM port, int mode, cycles *c)
   if (pretty_quotes) {
     /* Special case for pretty printing of quoted expressions */
     s = STk_quote2str(CAR(exp));
-    if (s && !NULLP(CDR(exp)) && NULLP(CDR(CDR(exp)))) {
+    if (s && !NULLP(CDR(exp)) && CONSP(CDR(exp)) && NULLP(CDR(CDR(exp)))) {
       STk_puts(s, port);
       print_cycle(CAR(CDR(exp)), port, mode, c);
       return;


### PR DESCRIPTION
@egallesio - is this the right fix for issue #96 ?

It seems to fix the crash, and passes all tests, but I'm not sure if there is some pretty-printing aspect that was lost with this patch.