### PR TITLE
Use fixed-size integers for opcodes

### DIFF
--- a/src/stklos.h
+++ b/src/stklos.h
@@ -46,7 +46,7 @@ extern "C"
 #include <setjmp.h>
 #include <memory.h>
 #include <locale.h>
-
+#include <stdint.h>
 #ifndef THEADS_NONE
 #  include <pthread.h>
 #  define GC_THREADS 1
@@ -218,7 +218,7 @@ typedef struct {
    * on the compiler. If you change this definition, change DEFINE_PRIMITIVE
    * accordingly
    */
-  short type, cell_info;
+  int16_t type, cell_info;
 } stk_header;
 
 
@@ -255,7 +255,7 @@ typedef struct {
    *    DEFINE_PRIMITIVE("pair?", pairp, subr1, (SCM obj)) {
    *       <body>
    *    }
-   * It will be expanded in
+   * It will be expansed in
    *    SCM STk_pairp(SCM obj);
    *    static struct obj_primitive obj_pairp = { "pair?", tc_subr1, STk_pairp};
    *    SCM STk_pairp(SCM obj){
@@ -543,7 +543,7 @@ void STk_export_all_symbols(SCM module);
   ------------------------------------------------------------------------------
 */
   /* The `extended_type_descr' structure is used for the types which need
-   * more information (such as modules, ports, ....). All the extended
+   *  more information (such as modules, ports, ....). All the extended
    * descriptors are stored in the STk_xtypes array.
    */
 struct extended_type_descr {
@@ -1126,12 +1126,12 @@ int STk_init_promise(void);
   ------------------------------------------------------------------------------
 */
 
-typedef short STk_instr;
+typedef int16_t STk_instr;
 
 struct closure_obj {
   stk_header header;
-  short arity;
-  unsigned short code_size;
+  int16_t arity;
+  uint16_t code_size;
   SCM formals;
   SCM env;
   SCM plist;
@@ -1334,9 +1334,9 @@ int STk_char2utf8(int ch, char *str); /* result = length of the UTF-8 repr. */
 int STk_utf8_strlen(char *s, int max);
 int STk_utf8_read_char(SCM port);
 int STk_utf8_sequence_length(char *str); /* # of bytes of sequence starting at str */
-int STk_utf8_char_bytes_needed(unsigned int ch);/* # of bytes needed to represent ch */
+int STk_utf8_char_bytes_needed(unsigned int ch);/* # of bytes needed to represent ch*/
 int STk_utf8_verify_sequence(char *s, int len); /* s constitutes a valid UTF8? */
-char *STk_utf8_index(char *s, int i, int max);/* return the address of ith char of s */
+char *STk_utf8_index(char *s, int i, int max);/* return the address of ith char of s*/
 int STk_utf8_char_from_byte(char *s, int i, int max); /*  byte index => char index */
 
 int STk_init_utf8(void);

--- a/src/vm.c
+++ b/src/vm.c
@@ -1,7 +1,7 @@
 /*
  * v m . c                              -- The STklos Virtual Machine
  *
- * Copyright © 2000-2022 Erick Gallesio - I3S-CNRS/ESSI <eg@unice.fr>
+ * Copyright © 2000-2021 Erick Gallesio - I3S-CNRS/ESSI <eg@unice.fr>
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
  *
  *           Author: Erick Gallesio [eg@unice.fr]
  *    Creation date:  1-Mar-2000 19:51 (eg)
- * Last file update: 11-Jan-2022 17:34 (eg)
+ * Last file update:  5-Nov-2021 17:14 (eg)
  */
 
 // INLINER values
@@ -366,7 +366,7 @@ static void patch_environment(vm_thread_t *vm)
   //STk_debug(">>>>>>>>>>");
 }
 
-static void error_bad_arity(SCM func, int arity, short given_args, vm_thread_t *vm)
+static void error_bad_arity(SCM func, int arity, int16_t given_args, vm_thread_t *vm)
 {
    ACT_SAVE_PROC(vm->fp) = func;
   if (arity >= 0)
@@ -378,15 +378,15 @@ static void error_bad_arity(SCM func, int arity, short given_args, vm_thread_t *
 }
 
 
-static Inline short adjust_arity(SCM func, short nargs, vm_thread_t *vm)
+static Inline int16_t adjust_arity(SCM func, int16_t nargs, vm_thread_t *vm)
 {
-  short arity = CLOSURE_ARITY(func);
+  int16_t arity = CLOSURE_ARITY(func);
 
   if (arity != nargs) {
     if (arity >= 0)
       error_bad_arity(func, arity, nargs, vm);
     else {                                              /* nary procedure call */
-      short min_arity = -arity-1;
+      int16_t min_arity = -arity-1;
 
       if (nargs < min_arity)
         error_bad_arity(func, arity, nargs, vm);
@@ -502,7 +502,7 @@ SCM STk_C_apply(SCM func, int nargs, ...)
   }
   va_end(ap);
 
-  code[1] = (short) nargs;                          /* Patch # of args  */
+  code[1]     = (int16_t) nargs;                    /* Patch # of args  */
   vm->val     = func;                               /* Store fun in VAL */
   vm->pc      = code;
   run_vm(vm);
@@ -569,7 +569,7 @@ DEFINE_PRIMITIVE("%execute", execute, subr23, (SCM code, SCM consts, SCM envt))
  * (values obj ...)
  *
  * Delivers all of its arguments to its continuation.
- * NOTE: R5RS imposes to use multiple values in the context of
+ * ,(bold "Note:") R5RS imposes to use multiple values in the context of
  * of a |call-with-values|. In STklos, if |values| is not used with
  * |call-with-values|, only the first value is used (i.e. others values are
  * ,(emph "ignored")).
@@ -875,7 +875,7 @@ DEFINE_PRIMITIVE("%vm", set_vm_debug, vsubr, (int _UNUSED(argc), SCM _UNUSED(*ar
 static void run_vm(vm_thread_t *vm)
 {
   jbuf jb;
-  short tailp;
+  int16_t tailp;
   volatile int offset,
                have_global_lock = 0;     /* if true, we're patching the code */
   int nargs=0;
@@ -884,7 +884,7 @@ static void run_vm(vm_thread_t *vm)
 #  define DEFINE_JUMP_TABLE
 #  include "vm-instr.h"
 #else
-   short byteop;
+   int16_t byteop;
 #endif
 #if defined(DEBUG_VM)
 #    define DEFINE_NAME_TABLE
@@ -892,7 +892,7 @@ static void run_vm(vm_thread_t *vm)
   static STk_instr *code_base = NULL;
 #endif
 #if defined(STAT_VM)
-  static short previous_op = NOP;
+  static int16_t previous_op = NOP;
 #endif
 
 #if defined(USE_COMPUTED_GOTO)
@@ -949,7 +949,7 @@ CASE(CONSTANT_PUSH) { push(fetch_const());           NEXT; }
 CASE(PUSH_GLOBAL_REF)
 CASE(GLOBAL_REF) {
   SCM ref = NULL;
-  short orig_opcode;
+  int16_t orig_opcode;
   SCM orig_operand;
 
   LOCK_AND_RESTART;
@@ -1017,7 +1017,7 @@ CASE(UGLOBAL_REF_PUSH) { /* Never produced by compiler */
 CASE(PUSH_GREF_INVOKE)
 CASE(GREF_INVOKE) {
   SCM ref = NULL;
-  short orig_opcode;
+  int16_t orig_opcode;
   SCM orig_operand;
 
   LOCK_AND_RESTART;
@@ -1060,7 +1060,7 @@ CASE(UGREF_INVOKE) { /* Never produced by compiler */
 CASE(PUSH_GREF_TAIL_INV)
 CASE(GREF_TAIL_INVOKE) {
   SCM ref = NULL;
-  short orig_opcode;
+  int16_t orig_opcode;
   SCM orig_operand;
 
   LOCK_AND_RESTART;
@@ -1905,7 +1905,7 @@ void STk_raise_exception(SCM cond)
  * (current-exception-handler)
  *
  * Returns the current exception handler. This procedure is defined in
- * {{link-srfi 18}}.
+ * ,(link-srfi 18).
 doc>
 */
 DEFINE_PRIMITIVE("current-exception-handler", current_handler, subr0, (void))


### PR DESCRIPTION
Not for everything in STklos -- using `long` is good, since
it makes STklos use the ideal integer size for integer arithmetic
depending on the platform. But the VM will now always use exactly
two bytes for opcodes, so we can be sure that the bytecode will
always be portable.

```
short          -> int16_t
unsigned short -> uint16_t
```

One thing: when compiling SRFI 25, gcc complains that we're converting `int` into `int16_t`, producing overflows:

```
25-incl.c:104:1: warning: overflow in conversion from ‘int’ to ‘short int’ changes value from ‘65535’ to ‘-1’ [-Woverflow]
  104 | 0xffff,  0x25,  0x75, 0x100,  0x25,  0x65,  0x56,  0x3f,   0x1,  0x6e,
      | ^~~~~~
25-incl.c:109:15: warning: overflow in conversion from ‘int’ to ‘short int’ changes value from ‘65532’ to ‘-4’ [-Woverflow]
  109 |  0x23,  0xbd, 0xfffc,  0x25,  0x25,  0x65,  0x56,  0x1b,   0x1,  0x1d,
      |               ^~~~~~
```

I don't see why it does this since it's the initialization of an array - it should interpret the elements as having the same type of  the base type (use `-Wall --pedantic -fanalyzer` to reproduce). Maybe it was expecting `-0x1` instead of `0xffff` and so on. Anyway, it's bytecode, and that doesn't seem to insert any bugs.

Tests pass, and I've also tested this:

```
stklos> 32767
32767
stklos> (- 32767 1)
32766
stklos> (+ 32767 1)
32768
stklos> (- 32768 1)
32767
```