### PR TITLE
Update and fix Docker image building

### DIFF
--- a/etc/Docker/Dockerfile.latest
+++ b/etc/Docker/Dockerfile.latest
@@ -14,10 +14,10 @@
 # 
 
 # ---------- Build stage
-FROM alpine:3.11 AS build
+FROM alpine:3.15 AS build
 RUN apk update && \
     apk add build-base automake autoconf git \
-        gc-dev gmp-dev libffi-dev pcre-dev 
+        gc-dev gmp-dev libffi-dev pcre-dev readline-dev
 
 WORKDIR /build
 RUN git clone https://github.com/egallesio/STklos.git stklos
@@ -30,7 +30,7 @@ RUN env CFLAGS='-O3' ./configure \
 RUN env TERM="dumb" make all tests install
 
 # ---------- Running stage
-FROM alpine:latest
+FROM alpine:3.15
 RUN apk update && \
     apk add gc gmp libffi pcre readline
 COPY --from=build /usr/local/ /usr/local/

--- a/etc/Docker/Dockerfile.stable
+++ b/etc/Docker/Dockerfile.stable
@@ -9,9 +9,9 @@
 # The image is created from a released version of STklos
 # The version number must be passed on the command line
 #
-# To build an image on your machine of STklos version 1.40,
+# To build an image on your machine of STklos version 1.70,
 # place yourself in this directory and type (don't forget the final dot)
-#    $ VERS=1.40
+#    $ VERS=1.70
 #    $ docker build --build-arg version=$VERS -f Dockerfile.stable -t stklos:$VERS .
 #
 # To run the image:
@@ -19,9 +19,9 @@
 #
 
 # ---------- Build stage
-FROM alpine:3.11 AS build
+FROM alpine:3.15 AS build
 RUN apk update && \
-    apk add build-base gc-dev gmp-dev libffi-dev pcre-dev git
+    apk add build-base gc-dev gmp-dev libffi-dev pcre-dev readline-dev git
 
 ARG version
 WORKDIR /build
@@ -37,7 +37,7 @@ RUN env CFLAGS=-O3 ./configure \
 RUN env TERM="dumb" make all tests install
 
 # ---------- Running stage
-FROM alpine:latest
+FROM alpine:3.15
 RUN apk update && \
     apk add gc gmp libffi pcre readline
 COPY --from=build /usr/local/ /usr/local/

--- a/etc/Docker/README.md
+++ b/etc/Docker/README.md
@@ -13,11 +13,11 @@ approximately 15Mb.
 **Example:**
 
 ```bash
-$ docker pull stklos/stklos:1.40          # grab the 1.40 version of STklos
-$ docker run -ti stklos/stklos:1.40       # and run it
+$ docker pull stklos/stklos:1.70          # grab the 1.70 version of STklos
+$ docker run -ti stklos/stklos:1.70       # and run it
 ...
 stklos> (version)
-"1.40"
+"1.70"
 stklos> (exit)
 ```
 


### PR DESCRIPTION
Hi @egallesio !

* Use same version of alpine for build and runtime.
  This fixes a problem with libffi not being found.

* Update alpine to 3.15.

* Update STklos to 1.70 in the docs.

There seems to be a problem with the current image builder. See issue #309 (I opened the issue as well as the PR so people looking for "the issue with docker" may find it easily)

Fixes #309 