### PR TITLE
Some fixnum optimizations

### DIFF
--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -503,7 +503,7 @@ DEFINE_PRIMITIVE("fx=?", fxeq, vsubr, (int argc, SCM *argv))
     if (argc == 1) return STk_true;
     for (p = *argv--; --argc; p=*argv,argv--) {
         ensure_fx(*argv);
-        if (p == *argv) return STk_false;
+        if (p != *argv) return STk_false;
     }
   return STk_true;
 }

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -99,6 +99,9 @@ extern "C"
 #define AS_LONG(x)              ((unsigned long) (x))
 #define AS_SCM(x)               ((SCM) ((unsigned long) (x)))
 
+/* UNTAG removes the tag bits. It is useful in optimized fixnum
+   operations (see fixnum.c). --jpellegrini */
+#define UNTAG(x)                (((long) x) & (~ ((unsigned long) 3)))
 
 /*===========================================================================*\
  *

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -602,6 +602,8 @@ EXTERN_PRIMITIVE("fx*",        fxtime,  subr2, (SCM o1, SCM o2));
 EXTERN_PRIMITIVE("fxquotient", fxdiv,   subr2, (SCM o1, SCM o2));
 int STk_init_fixnum(void);
 
+/* TAG_FIXNUM forces a fixnum tag on x. */
+#define TAG_FIXNUM(x)      ((UNTAG(x)) | 1)
 
 /*
   ------------------------------------------------------------------------------


### PR DESCRIPTION
Hi @egallesio !
I'm not sure about this one. It would maybe make fixnum operations a bit faster, but also makes the code a little less readable.
Also, the optimizations in `fxodd?` and `fxeven?` look a bit like something that "a smart compiler would figure out anyway"...
But I didn't check the generated assembly for them. And I didn't run any benchmarks this time either... 

Commit message:

Try to avoid tagging/untagging in some places.

A new macro, `UNTAG`, was created that just clears the two first bits of a word.