### PR TITLE
SRFIs 113 and 128 now are R7RS libraries

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -99,10 +99,8 @@ SRC_STK = bigloo-support.stk  \
           srfi-94.stk         \
           srfi-96.stk         \
           srfi-100.stk        \
-          srfi-113.stk        \
           srfi-117.stk        \
           srfi-127.stk        \
-          srfi-128.stk        \
           srfi-129.stk        \
           srfi-130.stk        \
           srfi-134.stk        \
@@ -156,10 +154,8 @@ scheme_OBJS = compfile.ostk     \
           srfi-94.ostk          \
           srfi-96.ostk          \
           srfi-100.ostk         \
-          srfi-113.ostk         \
           srfi-117.ostk         \
           srfi-127.ostk         \
-          srfi-128.ostk         \
           srfi-129.ostk         \
           srfi-130.ostk         \
           srfi-134.ostk         \
@@ -270,7 +266,6 @@ recette.ostk: pretty-print.ostk
 slib.ostk: slib.stk STklos.init
 srfi-41.ostk: streams-derived.ostk streams-primitive.ostk
 streams-derived.ostk: streams-primitive.ostk
-srfi-113.ostk: srfi-128.ostk
 srfi-134.ostk: srfi-158.ostk
 srfi-217.ostk: trie.ostk
 

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -453,10 +453,8 @@ SRC_STK = bigloo-support.stk  \
           srfi-94.stk         \
           srfi-96.stk         \
           srfi-100.stk        \
-          srfi-113.stk        \
           srfi-117.stk        \
           srfi-127.stk        \
-          srfi-128.stk        \
           srfi-129.stk        \
           srfi-130.stk        \
           srfi-134.stk        \
@@ -509,10 +507,8 @@ scheme_OBJS = compfile.ostk     \
           srfi-94.ostk          \
           srfi-96.ostk          \
           srfi-100.ostk         \
-          srfi-113.ostk         \
           srfi-117.ostk         \
           srfi-127.ostk         \
-          srfi-128.ostk         \
           srfi-129.ostk         \
           srfi-130.ostk         \
           srfi-134.ostk         \
@@ -973,7 +969,6 @@ recette.ostk: pretty-print.ostk
 slib.ostk: slib.stk STklos.init
 srfi-41.ostk: streams-derived.ostk streams-primitive.ostk
 streams-derived.ostk: streams-primitive.ostk
-srfi-113.ostk: srfi-128.ostk
 srfi-134.ostk: srfi-158.ostk
 srfi-217.ostk: trie.ostk
 

--- a/lib/srfi/113.stk
+++ b/lib/srfi/113.stk
@@ -20,12 +20,11 @@
 
 
 
-(require "srfi-9")
 (require "srfi-69")
-(require "srfi-128")
 
-(define-module SRFI-113
-  (import SRFI-128)
+(define-module srfi/113
+  (import (srfi 9)
+          (srfi 128))
   
   ;(import (only chicken
   ;  include define-record-type define-record-printer
@@ -1358,6 +1357,5 @@
 
 )
 ;; ----------------------------------------------------------------------
-(select-module stklos)
-(import SRFI-113)
-(provide "srfi-113")
+
+(provide "srfi/113")

--- a/lib/srfi/128.stk
+++ b/lib/srfi/128.stk
@@ -1,5 +1,5 @@
 ;;;;
-;;;; srfi-128.stk		-- Implementation of SRFI-128
+;;;; 128.stk		-- Implementation of SRFI-128
 ;;;;
 ;;;; Copyright © 2020 Jeronimo Pellegrini - <j_p@aleph0.info>
 ;;;;
@@ -46,12 +46,12 @@
 ;;;;
 ;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
 ;;;;    Creation date: 08-Jul-2020 13:21 (jpellegrini)
-;;;; Last file update: 26-Oct-2021 20:07 (eg)
+;;;; Last file update: 04-Dec-2021 10:22 (jpellegrini)
 ;;;;
 
-(require "srfi-9")
 
-(define-module SRFI-128
+(define-module srfi/128
+  (import (srfi 9))
   (export
    comparator? comparator-ordered? comparator-hashable?
    make-comparator
@@ -71,7 +71,7 @@
 
 (define comparator-if<=> "<<FIXME>>")
 (define hash-salt        "<<FIXME>>")
-(define hash-bound        "<<FIXME>>")
+(define hash-bound       "<<FIXME>>")
 
   
 
@@ -549,7 +549,5 @@
 
 ) ;; END OF DEFINE-MODULE
 ;;;; ======================================================================
-(select-module STklos)
 
-(import SRFI-128)
-(provide "srfi-128")
+(provide "srfi/128")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -56,6 +56,8 @@ SRC_STK   = 1.stk   \
             64.stk  \
             66.stk  \
             74.stk  \
+            113.stk \
+            128.stk \
             170.stk \
             189.stk \
             196.stk \
@@ -87,6 +89,8 @@ SRC_OSTK =  1.ostk   \
             64.ostk  \
             66.ostk  \
             74.ostk  \
+            113.ostk \
+            128.ostk \
             170.ostk \
             189.ostk \
             196.ostk \
@@ -131,6 +135,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 
 # Dependencies
 13.ostk: 14.ostk
+113.ostk: 128.ostk
 
 25.$(SO):  25-incl.c  25.c
 27.$(SO):  27-incl.c  27.c

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -369,6 +369,8 @@ SRC_STK = 1.stk   \
             64.stk  \
             66.stk  \
             74.stk  \
+            113.stk \
+            128.stk \
             170.stk \
             189.stk \
             196.stk \
@@ -400,11 +402,14 @@ SRC_OSTK = 1.ostk   \
             64.ostk  \
             66.ostk  \
             74.ostk  \
+            113.ostk \
+            128.ostk \
             170.ostk \
             189.ostk \
             196.ostk \
             214.ostk \
             215.ostk
+
 
 #
 # SRFIs written in C and Scheme
@@ -700,6 +705,7 @@ STKLOS_BINARY ?= ../src/stklos
 
 # Dependencies
 13.ostk: 14.ostk
+113.ostk: 128.ostk
 
 25.$(SO):  25-incl.c  25.c
 27.$(SO):  27-incl.c  27.c

--- a/tests/srfis/113.stk
+++ b/tests/srfis/113.stk
@@ -8,6 +8,8 @@
 
 ;; Most if not all of this code is taken from SRFI-114
 
+(import (srfi 128))
+
 (define exact inexact->exact)
 
 (define string-foldcase string-downcase)


### PR DESCRIPTION
113 depends on 128, so both are migrated together.

113 still depends on SRFI-69, and uses a require instead of import. This would change when srfi-69 is migrated, I think