### PR TITLE
SRFI 70 -> R7RS library

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -91,7 +91,6 @@ SRC_STK = bigloo-support.stk  \
           srfi-59.stk         \
           srfi-61.stk         \
           srfi-69.stk         \
-          srfi-70.stk         \
           srfi-89.stk         \
           srfi-94.stk         \
           srfi-96.stk         \
@@ -139,7 +138,6 @@ scheme_OBJS = compfile.ostk     \
           srfi-59.ostk          \
           srfi-61.ostk          \
           srfi-69.ostk          \
-          srfi-70.ostk          \
           srfi-89.ostk          \
           srfi-94.ostk          \
           srfi-96.ostk          \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -446,7 +446,6 @@ SRC_STK = bigloo-support.stk  \
           srfi-59.stk         \
           srfi-61.stk         \
           srfi-69.stk         \
-          srfi-70.stk         \
           srfi-89.stk         \
           srfi-94.stk         \
           srfi-96.stk         \
@@ -493,7 +492,6 @@ scheme_OBJS = compfile.ostk     \
           srfi-59.ostk          \
           srfi-61.ostk          \
           srfi-69.ostk          \
-          srfi-70.ostk          \
           srfi-89.ostk          \
           srfi-94.ostk          \
           srfi-96.ostk          \

--- a/lib/srfi/70.stk
+++ b/lib/srfi/70.stk
@@ -1,5 +1,5 @@
 ;;;;
-;;;; srfi-70.stk			-- Inexact Infinities
+;;;; 70.stk			-- SRFI 70: Numbers
 ;;;;
 ;;;; Copyright © 2005 Erick Gallesio - I3S-CNRS/ESSI <eg@essi.fr>
 ;;;;
@@ -21,7 +21,7 @@
 ;;;;
 ;;;;           Author: Aubrey Jaffer (SRFI Reference implementation)
 ;;;;    Creation date: 12-Sep-2005 14:51 (eg)
-;;;; Last file update: 13-Sep-2005 17:36 (eg)
+;;;; Last file update: 09-Dec-2021 19:05 (jpellegrini)
 ;;;;
 ;;;;
 ;;;; The implementation is taken directly from the SRFI reference implementation.
@@ -37,8 +37,73 @@
 ;;;; OTHER DEALINGS IN THE SOFTWARE.
 
 
-(unless (provided? "srfi-70")
 
+(define-module srfi/70
+  (import SCHEME)
+
+  ;; we re-export the R5RS procedures in the SRFI
+  ;; in case they have been changed:
+  (export ;; 6.2.2 Exactness
+          exact-round
+          exact-ceiling
+          exact-floor
+          exact-truncate
+
+          ;; 6.2.2x Infinities
+          ;; (nothing to export)
+
+          ;; 6.2.3 Implementation restrictions
+          +            -             *
+          quotient     remainder     modulo
+          max          min           abs
+          numerator    denominator   gcd
+          lcm          floor         ceiling
+          truncate     round         rationalize
+          expt
+
+          ;; 6.2.4 Syntax of numerical constants
+          ;; (reader-specific, nothing to export)
+
+          ;; 6.2.5 Numerical operations
+          number?
+          complex?
+          real?
+          rational?
+          integer?
+          exact?
+          inexact?
+
+          = < > <= >=
+
+          finite? infinite?
+          zero?   positive? negative?
+          odd?    even?
+
+          max min
+
+          /
+
+          abs
+
+          exp  log
+          sin  cos  tan
+          asin acos atan
+          sqrt
+          expt
+
+          make-rectangular make-polar 
+          real-part        imag-part 
+          magnitude        angle
+          
+          exact->inexact 
+          inexact->exact 
+
+          ;; 6.2.6 Numerical input and output
+          number->string
+          string->number)
+          
+          
+          
 (define (ipow-by-squaring x n acc proc)
   (cond ((zero? n) acc)
 	((eqv? 1 n) (proc acc x))
@@ -91,5 +156,5 @@
 (define (exact-truncate x) (inexact->exact (truncate x)))
 )
 
-(provide "srfi-70")
+(provide "srfi/70")
 

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -55,6 +55,7 @@ SRC_STK   = 1.stk   \
             60.stk  \
             64.stk  \
             66.stk  \
+            70.stk  \
             74.stk  \
             88.stk  \
             111.stk \
@@ -99,6 +100,7 @@ SRC_OSTK =  1.ostk   \
             60.ostk  \
             64.ostk  \
             66.ostk  \
+            70.ostk  \
             74.ostk  \
             88.ostk  \
             111.ostk \

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -35,7 +35,7 @@
 #
 #           Author: Erick Gallesio [eg@unice.fr]
 #    Creation date:  8-Oct-2021 11:54 (eg)
-# Last file update:  9-Dec-2021 14:23 (eg)
+# Last file update:  9-Dec-2021 14:24 (eg)
 
 #======================================================================
 
@@ -368,6 +368,7 @@ SRC_STK = 1.stk   \
             60.stk  \
             64.stk  \
             66.stk  \
+            70.stk  \
             74.stk  \
             88.stk  \
             111.stk \
@@ -412,6 +413,7 @@ SRC_OSTK = 1.ostk   \
             60.ostk  \
             64.ostk  \
             66.ostk  \
+            70.ostk  \
             74.ostk  \
             88.ostk  \
             111.ostk \


### PR DESCRIPTION
Ok - reexported all symbols mentioned in the SRFI, even those which were already available in R5RS / R7RS, so if the user changes them with `(define quotient *)`, for example, loading the SRFI will bring back the original one. This seems correct, since the intentin of the SRFI is to impose a certain semantics to the numeric fnuctions.