### PR TITLE
Describing things better :)

### DIFF
--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -34,11 +34,11 @@
   (cond
      ((number? x)       (if (exact? x)
                             (cond
-                              ((integer? x)  (format port "an integer"))
+                              ((integer? x)  (format port "an integer number"))
                               ((rational? x) (format port "a rational number"))
                               ((complex? x)  (format port "a complex number")))
                             (cond
-                              ((real? x)    (format port "a real"))
+                              ((real? x)    (format port "a real number"))
                               ((complex? x) (format port "a complex number")))))
      ((null?    x)      (format port "an empty list"))
      ((boolean? x)      (format port "a boolean value (~s)" (if x 'true 'false)))
@@ -54,10 +54,15 @@
                             (format port "an empty vector")
                             (format port "a vector of length ~s"
                                     (vector-length x))))
-     ((procedure? x)    (format port "a procedure"))
+     ((procedure? x)    (if (%procedure-signature x)
+                            (format port "a procedure, whose arguments are ~s"
+                                    (%procedure-signature x))
+                            (format port "a procedure")))
      ((eof-object? x)   (format port "the end-of-file object"))
      ((struct-type? x)  (format port "the type structure named ~A"
                                 (struct-type-name x)))
+     ((library? x)      (format port "an R7RS library named ~A"
+                                (%symbol->library-name (module-name x))))
      ((module? x)       (format port "a module named ~A" (module-name x)))
      (else              (let ((user-type-name (%user-type-name x)))
                           (if user-type-name

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -64,6 +64,9 @@
      ((library? x)      (format port "an R7RS library named ~A"
                                 (%symbol->library-name (module-name x))))
      ((module? x)       (format port "a module named ~A" (module-name x)))
+     ((port? x)         (format port "an ~a ~a port"
+                                (if (input-port? x) "input" "output")
+                                (if (binary-port? x) "binary" "textual")))
      (else              (let ((user-type-name (%user-type-name x)))
                           (if user-type-name
                               ;; Object type is user defined.


### PR DESCRIPTION
The first commit is an enhanced describe for libraries and numbers
    
* R7RS libraries are described as R7RS libraries, with their
  R7RS names  
* If we describe numbers as "rational number", "complex number", then
  we should as well say "an integer number" instead of "an integer"...
  Same for "real number".
* When a procedure is described, its signature is shown if available.

The second enables describe for ports. I have two questions, though:
* Shouldn't ports be objects of their own class? Currently they're not (a port is "`an instance of class <unknown>`").
* If a port is bound to a file, should we show the file name?

I can change the PR if necessary...