### PR TITLE
Optimize vector sorting with fx<, fx>

### DIFF
--- a/lib/srfi/132.c
+++ b/lib/srfi/132.c
@@ -40,6 +40,8 @@
    but those are not loaded by default (it's a SRFI), so things become
    more complicated.  */
 
+EXTERN_PRIMITIVE("symbol-value", symbol_value, subr23,
+                 (SCM symbol, SCM module, SCM default_value));
 EXTERN_PRIMITIVE("fx<?", fxlt, vsubr, (int argc, SCM *argv));
 EXTERN_PRIMITIVE("fx>?", fxgt, vsubr, (int argc, SCM *argv));
 
@@ -865,6 +867,30 @@ DEFINE_PRIMITIVE("vector-stable-sort!",
     long run_end = i+1;
 
     runs[0]=cstart;
+
+    SCM fxl   = STk_symbol_value(STk_intern("fx<"), Scheme_module, NULL);
+    SCM less2 = less;
+    BOXED_INFO(less2) |= CONS_CONST;
+    //if (STk_eqv(less,fxl)==STk_true)
+    if ((void*)less == (void*) fxl)
+	fprintf(stderr,"fx<?\n");
+    else
+	fprintf(stderr,"NO fx<?\n");
+    
+    fprintf(stderr,"STk_fxl = %p %lu\n",
+	    (void*) fxl,
+	    (unsigned long) fxl);
+
+    fprintf(stderr,"less = %p %lu, STk_fxlt = %p %lu\n",
+	    less,
+	    (unsigned long) less,
+	    STk_fxlt,
+	    (unsigned long) STk_fxlt);
+    fprintf(stderr,"less2 = %p %lu, STk_fxlt = %p %lu\n",
+	    less2,
+	    (unsigned long) less2,
+	    STk_fxlt,
+	    (unsigned long) STk_fxlt);
 
     while (run_end <= cend) {
         /* Find a run. Try forward, then backward. One of these will immediately fail,

--- a/src/env.c
+++ b/src/env.c
@@ -83,7 +83,7 @@ struct module_obj {
 #define MODULE_HASH_TABLE(m)    (((struct module_obj *) (m))->hash)
 
 SCM STk_STklos_module;          /* The module whose name is STklos */
-static SCM Scheme_module;       /* The module whose name is SCHEME */
+SCM Scheme_module;       /* The module whose name is SCHEME */
 static SCM all_modules;         /* List of all knowm modules */
 
 static void print_module(SCM module, SCM port, int mode)

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -528,6 +528,7 @@ int STk_init_env(void);
 int STk_late_init_env(void); /* must be done after symbol initialization */
 
 extern SCM STk_STklos_module;
+extern SCM Scheme_module;
 
 EXTERN_PRIMITIVE("%create-module", create_module, subr1, (SCM name));
 EXTERN_PRIMITIVE("current-module", current_module, subr0, (void));

--- a/tests/srfis/132.stk
+++ b/tests/srfis/132.stk
@@ -1379,3 +1379,46 @@
 (for-each test-all-sorts
           '( 3  5 10 10 10 20 20 10 10 10 10 10  10  10  10  10  10)
           '( 0  1  2  3  4  5 10 20 30 40 50 99 100 101 499 500 501))
+
+;;; Extra tests -- jpellegrini
+(let ((v (make-vector 5000)))
+  (dotimes (i 5000)
+    (vector-set! v i (if (odd? i) i (- i))))
+  (let ((w (vector-copy v))
+        (u (vector-copy v)))
+    (vector-stable-sort! < v)
+    (vector-stable-sort! fx< w)
+    (test "sorted? <" #t (vector-sorted? < v))
+    (test "sortd? fx<" #t (vector-sorted? < w))
+    (test "sorted the same, < fx<" #t (equal? v w))
+    (vector-stable-sort! < v)
+    (test "re-sorted <" #t (vector-sorted? < v))
+    (test "re-sorted <, same as fx<" #t (equal? v w))
+    (vector-stable-sort! < w)
+    (test "re-sorted fx<" #t (vector-sorted? < w))
+    (test "re-sorted fx<, same as <" #t (equal? v w))))
+    
+
+    
+         
+
+ 
+(let ((v (make-vector 500000)))
+
+  ;; Interleave an ascending vector with a descending one:
+  (dotimes (i 500000)
+    (vector-set! v i (if (odd? i) i (- i))))
+  
+  (let ((w (vector-copy v))
+        (u (vector-copy v)))
+    (vector-stable-sort! < v)
+    (vector-stable-sort! fx< w)
+    (test "sorted? <" #t (vector-sorted? < v))
+    (test "sortd? fx<" #t (vector-sorted? < w))
+    (test "sorted the same, < fx<" #t (equal? v w))
+    (vector-stable-sort! < v)
+    (test "re-sorted <" #t (vector-sorted? < v))
+    (test "re-sorted <, same as fx<" #t (equal? v w))
+    (vector-stable-sort! < w)
+    (test "re-sorted fx<" #t (vector-sorted? < w))
+    (test "re-sorted fx<, same as <" #t (equal? v w))))


### PR DESCRIPTION
This commit creates fast paths for vector sorting when
the comparison predicate is either `fx<` or `fx>`.

In order to check if the predicate *really* is one of those,
we check if it is `eq` to the binding of the symbols `fx<` and
`fx>` in the immutable `SCHEME` module

Remark 1: Fast paths for `fx<=` and `fx>=` would be possible,
but I'm not sure many people would use those, and they'd
clutter the code.

Remark 2: Fast paths for `fl<` and `fl>` would certainly be
possible, but those are not in the immutable `SCHEME` module
(it's a SRFI), so things become more complicated.

The following is not really a benchmark, but hints at how large the speedup is.

```
stklos> 
(import (srfi 27))
(import (srfi 132))

(define v (make-vector 5000000))

(dotimes (i 5000000)
  (vector-set! v i (- 20000 (random-integer 50000))))

(define w (make-vector 5000000))

(dotimes (i 5000000)
  (vector-set! w i (- 20000 (random-integer 50000))))
;; v
;; w
stklos> (time (vector-stable-sort! fx< v))
Elapsed time: 900.284000000003 ms
stklos> (dotimes (i 5000000)
  (vector-set! v i (- 20000 (random-integer 50000))))
stklos> (time (vector-stable-sort! fx< v))
Elapsed time: 901.396999999997 ms
stklos> (time (vector-stable-sort! < w))
Elapsed time: 6557.967 ms
stklos> (dotimes (i 5000000)
  (vector-set! w i (- 20000 (random-integer 50000))))
stklos> (time (vector-stable-sort! < w))
Elapsed time: 6506.484 ms
```