### PR TITLE
Use unicode in hash stats histogram

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -158,13 +158,21 @@ static void hash_stats(struct hash_table_obj *h, SCM port)
 {
   int i, j, more, len, count[_MAX_COUNT] = {0};
 
+  /* If we're using unicode, we can draw a nicer histogram bar... */
+  char *bar_char;
+  if (STk_use_utf8)
+      bar_char = "█"; /* Other interesting options: 🮘 🮕 🮈 🮉 🮔 🭬 ═ */
+  else
+      bar_char = "#";
+
   STk_fprintf(port, "Hash table statistics\n");
   more = 0;
   for (i = 0; i < HASH_NBUCKETS(h); i++) {
     len = STk_int_length(HASH_BUCKETS(h)[i]);
 
     STk_fprintf(port, "%d: ", i);
-    for (j = 0; j < len; j++) STk_putc('#', port);
+    for (j = 0; j < len; j++)
+        STk_fprintf(port,bar_char);
     STk_putc('\n', port);
 
     if (len < _MAX_COUNT)


### PR DESCRIPTION
Hi @egallesio !

I thought we could put some nicer histogram bars in `hash-table-stats`:

We check if we're using Unicode, and if so, we use some pretty unicode box instead of '#' to make the histogram.

```
stklos> (hash-table-stats x)
Hash table statistics
0: 
1: █
2: ███
3: █
  5 entries in table, 4 buckets (ratio 1.25)
Repartition
  1 buckets with 0 entries
  2 buckets with 1 entries
  1 buckets with 3 entries
```

Other interesting characters that could be used are 🮘 🮕 🮈 🮉 🮔 🭬 ═ :

🮘🮘🮘
🮕🮕🮕🮕
🮈🮈🮈🮈🮈
🮉🮉🮉🮉🮉
🮔🮔🮔🮔🮔
🭬🭬🭬
════

If you want I can change thee PR to use one of those.
