### PR TITLE
Use $(STKLOS_BINARY) instead of hardcoded stklos relative path

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -179,7 +179,7 @@ am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/stklos-compile.1.in \
 	$(srcdir)/stklos-config.1.in $(srcdir)/stklos-genlex.1.in \
 	$(srcdir)/stklos-pkg.1.in $(srcdir)/stklos-script.1.in \
-	$(srcdir)/stklos.1.in $(top_srcdir)/mkinstalldirs TODO
+	$(srcdir)/stklos.1.in $(top_srcdir)/mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@

--- a/doc/hacking/Makefile.in
+++ b/doc/hacking/Makefile.in
@@ -470,11 +470,12 @@ extradoc: pdf
 
 # ----------------------------------------------------------------------
 ../HTML/$(HTMLMAIN): tmp-html.txt
+	mkdir -p ../HTML
 	$(ADOC) -v -o $@ tmp-html.txt
 
 # ----------------------------------------------------------------------
 ../PDF/$(PDF): tmp-pdf.txt
-	mkdir -p ../pdf
+	mkdir -p ../PDF
 	$(ADOC) -v -r asciidoctor-pdf -b pdf -o $@ tmp-pdf.txt
 
 # ----------------------------------------------------------------------
@@ -489,7 +490,7 @@ clean:
 	rm -f  tmp-html.txt tmp-pdf.txt  *~
 
 distclean: clean
-	rm -f  ../HTML/$(HTMLMAIN) 
+	rm -f ../HTML/$(HTMLMAIN) 
 	rm -f ../PDF/$(PDF)
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/doc/refman/Makefile.am
+++ b/doc/refman/Makefile.am
@@ -12,7 +12,7 @@ SOURCES  = biblio.adoc cond.adoc custom.adoc expr.adoc ffi.adoc      \
            progstruct.adoc regexp.adoc scmpkg.adoc slib.adoc         \
            srfi.adoc stdproc.adoc stklos.adoc threads.adoc
 DOCDB    = ../DOCDB
-SPP      = ../../src/stklos -q -I ../../lib -f ../../utils/stklos-pp.stk --
+SPP      = $(STKLOS_BINARY) -q -I ../../lib -f ../../utils/stklos-pp.stk --
 
 HTMLMAIN  = stklos-ref.html
 HTMLMULTI = stklos-ref-multi.html

--- a/doc/refman/Makefile.in
+++ b/doc/refman/Makefile.in
@@ -297,7 +297,7 @@ SOURCES = biblio.adoc cond.adoc custom.adoc expr.adoc ffi.adoc      \
            srfi.adoc stdproc.adoc stklos.adoc threads.adoc
 
 DOCDB = ../DOCDB
-SPP = ../../src/stklos -q -I ../../lib -f ../../utils/stklos-pp.stk --
+SPP = $(STKLOS_BINARY) -q -I ../../lib -f ../../utils/stklos-pp.stk --
 HTMLMAIN = stklos-ref.html
 HTMLMULTI = stklos-ref-multi.html
 MULTI_AUX = FDL.html                                        \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -267,7 +267,7 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/extraconf.h.in \
 	$(srcdir)/stklosconf.h.in $(top_srcdir)/depcomp \
-	$(top_srcdir)/mkinstalldirs TODO
+	$(top_srcdir)/mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@


### PR DESCRIPTION
Hi @egallesio !

I just realized there was a problem with my ports to wireless routers -- I thought they could be built without having STklos installed, but yesterday I tried compiling on a container, and it didn't work.

There was one place where `$(STKLOS_BINARY)` wasn't used, and compilation failed there.
This PR fixes it. Do you think it's OK?