### PR TITLE
Implement some algebraic simplification

### DIFF
--- a/lib/peephole.stk
+++ b/lib/peephole.stk
@@ -203,7 +203,7 @@
                                           (this-arg1 code)
                                           (next-arg1 code))))
 
-             ;; [GLOBAL-REF, TAIL-INVOKE] => GREF-TAIL(INVOKE
+             ;; [GLOBAL-REF, TAIL-INVOKE] => GREF-TAIL-INVOKE
              ((and (eq? i1 'GLOBAL-REF) (eq? i2 'TAIL-INVOKE))
               (replace-2-instr code (list 'GREF-TAIL-INVOKE
                                           (this-arg1 code)
@@ -228,13 +228,24 @@
              ;; Algebraic simplification
              ;; 0 + x => x
              ;; 1 * x => x
+             ;;
+             ;; [IN-SINT-ADD2 0]   => nil
+             ;; [IN-SINT-FXADD2 0] => nil
+             ;; [IN-SINT-DIV2 1]   => nil
+             ;; [IN-SINT-MUL2 1]   => nil
+             ;; [IN-SINT-FXMUL2 1] => nil
+             ;;
+             ;; remark: 0.0 and 1.0 are *not* considered because they may
+             ;;         change the type of the result.
+             ;;         (let ((a 4)) (+ a 0.0))  =>  4.0
+             ;;         'a' was exact, became inexact...
              ((or (and (memq i2 '(IN-SINT-ADD2 IN-SINT-FXADD2))
                        (eq? (next-arg1 code) 0))
                   (and (eq? i2  'IN-SINT-DIV2)
                        (eq? (next-arg1 code) 1))
                   (and (memq i2 '(IN-SINT-MUL2 IN-SINT-FXMUL2))
                        (eq? (next-arg1 code) 1)))
-               (set-cdr! code (cddr code)))
+              (set-cdr! code (cddr code)))   ;; skip the *second* instruction!
 
              (else ;; No optimization; goto next instruction
               (set! code (cdr code))))))

--- a/lib/peephole.stk
+++ b/lib/peephole.stk
@@ -225,6 +225,17 @@
              ((and (eq? i1 'RETURN) (eq? i2 'RETURN))
               (replace-2-instr code (list 'RETURN)))
 
+             ;; Algebraic simplification
+             ;; 0 + x => x
+             ;; 1 * x => x
+             ((or (and (memq i2 '(IN-SINT-ADD2 IN-SINT-FXADD2))
+                       (eq? (next-arg1 code) 0))
+                  (and (eq? i2  'IN-SINT-DIV2)
+                       (eq? (next-arg1 code) 1))
+                  (and (memq i2 '(IN-SINT-MUL2 IN-SINT-FXMUL2))
+                       (eq? (next-arg1 code) 1)))
+               (set-cdr! code (cddr code)))
+
              (else ;; No optimization; goto next instruction
               (set! code (cdr code))))))
       ;; Loop again on the same instruction


### PR DESCRIPTION
I know I said I'd be working on the macros, but... This one is so simple that I had to implement it :)


Don't operate on identities in two-args + and *

```
(+   0 a) => a
(fx+ 0 a) => a
(*   1 a) => a
(fx* 1 a) => a
```

The n-args case would need to be handled in code generation, though...

Without the optimization:

```
stklos> (disassemble-expr ' (+ s (+ a 0)))

000:  GLOBAL-REF-PUSH      0
002:  GLOBAL-REF           1
004:  IN-SINT-ADD2         0
006:  IN-ADD2             
007:
```

With the optimization:
```
stklos> (disassemble-expr ' (+ s (+ a 0)))

000:  GLOBAL-REF-PUSH      0
002:  GLOBAL-REF           1
004:  IN-ADD2             
005:
```

And:

```
stklos> (time
 (let ((s 0)
       (a 2))
   (dotimes (i 100_000_000)
     (set! s (+ s (+ a 0))))
   s))
Elapsed time: 9165.562 ms                                 <=== before optimization
200000000
```

```
stklos> (time
 (let ((s 0)
       (a 2))
   (dotimes (i 100_000_000)
     (set! s (+ s (+ a 0))))
   s))
Elapsed time: 7703.148 ms                                 <=== after optimization
200000000
```

I've repeated the timing 10 times, and it consistently gives something close to 1.5s difference.

Passes all tests.

