### PR TITLE
SRFI-214: change to R7RS library

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -127,7 +127,6 @@ SRC_STK = bigloo-support.stk  \
           srfi-190.stk        \
           srfi-196.stk        \
           srfi-207.stk        \
-          srfi-214.stk        \
           srfi-216.stk        \
           srfi-217.stk        \
           srfi-223.stk        \
@@ -194,7 +193,6 @@ scheme_OBJS = compfile.ostk     \
           srfi-190.ostk         \
           srfi-196.ostk         \
           srfi-207.ostk         \
-          srfi-214.ostk         \
           srfi-216.ostk         \
           srfi-217.ostk         \
           srfi-223.ostk         \

--- a/lib/srfi/214.stk
+++ b/lib/srfi/214.stk
@@ -1,5 +1,5 @@
 ;;;;
-;;;; srfi-214.stk         -- SRFI-214: Flexvectors
+;;;; 214.stk         -- SRFI-214: Flexvectors
 ;;;;
 ;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
 ;;;;
@@ -45,10 +45,10 @@
 ;;;;
 ;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
 ;;;;    Creation date: 05-Sep-2021 08:23
-;;;; Last file update: 17-Sep-2021 13:11 (eg)
+;;;; Last file update: 10-Nov-2021 05:33 (jpellegrini)
 ;;;;
 
-(define-module SRFI-214
+(define-module srfi/214
   (export ; Constructors
           make-flexvector flexvector
           flexvector-unfold flexvector-unfold-right
@@ -782,7 +782,4 @@
 
 )
 
-(select-module STklos)
-(import SRFI-214)
-
-(provide "srfi-214")
+(provide "srfi/214")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -33,11 +33,11 @@ SO = @SH_SUFFIX@
 #
 SRC_STK   = 1.stk 2.stk 4.stk 5.stk 6.stk 7.stk 8.stk 9.stk 10.stk \
             11.stk 13.stk 14.stk 16.stk 17.stk 18.stk \
-            22.stk 23.stk 26.stk 28.stk 29.stk
+            22.stk 23.stk 26.stk 28.stk 29.stk 214.stk
 
 SRC_OSTK = 1.ostk 2.ostk 4.ostk 5.ostk 6.ostk 7.ostk 8.ostk 9.ostk 10.ostk \
            11.ostk 13.ostk 14.ostk 16.ostk 17.ostk 18.ostk \
-           22.ostk 23.ostk 26.ostk 28.ostk 29.ostk
+           22.ostk 23.ostk 26.ostk 28.ostk 29.ostk 214.ostk
 #
 # SRFIs written in C and Scheme
 #


### PR DESCRIPTION
Hello @egallesio !
I have migrated one SRFI to the new R7RS `define-library` implementation. Tell me if this is OK, and I'll try to migrate others.