### PR TITLE
Add non-mutable bindings in modules

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1643,6 +1643,24 @@ doc>
         value)))
 
 
+#|
+<doc EXT define-constant
+ * (define-constant name expr)
+ *
+ * Evaluates the expression |expr|, then creates a new, non-mutable
+ * binding for |name| with the resulting value.
+ *
+ * (define-constant a 'hello)
+ * a                 => 'hello
+ * (set! a 'goodbye) => error
+ * (define q 2)      => ok (it's a new binding)
+doc>
+|#
+(define-macro (define-constant name expr)
+  `(begin (define ,name ,expr)
+          (module-lock-binding! ',name)))
+
+
 ;;;; ======================================================================
 ;;;;
 ;;;; SRFIs support

--- a/lib/boot.stk
+++ b/lib/boot.stk
@@ -199,13 +199,15 @@
 ;;; may have the possibility to modify standard bindings.
 ;;; If a module needs to be sure to have the original bindings, it
 ;;; can import this module which will be visible before the STklos
-;;; module. Note that this is only partially true since bindings
-;;; in SCHEME module are mutable
+;;; module.
 ;;; Note that module SCHEME was already created before bootstrap
 (let ((STklos (find-module 'STklos))
       (SCHEME (find-module 'SCHEME)))
   (%populate-scheme-module)
-  (%module-exports-set! SCHEME (module-exports STklos)))
+  (%module-exports-set! SCHEME (module-exports STklos))
+  ;; make the SCHEME module completely unmutable:
+  (module-lock-define!  SCHEME)
+  (module-lock-bindings! SCHEME))
 
 ;; ----------------------------------------------------------------------
 ;;      option analysis and REPL launching

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -61,9 +61,12 @@
      ((eof-object? x)   (format port "the end-of-file object"))
      ((struct-type? x)  (format port "the type structure named ~A"
                                 (struct-type-name x)))
-     ((library? x)      (format port "an R7RS library named ~A"
-                                (%symbol->library-name (module-name x))))
-     ((module? x)       (format port "a module named ~A" (module-name x)))
+     ((module? x)       (format port "a module named ~A, where new bindings are~A allowed"
+                                (module-name x)
+                                (if (module-define-allowed? x) "" " not")))
+     ((library? x)      (format port "an R7RS library named ~A, where new bindings are~A allowed"
+                                (%symbol->library-name (module-name x))
+                                (if (module-define-allowed? x) "" " not")))
      ((port? x)         (format port "an ~a ~a port"
                                 (if (input-port? x) "input" "output")
                                 (if (binary-port? x) "binary" "textual")))

--- a/lib/module.stk
+++ b/lib/module.stk
@@ -534,3 +534,31 @@ doc>
 |#
 (define-macro (in-module mod symb . default)
   `(apply symbol-value* ',symb (find-module ',mod) ',default))
+
+;;=============================================================================
+;;
+;;                            MODULE-LOCK-SYMBOLS!
+;;
+;;=============================================================================
+
+#|
+<doc EXT module-lock-bindings!
+ * (module-lock-bindings! mod)
+ *
+ * Lock all symbol bindins  module |mod|, so they will all be unmutable.
+ * @lisp
+ * (define-module mod (define a 1) (define b 2))
+ * (select-module mod)
+ * (module-lock-bindings! (find-module 'mod))
+ * (set! a 10)   => error
+ * (set! b 20)   => error
+ * (define c 20) => OK, c was not locked when module-lock-bindings was called.
+ * (set! c 50)   => OK for the same reason
+ * (define a -1) => OK, a is a *new* binding, and define is allowed
+ * (set! a -2)   => OK, a is a *new* binding!
+ * @end lisp
+|#
+(define (module-lock-bindings! mod)
+  (unless (module? mod) (error "bad module ~S" mod))
+  (for-each (lambda (sym) (module-lock-binding! sym mod))
+            (module-symbols mod)))

--- a/src/env.c
+++ b/src/env.c
@@ -212,6 +212,7 @@ DEFINE_PRIMITIVE("binding-mutable?", module_binding_mutablep, subr12, (SCM sym,
     SCM res = STk_hash_get_variable(&MODULE_HASH_TABLE(module),
                                     sym,
                                     &i);
+    if (!res) return STk_false; /* TODO: or error? */
     return MAKE_BOOLEAN (!(BOXED_INFO(res) & CONS_CONST));
 }
 
@@ -277,6 +278,7 @@ DEFINE_PRIMITIVE("module-lock-binding!", module_lock_binding, subr12, (SCM sym,
     SCM res = STk_hash_get_variable(&MODULE_HASH_TABLE(module),
                                     sym,
                                     &i);
+    if (!res) STk_error("unbound variable ~S", sym);
     BOXED_INFO(res) = BOXED_INFO(res) | CONS_CONST;
     return STk_void;
 }

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -512,6 +512,9 @@ struct frame_obj {
 #define FRAME_LOCAL(p, i)       (FRAME_LOCALS(p)[i])
 #define FRAMEP(p)               (BOXED_TYPE_EQ((p), tc_frame))
 
+/* MODULE_CONST is used to tell if define can be used in a module */
+#define MODULE_CONST            (1 << 0)
+
 /* modules are defined in env.c but are private */
 #define MODULEP(p)              (BOXED_TYPE_EQ((p), tc_module))
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -75,6 +75,9 @@ static int debug_level = 0;     /* 0 is quiet, 1, 2, ... are more verbose */
 
 #define FX(v)                   (STk_fixval(v))
 
+EXTERN_PRIMITIVE("module-name", module_name, subr1, (SCM module));
+
+
 static Inline sigset_t get_signal_mask(void)
 {
   sigset_t new, old;
@@ -1172,9 +1175,10 @@ CASE(GLOBAL_SET) {
   }
   if (BOXED_INFO(ref) & CONS_CONST) {
     RELEASE_LOCK;
-    STk_error("cannot mute the value of ~S in ~S", orig_operand, vm->current_module);
-
+    STk_error("mutating ~S not allowed in module ~S", orig_operand,
+              STk_module_name(vm->current_module));
   }
+
   *BOX_VALUES(CDR(ref)) = vm->val;    /* sure that this box arity is 1 */
   /* patch the code for optimize next accesses */
   vm->pc[-1] = add_global(CDR(ref));

--- a/tests/do-test.stk
+++ b/tests/do-test.stk
@@ -51,6 +51,7 @@
   (load "test-utf8.stk")
   (load "test-misc.stk")
   (load "test-r5rs-pitfall.stk")
+  (load "test-unmutable-bindings.stk")
   )
 
 

--- a/tests/test-unmutable-bindings.stk
+++ b/tests/test-unmutable-bindings.stk
@@ -1,0 +1,84 @@
+;;;;
+;;;; test-unmutable-bindings.stk   -- Tests on unmutable bindings
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date:  7-Dec-2021 23:04 (jpellegrini)
+;;;; Last file update:  7-Nov-2021 23:04 (jpellegrini)
+;;;;
+
+
+(define-module %%unmutability)
+
+(select-module %%unmutability)
+     (define a -1)
+     (define b -2)
+     (define c -3)
+(select-module STklos)
+
+
+(require "test")
+
+(test-section "Unmutability")
+
+
+(define %%mod (find-module '%%unmutability))
+
+(module-lock-binding! 'a %%mod)
+
+(test "unmutable binding.1" #f (binding-mutable? 'a %%mod))
+(test "unmutable binding.2" #t (binding-mutable? 'b %%mod))
+(test "unmutable binding.3" #t (binding-mutable? 'c %%mod))
+
+(select-module %%unmutability)
+(test/error "unmutable binding.4"  (set! a 10))
+(test "unmutable binding.5" (void) (set! b 20))
+(select-module STklos)
+(test "unmutable binding.6" -1 (in-module %%unmutability a))
+(test "unmutable binding.7" 20 (in-module %%unmutability b))
+
+(module-lock-bindings! %%mod)
+
+(test "unmutable binding.8"  #f (binding-mutable? 'a %%mod))
+(test "unmutable binding.9"  #f (binding-mutable? 'b %%mod))
+(test "unmutable binding.10" #f (binding-mutable? 'c %%mod))
+
+(select-module %%unmutability)
+(test/error "unmutable binding.11"  (set! a 100))
+(test/error "unmutable binding.12"  (set! b 100))
+(test/error "unmutable binding.13"  (set! c 100))
+(select-module STklos)
+
+(test "unmutable binding.14" -1 (in-module %%unmutability a))
+(test "unmutable binding.15" 20 (in-module %%unmutability b))
+(test "unmutable binding.16" -3 (in-module %%unmutability c))
+
+(test "unmutable SCHEME module.1"
+      #f
+      (module-define-allowed? (find-module 'SCHEME)))
+(test "unmutable SCHEME module.2"
+      #f
+      (binding-mutable? '/ (find-module 'SCHEME)))
+
+(select-module SCHEME)
+(test/error "unmutable SCHEME module.3" (set! + -))
+(select-module STklos)
+
+(test-section-end)


### PR DESCRIPTION
Hi @egallesio !

About issue #335 ... I think this PR implements it.

I tried to not put more code in the VM, except for when the error is signaled (the module name is printed), so STklos won't get a slower `set!`. But `define` would need to check if the modules allows new bindings (should be very fast anyway).

The only part which seems a bit inefficient is that when we call `define`, it retrieves the old binding, if it exists, then makes it mutable again (if it was not), and that is a bit expensive. But I suppose people won't call global `define`s inside loops. :)

The commit message:

Adds the following primitives:

* `module-lock-define!`     disallows define in a module
* `module-define-allowed?`  checks if define is allowed

* `module-lock-binding!`    makes one binding non-mutable
* `module-lock-bindings!`  makes all module bindings non-mutable
* `binding-mutable?`        checks if a binding is mutable

The `SCHEME` module does not allow new bindings do be `DEFINE`d, and does not allow its bindings to be `SET!`, so it now can be safely used as a reference for the original Scheme bindings.

Update:
* Added a `define-constant` macro (it's trivial now)
* Added the module mutability info to `describe`
