### PR TITLE
Add library-name

### DIFF
--- a/lib/module.stk
+++ b/lib/module.stk
@@ -534,3 +534,35 @@ doc>
 |#
 (define-macro (in-module mod symb . default)
   `(apply symbol-value* ',symb (find-module ',mod) ',default))
+
+;;=============================================================================
+;;
+;;                              R7RS LIBRARIES
+;;
+;;=============================================================================
+
+#|
+<doc EXT library-name
+ * (library-name lib)
+ *
+ * Returns the name of |lib| if it was defined as an R7RS library, and
+ * raises an error otherwise.
+ *
+ * @lisp
+ * (define-library (example cool-library))
+ * (library-name (find-module 'example/cool-library)) => (example cool-library)
+ * (module-name  (find-module 'example/cool-library)) => example/cool-library
+ *  
+ * (define-module example/a-module)
+ * (library-name (find-module 'example/a-module))     => error
+ *  
+ * (library-name quotient)                            => error
+ * @end lisp
+doc>
+|#
+(define (library-name lib)
+  (unless (library? lib)
+    (if (module? lib)
+        (error 'library-name "module ~S is not a library" (module-name lib))
+        (error 'library-name "bad module/library ~S" lib)))
+  (%symbol->library-name (module-name lib)))


### PR DESCRIPTION
Module-name will return the name of a module.
If the module is also an R7RS library, we could also ask its library name, which is different fro mits module name!

```
(define-library (example cool-library))
(library-name (find-module 'example/cool-library)) => (example cool-library)
(module-name  (find-module 'example/cool-library)) => example/cool-library

(define-module example/a-module)
(library-name (find-module 'example/a-module))     => error

(library-name quotient)                            => error
```

The error message tries to be informative: if the object is a module, say "the module is not a library"; if it's not even a module, then "bad library/module"...

Is this the best way to do this?