### PR TITLE
SRFIs 66 and 74: now R7RS libraries

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -93,10 +93,8 @@ SRC_STK = bigloo-support.stk  \
           srfi-54.stk         \
           srfi-59.stk         \
           srfi-61.stk         \
-          srfi-66.stk         \
           srfi-69.stk         \
           srfi-70.stk         \
-          srfi-74.stk         \
           srfi-89.stk         \
           srfi-94.stk         \
           srfi-96.stk         \
@@ -154,10 +152,8 @@ scheme_OBJS = compfile.ostk     \
           srfi-54.ostk          \
           srfi-59.ostk          \
           srfi-61.ostk          \
-          srfi-66.ostk          \
           srfi-69.ostk          \
           srfi-70.ostk          \
-          srfi-74.ostk          \
           srfi-89.ostk          \
           srfi-94.ostk          \
           srfi-96.ostk          \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -447,10 +447,8 @@ SRC_STK = bigloo-support.stk  \
           srfi-54.stk         \
           srfi-59.stk         \
           srfi-61.stk         \
-          srfi-66.stk         \
           srfi-69.stk         \
           srfi-70.stk         \
-          srfi-74.stk         \
           srfi-89.stk         \
           srfi-94.stk         \
           srfi-96.stk         \
@@ -507,10 +505,8 @@ scheme_OBJS = compfile.ostk     \
           srfi-54.ostk          \
           srfi-59.ostk          \
           srfi-61.ostk          \
-          srfi-66.ostk          \
           srfi-69.ostk          \
           srfi-70.ostk          \
-          srfi-74.ostk          \
           srfi-89.ostk          \
           srfi-94.ostk          \
           srfi-96.ostk          \

--- a/lib/srfi/66.stk
+++ b/lib/srfi/66.stk
@@ -24,7 +24,14 @@
 ;;;; Last file update:  3-Apr-2007 23:25 (eg)
 ;;;;
 
-(require "srfi-4")
+(define-module srfi/66
+
+(import  (srfi 4))
+
+(export u8vector-copy!
+        u8vector-copy
+        u8vector=?
+        u8vector-compare)
 
 (define (u8vector-copy! source source-start target target-start count)
   (if (>= source-start target-start)
@@ -69,5 +76,6 @@
                (cond ((< elt1 elt2) -1)
                      ((> elt1 elt2)  1)
                      (else (Loop (+ i 1)))))))))))
+)
 
-(provide "srfi-66")
+(provide "srfi/66")

--- a/lib/srfi/74.stk
+++ b/lib/srfi/74.stk
@@ -35,13 +35,12 @@
 ; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ; SOFTWARE.
 
-; This uses SRFIs 23, 26, 60, and 66
 
-(require "srfi-26")
-(require "srfi-66")
-
-(define-module SRFI-74
-  (import (srfi 4) (srfi 60))
+(define-module srfi/74
+  (import (srfi 4) 
+          (srfi 26)
+          (srfi 60)
+          (srfi 66))
   (export endianness blob? make-blob blob-length
           blob-u8-ref blob-s8-ref
           blob-u8-set! blob-s8-set!
@@ -76,9 +75,9 @@
 
 (define-syntax endianness
   (syntax-rules (little big native)
-    ((endianness little) (in-module SRFI-74 *endianness/little*))
-    ((endianness big)    (in-module SRFI-74 *endianness/big*))
-    ((endianness native) (in-module SRFI-74 *endianness/native*))))
+    ((endianness little) (in-module srfi/74 *endianness/little*))
+    ((endianness big)    (in-module srfi/74 *endianness/big*))
+    ((endianness native) (in-module srfi/74 *endianness/native*))))
 
 (define blob? u8vector?)
 
@@ -279,6 +278,5 @@
 
 )
 ;; ----------------------------------------------------------------------
-(select-module stklos)
-(import SRFI-74)
-(provide "srfi-74")
+
+(provide "srfi/74")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -54,6 +54,8 @@ SRC_STK   = 1.stk   \
             31.stk  \
             60.stk  \
             64.stk  \
+            66.stk  \
+            74.stk  \
             170.stk \
             214.stk
 
@@ -80,6 +82,8 @@ SRC_OSTK =  1.ostk   \
             31.ostk  \
             60.ostk  \
             64.ostk  \
+            66.ostk  \
+            74.ostk  \
             170.ostk \
             214.ostk
 

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -367,6 +367,8 @@ SRC_STK = 1.stk   \
             31.stk  \
             60.stk  \
             64.stk  \
+            66.stk  \
+            74.stk  \
             170.stk \
             214.stk
 
@@ -393,6 +395,8 @@ SRC_OSTK = 1.ostk   \
             31.ostk  \
             60.ostk  \
             64.ostk  \
+            66.ostk  \
+            74.ostk  \
             170.ostk \
             214.ostk
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -267,7 +267,7 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/extraconf.h.in \
 	$(srcdir)/stklosconf.h.in $(top_srcdir)/depcomp \
-	$(top_srcdir)/mkinstalldirs TODO
+	$(top_srcdir)/mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@


### PR DESCRIPTION
74 uses 66, so I converted both at once. Sorry, should have been two commits, but it's already done...