### PR TITLE
Document MOP

### DIFF
--- a/lib/object.stk
+++ b/lib/object.stk
@@ -158,9 +158,87 @@
 ;;;
 ;;; Classes
 ;;;
+#|
+<doc EXT class-name
+ * (class-name c)
+ *
+ * Returns the name of the class |c|. Note that |c| must be a class
+ * (not an object).
+ *
+ * @lisp
+ * (define-class <A> () ())
+ * (define X <A>)
+ * (class-name X) => <A>
+ * @end lisp
+ *
+ * The result is a symbol, not a string.
+doc>
+|#
 (define (class-name C)
   (if (class? C) (slot-ref C 'name) (%error-bad-class 'class-name C)))
 
+#|
+<doc EXT class-direct-supers class-direct-subclasses class-precedence-list class-slots class-direct-slots
+ * (class-direct-supers c)
+ * (class-direct-subclasses c)
+ * (class-precedence-list c)
+ * (class-slots c)
+ * (class-direct-slots c)
+ *
+ * |Class-direct-supers| and |class-direct-subclasses| return a list with
+ * all direct superclasses or subclasses of |c|, which must be a class
+ * (not object, string or symbol).
+ *
+ * |class-precedence-list| returns the precedence list for class |c|. If
+ * |c| is a superclass of several classes, this list shows what precedence
+ * each superlclass has when resolving names of attributes and methods in
+ * |c|.
+ *
+ * @lisp
+ * (define-class <A> () (slot-one slot-two))
+ * (define-class <B> () ())
+ * (define-class <C> (<A> <B>) (slot-one))
+ * (define-class <D> (<A>) ())
+ *
+ * (class-direct-supers <C>)
+ *      => (#[<class> <A> 7fbc628e6ba0] #[<class> <B> 7fbc626edb10])
+ * (class-direct-supers <D>)
+ *      => (#[<class> <A> 7fbc628e6ba0])
+ * (class-direct-subclasses <A>)
+ *      =>(#[<class> <D> 7fbc6270f2a0] #[<class> <C> 7fbc62704630])
+ * (class-precedence-list <C>)
+ *      =>(#[<class> <C> 7fbc62704630]
+ *         #[<class> <A> 7fbc628e6ba0]
+ *         #[<class> <B> 7fbc626edb10]
+ *         #[<class> <object> 7fbc62aacf30]
+ *         #[<class> <top> 7fbc62aacf60])
+ * @end lisp
+ *
+ * |Slot-one| in class |<C>| refers to the slot defined in |<C>| (because
+ * it is present in both |<A>| and |<C>|, but |<C>| has precedence over
+ * |<A>|). |Slot-two| in |<C>| can only be the one defined in |<A>|.
+ *
+ * The items retruned in the list are not class names; they are the
+ * classes themselves. Use |class-name| to obtain their names.
+ *
+ * |Class-slots| returns a list with the names of the slots in class |c|,
+ * including those inherited from other classes.
+ *
+ * @lisp
+ * (class-slots <A>) => (slot-one slot-two)
+ * (class-slots <C>) => (slot-one slot-two slot-one)
+ * @end lisp
+ *
+ * The names of slots in the list are symbols.
+ *
+ * |Class-direct-slots| returns a list with the names of the slots that
+ * were defined directly in the class (excluding the inherited slots).
+ *
+ * @lisp
+ * (class-direct-slots <C>) => (slot-one)
+ * @end lisp
+doc>
+|#
 (define (class-direct-supers C)
   (if (class? C)
       (slot-ref C 'direct-supers)
@@ -194,6 +272,31 @@
 ;;;
 ;;; Slots
 ;;;
+#|
+<doc EXT slot-definition-name slot-definition-options slot-definition-allocation slot-definition-getter slot-definition-setter slot-definition-accessor slot-definition-init-form slot-definition-init-keyword
+ * (slot-definition-name s)
+ * (slot-definition-options s)
+ * (slot-definition-allocation s)
+ * (slot-definition-getter s)
+ * (slot-definition-setter s)
+ * (slot-definition-accessor s)
+ * (slot-definition-init-form s)
+ * (slot-definition-init-keyword s)
+ *
+ * These procedures operate on slot definitions (the lists included in class
+ * definitions). They return the slot name, the list of options, the slot
+ * allocation, and the getter, setter, accessor, init-form and init-keyword
+ * of a slot, as returned by |class-slots| or by |class-slot-definition|.
+ *
+ * @lisp
+ * (slot-definition-name '(x #:init-form 0  #:accessor x))       => x
+ * (slot-definition-accessor '(x #:init-form 0  #:accessor x))   => x
+ * (slot-definition-allocation '(x #:init-form 0  #:accessor x)) => instance
+ * (slot-definition-options '(x #:init-form 0 #:accessor x))
+ *  => (#:init-form 0 #:accessor x)
+ * @end lisp
+doc>
+|#
 (define (slot-definition-name s)
   (if (pair? s) (car s) s))
 
@@ -222,6 +325,30 @@
 (define (slot-definition-init-keyword s)
   (and (pair? s) (key-get (cdr s) :init-keyword #f)))
 
+
+;; TODO: slot-init-function.
+#|
+<doc EXT class-slot-definition
+ * (class-slot-definition c s)
+ *
+ * |Class-slot-definition| returns the definition of slot |s|
+ * in class |c|. It is the same item in the list returned by
+ * |(class-slots c)|.
+ *
+ * @lisp
+ * (define-class <A> ()
+ *   ((slot-one :init-form 'none :getter get-one)
+ *    (slot-two :init-form 'nada :init-keyword :two)))
+ *
+ * (class-slot-definition <A> 'slot-two)
+ *   => (slot-two #:init-form 'nada #:init-keyword #:two)
+ *
+ * (class-slots <A>)
+ *   => ((slot-one #:init-form 'none #:getter get-one)
+ *       (slot-two #:init-form 'nada #:init-keyword #:two))
+ * @end lisp
+doc>
+|#
 (define (slot-init-function c s)
   (let ((s (slot-definition-name s)))
     (cadr (assq s (slot-ref c 'getters-n-setters)))))
@@ -344,6 +471,26 @@ doc>
 ;                       M e t a c l a s s e s   s t u f f
 ;
 ;=============================================================================
+#|
+<doc EXT ensure-metaclass
+ * (ensure-metaclass class-list)
+ *
+ * Given a list of classes, returns a class which is a superclass of all
+ * the classes given. This superclass will be built so that it is a subclass
+ * of the most specific classes posible.
+ *
+ * @lisp
+ * (define-class <A> () ())
+ * (define-class <B> (<A>) ())
+ * (define-class <C> () ())
+ *
+ * (ensure-metaclass (list <B> <A>)) => #[<class> <B> 7fea2b8a3c30]
+ * (define m (ensure-metaclass (list <B> <A> <C>)))
+ * (class-direct-supers m)
+ *   => (#[<class> <B> 7fea2b8a3c30] #[<class> <C> 7fea2b8afb40])
+ * @end lisp
+doc>
+|#
 (define ensure-metaclass-with-supers
   (let ((table-of-metas '()))
     (lambda (meta-supers)
@@ -510,6 +657,136 @@ doc>
 ;                       D e f i n e - m e t h o d
 ;
 ;=============================================================================
+
+#|
+<doc EXT define-method define-generic next-method
+ * (define-generic gf)
+ * (define-method gf args body)
+ * (next-method)
+ *
+ * The macro |define-method| creates a generic method that will be added to a
+ * generic function |gf|, having arguments |args| and body |body|.
+ * |Args| is a list of arguments, and each argument can be either a single
+ * symbol (the argument name) or an argumetn specification.
+ * In its simplest form, a generic method behaves a lot like an ordinary
+ * procedure:
+ * @lisp
+ * (define-method square (x)
+ *   (* x x))
+ *
+ * (square 10)  => 100
+ * @end lisp
+ * In the above example, |x| is the only argument to the method, and it is
+ * specified as a single symbol, which means that *_any_* type of argument will
+ * be matched and this method will be used.
+ *
+ * An argument may also be specified in the form of a list with two elements:
+ * the argument name and its class. The method will only be applicable when its
+ * arguments are of the specified classes (or types).
+ * @lisp
+ * (define-method ++ ( (x <string>) (y <string>) )
+ *   (string-append x y))
+ *
+ * (define-method ++ ( (x <number>) (y <number>) )
+ *   (+ x y))
+ *
+ * (define-method ++ ( (x <string>) (y <number>) )
+ *   (format #f (string-append x "~a") y))
+ *
+ * (++ "abc" "def")   => "abcdef"
+ * (++ 2 3.5)         => 5.5
+ * (++ 2 2-3i)        => 4-3i
+ * (++ "number: " 10) => "number: 10"
+ * (++ 3 "wrong")     => error
+ * @end lisp
+ * In this example, three methods are added to the generic function |++|,
+ * and when the generic function is called, the appropriate method is chosen.
+ * When no method is applicable, an error is signaled.
+ *
+ * The classes matched in the example are |<string>| and |<number>|, but any
+ * class can be used. All Scheme types are built-in classes in STklos:
+ *
+ * <boolean>  <null>
+ * <char>     <object>
+ * <class>    <pair>
+ * <complex>  <procedure>
+ * <eof>      <rational>
+ * <integer>  <real>
+ * <list>     <symbol>
+ * <method>   <vector>
+ *
+ * User-defined classes can also be used (and this is the main original use case
+ * for generic functions). A very simple example follows.
+ * @lisp
+ * (define-class <figure> ()
+ *   ((pos-x :getter pos-x :init-keyword :pos-x)
+ *    (pos-y :getter pos-y :init-keyword :pos-y)))
+ *
+ * (define-class <circle> (<figure>)
+ *   ((radius :getter radius :init-keyword :radius)))
+ *
+ * (define-class <square> (<figure>)
+ *   ((side :getter side :init-keyword :side)))
+ *
+ * (define-method describe-figure ( (c <circle>) )
+ *   (format #f "A circle at (~a, ~a), with radius ~a.~%"
+ *           (pos-x c)
+ *           (pos-y c)
+ *           (radius c)))
+ *
+ * (define-method describe-figure ( (s <square>) )
+ *   (format #f "A square centered at (~a, ~a), with side ~a.~%"
+ *           (pos-x s)
+ *           (pos-y s)
+ *           (side s)))
+ *
+ * (define sq (make <square> :pos-x 1 :pos-y 2 :side 10))
+ * (define ci (make <circle> :pos-x 2 :pos-y 2 :radius 5))
+ *
+ * (describe-figure sq)
+ *   => "A square centered at (1, 2), with side 10.\n"
+ *
+ * (describe-figure ci)
+ *   => "A circle at (2, 2), with radius 5.\n"
+ * @end lisp
+ * Generic methods can be created with different number of arguments, and that
+ * will also be one criterion to match the method.
+ *
+ * @lisp
+ * (define-method process (a b c) (+ a b c))
+ * (define-method process (a b) (* a b))
+ *
+ * (process 2 3)   => 6
+ * (process 2 3 4) => 9
+ * @end lisp
+ *
+ * Inside a method, one can use the syntax (next-method)  to call the next
+ * applicable method.
+ * @lisp
+ * (define-method class-list ((obj <integer>))  (cons 'integer  (next-method)))
+ * (define-method class-list ((obj <rational>)) (cons 'rational (next-method)))
+ * (define-method class-list ((obj <real>))     (cons 'real     (next-method)))
+ * (define-method class-list ((obj <complex>))  (cons 'complex  (next-method)))
+ * (define-method class-list ((obj <number>))   (cons 'number   (next-method)))
+ * (define-method class-list ((obj <top>))      (list 'top))
+ *
+ * (class-list 2.3)  => (real complex number top)
+ * (class-list 2)    => (integer rational real complex number top)
+ * (class-list 1-2i) => (complex number top)
+ * @end lisp
+ * The generic function is created the first time a generic method
+ * with the name of that function is created. Optionally, for the sake of
+ * documentation, it is possible also to define the generic function before
+ * the methods:
+ * @lisp
+ * (define-generic describe-figure)
+ * @end lisp
+doc>
+|#
+
+;; FIXME: classes are missing?
+;; <port>
+;; <bytevector>
 
 ;==== Add-method!
 (define (%method-specializers-equal? gf m1 m2)
@@ -1081,6 +1358,34 @@ doc>
 ;
 ;=============================================================================
 
+#|
+<doc allocate-instance make-instance
+ * (allocate-instance c init-args)
+ * (make-instance c)
+ * (make c)
+ *
+ * |Make-instance| creates and initializes an instance of class |c|.
+ * |Make| is the same as |make-instance|.
+ * |Allocate-instance| is similar, but only allocates the instance,
+ * without initializing it.
+ * |C| must be a class object, not a class name.
+ *
+ * @lisp
+ * (define-class <X> () ((xx :init-form 10)))
+ * (define my-x (make-instance <X>))
+ * (describe my-x)
+ * #[<X> 7fbd2e3075d0] is an an instance of class <X>.
+ * The only slot is:
+ *   xx = 10
+ *
+ *  (define my-other-x (allocate-instance <X> 20))
+ * (describe y)
+ * #[<X> 7fbd2e2bdab0] is an an instance of class <X>.
+ * The only slot is:
+ *      xx = #[unbound]
+ * @end lisp
+doc>
+|#
 (define-method allocate-instance ((class <class>) initargs)
   (%allocate-instance class))
 


### PR DESCRIPTION
Hi @egallesio !
Some more documentation :)
STklos implements a great object system with a MOP, and I'll try to document it little by little.
Some questions:

* What does `slot-init-function` do? It seems to always return the init form, independent of what argument I pass to it
* Shouldn't `slot-init-function` be called `class-slot-init-function`, since it also takes a class as argument?
* The names `class-direct-supers` `class-direct-subclasses` seem a bit inconsistent.  Shouldn't those be either both abbreviated (`class-direct-supers` `class-direct-subs`) or both extended/complete (`class-direct-superclasses` `class-direct-subclasses`)?

