### PR TITLE
Fix typos & spelling; fix multiline macros

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -40,13 +40,13 @@ static char rev_table[128] = {
      41, 42, 43, 44,  45, 46, 47, 48, 49, 50, 51,  0,  0,  0,  0,  0
 };
 
-#define OutChar(c, f) {             \
+#define OutChar(c, f) do{             \
     STk_putc((c), (f));             \
     if (++count>=72) {              \
       STk_putc('\n', (f));          \
       count=0;                  \
     }                       \
-}
+}while(0)
 
 static void error_bad_input_port(SCM obj)
 {

--- a/src/boolean.c
+++ b/src/boolean.c
@@ -31,7 +31,7 @@
 
 
 /* Define the maximum calls for equal-count (a version of equal bounded in
-  recursive calls). The value depends of the way the program is compiled:
+  recursive calls). The value depends on the way the program is compiled:
   if optimizations are used, the program grows stack faster
 */
 
@@ -51,7 +51,7 @@ static void limit_max_equal_calls(void) {
   struct rlimit rl;
 
   if (getrlimit(RLIMIT_STACK, &rl) == 0) {
-    /* Determine a value for the maximum calls for equal-count depending of stack size*/
+    /* Determine a value for the maximum calls for equal-count depending on stack size*/
     max_equal_calls = rl.rlim_cur / (optimized? STK_DIVISOR_OPTIM: STK_DIVISOR_NOT_OPTIM);
   }
 }
@@ -174,7 +174,7 @@ doc>
  *       (lambda (y) y))    =>  unspecified
  * @end lisp
  *
- * NOTE: In fact, the value returned by STklos depends of
+ * NOTE: In fact, the value returned by STklos depends on
  * the way code is entered and can yield |#t| in some cases and |#f|
  * in others.
  *

--- a/src/char.c
+++ b/src/char.c
@@ -192,7 +192,7 @@ int STk_string2char(char *s)
   register struct charelem *p;
   uint32_t val;
 
-  /* Try to see if it is a multi-byte character */
+  /* Try to see if it is a multibyte character */
   if (* (STk_utf8_grab_char(s, &val)) == '\0') return val;
 
   if (*s == 'x') {
@@ -433,8 +433,8 @@ DEFINE_PRIMITIVE("digit-value", digit_value, subr1, (SCM c))
  *            (integer->char y))     =>  #t
  * @end lisp
  * |integer->char| accepts an exact number between 0 and #xD7FFF or between
- * #xE000 and #x10FFFF, if UTF8 encoding is used. Otherwise it accepts a
- * number between0 and #xFF.
+ * #xE000 and #x10FFFF, if UTF8 encoding is used. Otherwise, it accepts a
+ * number between 0 and #xFF.
 doc>
  */
 DEFINE_PRIMITIVE("char->integer", char2integer, subr1, (SCM c))

--- a/src/char.c
+++ b/src/char.c
@@ -30,8 +30,6 @@
 #include "stklos.h"
 
 
-SCM STk_char_foldcase(SCM c);
-
 
 struct charelem {
   char *name;
@@ -166,13 +164,13 @@ static void error_bad_char(SCM c)
   STk_error("bad char", c);
 }
 
-static Inline int charcomp(SCM c1, SCM c2)
+Inline int charcomp(SCM c1, SCM c2)
 {
   return (CHARACTER_VAL(c1) - CHARACTER_VAL(c2));
 }
 
 
-static int charcompi(SCM c1, SCM c2)
+int charcompi(SCM c1, SCM c2)
 {
   return STk_use_utf8 ?
     (int) (STk_to_fold(CHARACTER_VAL(c1)) -
@@ -180,10 +178,6 @@ static int charcompi(SCM c1, SCM c2)
     (int) (tolower((unsigned char) CHARACTER_VAL(c1)) -
            tolower((unsigned char) CHARACTER_VAL(c2)));
 }
-
-/* Comparison of characters. No test on types */
-int STk_charcomp(SCM c1, SCM c2)  { return charcomp(c1,  c2);  }
-int STk_charcompi(SCM c1, SCM c2) { return charcompi(c1,  c2); }
 
 
 int STk_string2char(char *s)

--- a/src/cond.c
+++ b/src/cond.c
@@ -143,7 +143,7 @@ DEFINE_PRIMITIVE("make-condition-type", make_cond_type, subr3,
  *
  * |Make-compound-condition-type| returns a new condition type, built
  * from the condition types |ct~1~|, ...
- * |Id| must be a symbol  that serves as a symbolic name for the
+ * |Id| must be a symbol that serves as a symbolic name for the
  * condition type. The slots names of the new condition type is the
  * union of the slots of conditions |ct~1~| ...
  * 
@@ -315,7 +315,7 @@ DEFINE_PRIMITIVE("make-compound-condition", make_comp_cond, vsubr,
     cts = STk_cons(STRUCT_TYPE(*argv--), cts);
   }
 
-  /* Create a new type and and instance of it for the compound condition */
+  /* Create a new type and instance of it for the compound condition */
   snprintf(buff, sizeof(buff), "&cct-%d", counter++);
   type = STk_make_comp_cond_type(STk_make_uninterned_symbol(buff),
                                  cts);
@@ -545,7 +545,7 @@ int STk_init_cond(void)
                                                      STk_intern("errno")),
                                         module);
 
-  /* Conditions types */
+  /* Condition types */
   ADD_PRIMITIVE(alloc_cond);
   ADD_PRIMITIVE(make_cond_type);
   ADD_PRIMITIVE(ctp);

--- a/src/cpointer.c
+++ b/src/cpointer.c
@@ -172,7 +172,7 @@ DEFINE_PRIMITIVE("cpointer->string",cpointer2string, subr1, (SCM p))
 <doc EXT allocate-bytes
  * (allocate-bytes n)
  *
- * |Allocate-bytes| will allocate |n| consecutive bytes using the
+ * |Allocate-bytes| will allocate |n| consecutive bytes using
  * the standard STklos allocation function (which uses the
  * Boehm–Demers–Weiser garbage collector <<BoehmGC>>).
  * It returns a |cpointer| Scheme object that points to the first byte
@@ -208,7 +208,7 @@ DEFINE_PRIMITIVE("allocate-bytes", allocate_bytes, subr1, (SCM sz))
  * - the C function |free| (if it  was allocated by the standard C |malloc|
  *   function), or
  * - the Boehm GC free  function (if the pointer was allocated using
- *   |allocate-bytes| primitive.
+ *   |allocate-bytes| primitive).
  *
  * @lisp
  * (define a (allocate-bytes 10))

--- a/src/dynload.c
+++ b/src/dynload.c
@@ -83,7 +83,7 @@ void *STk_find_external_function(char *path, char *fname, int error_if_absent)
 
   /* See if the file has already loaded. If so, use the old handle */
   for (l = files_already_loaded; !NULLP(l); l = CDR(l)) {
-    /* An inline Assoc which knows that keys are well formed C strings */
+    /* An inline Assoc which knows that keys are well-formed C strings */
     if (strcmp(STRING_CHARS(CAR(CAR(l))), path) == 0) {
       handle = (void *) CDR(CAR(l));
       break;

--- a/src/dynload.c
+++ b/src/dynload.c
@@ -55,7 +55,7 @@ typedef SCM  (*InfoFunc)(void);
 
 
 static SCM files_already_loaded = (SCM) NULL;
-MUT_DECL(dynload_mutex)
+MUT_DECL(dynload_mutex);
 
 
 static void initialize_dynload(void)

--- a/src/env.c
+++ b/src/env.c
@@ -94,7 +94,7 @@ static void print_module(SCM module, SCM port, int mode)
     STk_nputs(port, "#[library ", 11);
     if (SYMBOLP(name)) {
       STk_putc('(', port);
-      for (char *s = SYMBOL_PNAME(name); *s; s++) {
+      for (const char *s = SYMBOL_PNAME(name); *s; s++) {
         STk_putc((*s == '/') ? ' ': *s, port);
       }
       STk_putc(')', port);

--- a/src/env.c
+++ b/src/env.c
@@ -210,7 +210,7 @@ DEFINE_PRIMITIVE("%register-library-as-module", register_library,
   if (!SYMBOLP(name)) error_bad_symbol(name);
   MODULE_NAME(m) = name;
   register_module(m);
-  return STk_void;;
+  return STk_void;
 }
 
 
@@ -701,7 +701,7 @@ SCM STk_lookup(SCM symbol, SCM env, SCM *ref, int err_if_unbound)
   }
 
   // symbol was not found in the given env module. Try to find it in
-  // the the STklos modle (if this is not a R7RS library)
+  // the STklos modle (if this is not a R7RS library)
   if (!MODULE_IS_LIBRARY(env) &&  env != STk_STklos_module) {
     env = STk_STklos_module;
     res = STk_hash_get_variable(&MODULE_HASH_TABLE(env), symbol);

--- a/src/extend.c
+++ b/src/extend.c
@@ -80,7 +80,7 @@ SCM STk_extended_class_of(SCM o)
 // Scheme aceess to the extended type descriptor
 //
 // ----------------------------------------------------------------------
-static struct extended_type_descr *search_descriptor(char *str) {
+static struct extended_type_descr *search_descriptor(const char* str) {
   for (int i = tc_last_standard+1; i <= user_extended_type; i++) {
     if (strcmp(str, (STk_xtypes[i])->name) == 0) return STk_xtypes[i];
   }

--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -56,25 +56,25 @@ long exp_2_fxwidth() {
 }
 
 #if CONTROL_FX_PARAMETERS == 1
-#define ensure_fx(x) {        \
+#define ensure_fx(x) do{        \
   if (!INTP(x))               \
     error_bad_fixnum1(x);     \
-}
+}while(0)
 
-#define ensure_fx2(x, y) {      \
+#define ensure_fx2(x, y) do{      \
   if (!(INTP(x) && INTP(y)))    \
     error_bad_fixnum2(x, y);    \
-}
+}while(0)
 
-#define ensure_fx3(x, y, z) {           \
+#define ensure_fx3(x, y, z) do{           \
   if (!(INTP(x) && INTP(y) && INTP(z))) \
     error_bad_fixnum3(x, y, z);         \
-}
+}while(0)
 
-#define ensure_fx4(x, y, z, w) {                   \
+#define ensure_fx4(x, y, z, w) do{                   \
   if (!(INTP(x) && INTP(y) && INTP(z) && INTP(w))) \
     error_bad_fixnum4(x, y, z, w);                 \
-}
+}while(0)
 
 static void error_bad_fixnum1(SCM o1)
 {

--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -492,7 +492,7 @@ FX_COMP("fx<=?", fxle, >)
 FX_COMP("fx>?",  fxgt, <=)
 FX_COMP("fx>=?", fxge, <)
 
-/* fx=? is different than other compare ops, as it requires nothing
+/* fx=? is different from other compare ops, as it requires nothing
    else than a direct comparison with ==, so it's defined separately
    --jpellegrini */
 DEFINE_PRIMITIVE("fx=?", fxeq, vsubr, (int argc, SCM *argv))
@@ -737,7 +737,7 @@ doc>
   Count the number of ones in a long integer.
 
   It does work with signed long integers; the 'unsigned long' in the
-  declaration is to fore a cast so 'n' will be treated as if it were
+  declaration is to force a cast so 'n' will be treated as if it were
   unsigned, because the algoritm does shift it to the right, and if
   it's signed negative numbers would get ones from the right side when
   shifted (at least with GCC and LLVM -- this is not defined by the

--- a/src/fport.c
+++ b/src/fport.c
@@ -50,7 +50,7 @@ MUT_DECL(all_fports_mutex);
  * for the redirection. This pid is stored in the internal file port
  * representation to wait on it during the fd_pclose.
  */
-static int fd_popen(char *cmd, char *mode, int *pid)
+static int fd_popen(const char *cmd, const char *mode, int *pid)
 {
   int p[2];
 
@@ -347,7 +347,7 @@ static Inline int Fputc(int c, void *stream)
 }
 
 
-static Inline int Fwrite(void *stream, void *buff, int count)
+static Inline int Fwrite(void *stream, const void *buff, int count)
 {
   /* Flush (eventually) chars which are already in the buffer before writing  */
   if (PORT_CNT(stream)) {
@@ -363,7 +363,7 @@ static Inline int Fwrite(void *stream, void *buff, int count)
 }
 
 
-static Inline int Fnputs(void *stream, char *s, int len)
+static Inline int Fnputs(void *stream, const char *s, int len)
 {
   int res, flush = (PORT_STREAM_FLAGS(stream) & STK_IOLBF);
 
@@ -403,7 +403,7 @@ static Inline int Fnputs(void *stream, char *s, int len)
 }
 
 
-static Inline int Fputs(char *s, void *stream)
+static Inline int Fputs(const char *s, void *stream)
 {
   return Fnputs(stream, s, strlen(s));
 }
@@ -441,7 +441,7 @@ static void fport_finalizer(struct port_obj *port, void _UNUSED(*client_data))
 
 
 static struct port_obj *
-make_fport(char *fname, int fd, int flags)
+make_fport(const char *fname, int fd, int flags)
 {
   struct fstream  *fs = STk_must_malloc(sizeof(struct fstream));
   int n, mode;
@@ -534,7 +534,7 @@ static char *convert_for_win32(char *mode)
 }
 #endif
 
-static int convert_mode(char* mode) {
+static int convert_mode(const char* mode) {
   char first = *mode;
 
   if (mode[1] == 'b')
@@ -561,9 +561,9 @@ static int convert_mode(char* mode) {
 }
 
 
-static SCM open_file_port(SCM filename, char *mode, int flags, int error)
+static SCM open_file_port(SCM filename, const char *mode, int flags, int error)
 {
-  char *full_name, *name;
+  const char *full_name, *name;
   SCM z;
   int fd;
 
@@ -603,7 +603,7 @@ static SCM open_file_port(SCM filename, char *mode, int flags, int error)
 
 
 
-SCM STk_fd2scheme_port(int fd, char *mode, char *identification)
+SCM STk_fd2scheme_port(int fd, const char *mode, char *identification)
 {
   int flags;
 

--- a/src/fport.c
+++ b/src/fport.c
@@ -40,7 +40,7 @@
 
 int STk_interactive = 0;                  /* We are in interactive mode */
 SCM STk_stdin, STk_stdout, STk_stderr;    /* The unredirected ports */
-MUT_DECL(all_fports_mutex)
+MUT_DECL(all_fports_mutex);
 
 /*
  * Implementation of our own popen/pclose. We use her file descriptor, instad

--- a/src/fport.c
+++ b/src/fport.c
@@ -166,7 +166,7 @@ void STk_close_all_ports(void)
   }
   MUT_UNLOCK(all_fports_mutex);
 
-  /* Finally close error and output port (must be done last) */
+  /* Finally, close error and output port (must be done last) */
   STk_close(eport);
   STk_close(oport);
 }
@@ -460,7 +460,7 @@ make_fport(char *fname, int fd, int flags)
   /* keep the indication that file is opened in read in the stream part */
   if (flags & (PORT_READ | PORT_RW)) mode |= STK_IOREAD;
 
-  /* Set the case sensitive bit */
+  /* Set the case-sensitive bit */
   if (STk_read_case_sensitive) flags |= PORT_CASE_SENSITIVE;
 
   /* Initialize the stream part */

--- a/src/fport.h
+++ b/src/fport.h
@@ -35,7 +35,7 @@
 
 #define STK_IOFBF   (1 << 0) /* Full buffered*/
 #define STK_IOLBF   (1 << 1) /* Line buffered */
-#define STK_IONBF   (1 << 2) /* No buffered (unused for now) */
+#define STK_IONBF   (1 << 2) /* Non buffered (unused for now) */
 #define STK_IOEOF   (1 << 3) /* EOF encountered on this file */
 #define STK_IOREAD  (1 << 4) /* File is opened in read */
 

--- a/src/fport.h
+++ b/src/fport.h
@@ -52,7 +52,7 @@ struct fstream {
   SCM  idle_procs;
   void *user_data;
   int (*low_read)(struct fstream *f, void *buf, int count);
-  int (*low_write)(struct fstream *f, void *buf, int count);
+  int (*low_write)(struct fstream *f, const void *buf, int count);
 };
 
 

--- a/src/gnu-getopt.c
+++ b/src/gnu-getopt.c
@@ -91,7 +91,7 @@ static void getopt_fprintf(FILE* f, const char *format, ...)
 
 void STk_start_getopt_from_scheme(void)
 {
-  we_are_in_scheme = TRUE; /* Don't use anymore fprintf for reportin errors */
+  we_are_in_scheme = TRUE; /* Don't use fprintf anymore for reporting errors */
 }
 
 
@@ -150,7 +150,7 @@ void STk_start_getopt_from_scheme(void)
    to intersperse the options with the other arguments.
 
    As `getopt' works, it permutes the elements of ARGV so that,
-   when it is done, all the options precede everything else.  Thus
+   when it is done, all the options precede everything else.  Thus,
    all application programs are extended to handle flexible argument order.
 
    Setting the environment variable POSIXLY_CORRECT disables permutation.
@@ -535,7 +535,7 @@ _getopt_initialize (argc, argv, optstring)
    OPTSTRING is a string containing the legitimate option characters.
    If an option character is seen that is not listed in OPTSTRING,
    return '?' after printing an error message.  If you set `opterr' to
-   zero, the error message is suppressed but we still return '?'.
+   zero, the error message is suppressed, but we still return '?'.
 
    If a char in OPTSTRING is followed by a colon, that means it wants an arg,
    so the following text in the same ARGV-element, or the text of the following
@@ -684,7 +684,7 @@ _getopt_internal (argc, argv, optstring, longopts, longind, long_only)
 
      If long_only and the ARGV-element has the form "-f", where f is
      a valid short option, don't consider it an abbreviated form of
-     a long option that starts with f.  Otherwise there would be no
+     a long option that starts with f.  Otherwise, there would be no
      way to give the -f short option.
 
      On the other hand, if there's a long option "fubar" and

--- a/src/hash.c
+++ b/src/hash.c
@@ -79,7 +79,7 @@ static unsigned long hash_string(register char *string)
    *    and multiplying by 9 is just about as good.
    * 2. Times-9 is (shift-left-3) plus (old).  This means that each
    *    character's bits hang around in the low-order bits of the
-   *    hash value for ever, plus they spread fairly rapidly up to
+   *    hash value forever, plus they spread fairly rapidly up to
    *    the high-order bits to fill out the hash value.  This seems
    *    works well both for decimal and non-decimal strings.
    */
@@ -140,8 +140,8 @@ static unsigned long sxhash(SCM obj)
                         return h;
     default:            /* A complex type (STklos object, user defined type,
                          * hashtable...). In this case we return the type of the
-                         * object. This is very  inneficient but it should be
-                         * rare to use a  structured object as a key.
+                         * object. This is very inefficient, but it should be
+                         * rare to use a structured object as a key.
                          */
                          return (unsigned long) BOXED_TYPE(obj);
   }
@@ -225,7 +225,7 @@ static void enlarge_table(register struct hash_table_obj *h)
     HASH_BUCKETS(h)[i] = STk_nil;
   }
 
-  /*  Rehash all of the existing entries into the new bucket array. */
+  /*  Rehash all the existing entries into the new bucket array. */
   for (i = 0; i < old_size; i++) {
     for (tmp = old_buckets[i]; !NULLP(tmp); tmp = CDR(tmp)) {
       switch (BOXED_INFO(h)) {
@@ -333,7 +333,7 @@ SCM STk_hash_intern_symbol(struct hash_table_obj *h, char *s, SCM (*create) (cha
 
 /*===========================================================================*\
  *
- *             v a r i a b l e s    h a s h t a b l e   f u n t i o n s
+ *             v a r i a b l e s    h a s h t a b l e   f u n c t i o n s
  *
  *
  * Here variable are the variables defined in a module. Keys are symbols.
@@ -869,12 +869,12 @@ DEFINE_PRIMITIVE("hash-table-map", hash_map, subr2, (SCM ht, SCM proc))
  * (hash-table-hash obj)
  *
  * Computes a hash code for an object and returns this hash code as a
- * non negative integer. A property of |hash-table-hash| is that
+ * non-negative integer. A property of |hash-table-hash| is that
  * @lisp
  * (equal? x y) => (equal? (hash-table-hash x) (hash-table-hash y)
  * @end lisp
  *
- * as the the Common Lisp |sxhash| function from which this procedure is
+ * as the Common Lisp |sxhash| function from which this procedure is
  * modeled.
 doc>
 */

--- a/src/hash.c
+++ b/src/hash.c
@@ -64,7 +64,7 @@
  *
 \*===========================================================================*/
 
-static unsigned long hash_string(register char *string)
+static unsigned long hash_string(const register char* string)
 {
   register unsigned long result = 0;
   register int c;
@@ -93,7 +93,7 @@ static unsigned long hash_string(register char *string)
 
 static unsigned long hash_scheme_string(SCM str)
 {                                            /* The same one for Scheme strings */
-  char *string;
+  const char *string;
   unsigned long result = 0;
   int i, l;
 
@@ -299,7 +299,7 @@ void STk_hashtable_init(struct hash_table_obj *h, int flag)
  *
 \*===========================================================================*/
 
-static Inline SCM hash_get_symbol(struct hash_table_obj *h, char *s, int *index)
+static Inline SCM hash_get_symbol(struct hash_table_obj *h, const char* s, int *index)
 {
   register SCM l;
 
@@ -312,7 +312,7 @@ static Inline SCM hash_get_symbol(struct hash_table_obj *h, char *s, int *index)
 }
 
 
-SCM STk_hash_intern_symbol(struct hash_table_obj *h, char *s, SCM (*create) (char*s))
+SCM STk_hash_intern_symbol(struct hash_table_obj *h, const char* s, SCM (* create) (const char* s))
 {
   SCM z;
   int index;

--- a/src/hash.c
+++ b/src/hash.c
@@ -152,11 +152,11 @@ static unsigned long sxhash(SCM obj)
  *                              H a s h    S t a t s
  *
 \*===========================================================================*/
-#define _MAX_COUNT 5
+#define MAX_COUNT 5
 
 static void hash_stats(struct hash_table_obj *h, SCM port)
 {
-  int i, j, more, len, count[_MAX_COUNT] = {0};
+  int i, j, more, len, count[MAX_COUNT] = {0};
 
   /* If we're using unicode, we can draw a nicer histogram bar... */
   char *bar_char;
@@ -175,7 +175,7 @@ static void hash_stats(struct hash_table_obj *h, SCM port)
         STk_fprintf(port,bar_char);
     STk_putc('\n', port);
 
-    if (len < _MAX_COUNT)
+    if (len < MAX_COUNT)
       count[len] += 1;
     else
       more += 1;
@@ -186,12 +186,12 @@ static void hash_stats(struct hash_table_obj *h, SCM port)
               (double) HASH_NENTRIES(h)/ HASH_NBUCKETS(h));
   STk_fprintf(port, "Repartition\n");
 
-  for (i = 0; i < _MAX_COUNT; i++) {
+  for (i = 0; i < MAX_COUNT; i++) {
     if (count[i])
       STk_fprintf(port, "  %d buckets with %d entries\n", count[i], i);
   }
   if (more)
-    STk_fprintf(port, "  %d buckets with more than %d entries\n", more, _MAX_COUNT);
+    STk_fprintf(port, "  %d buckets with more than %d entries\n", more, MAX_COUNT);
 }
 
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -345,7 +345,7 @@ SCM STk_hash_intern_symbol(struct hash_table_obj *h, const char* s, SCM (* creat
 static inline SCM hash_get_variable(struct hash_table_obj *h, SCM v, int *index)
 {
   register SCM l;
-  char *s = SYMBOL_PNAME(v);
+  const char *s = SYMBOL_PNAME(v);
 
   *index = hash_string(s) & HASH_MASK(h);
 
@@ -639,7 +639,7 @@ DEFINE_PRIMITIVE("hash-table-set!", hash_set, subr3, (SCM ht, SCM key, SCM val))
  * @end lisp
 doc>
 */
-static Inline SCM hash_table_search(SCM ht, SCM key)
+Inline SCM hash_table_search(SCM ht, SCM key)
 {
   int index = 0;
   SCM func, l = STk_nil;

--- a/src/hash.h
+++ b/src/hash.h
@@ -86,8 +86,8 @@ void STk_hashtable_init(struct hash_table_obj *h, int flag);
  * little interest except for the obarrays. Don't use it but the
  * higher level interface instead.
  */
-SCM STk_hash_intern_symbol(struct hash_table_obj *h, char *s,
-                           SCM (*create)(char *s));
+SCM STk_hash_intern_symbol(struct hash_table_obj *h, const char* s,
+                           SCM (* create)(const char* s));
 
 /*
  * Function for accessing module hash table. Don't use them but the

--- a/src/hash.h
+++ b/src/hash.h
@@ -102,7 +102,7 @@ void STk_hash_set_alias(struct hash_table_obj *h, SCM v, SCM value, int ronly);
  */
 SCM STk_hash_keys(struct hash_table_obj *h);
 SCM STk_make_basic_hash_table(void);
-SCM STk_hash_table_search(SCM ht, SCM key);
+SCM hash_table_search(SCM ht, SCM key);
 
 /*
  * Scheme interface

--- a/src/keyword.c
+++ b/src/keyword.c
@@ -239,7 +239,7 @@ DEFINE_PRIMITIVE("key-set!", key_set, subr3, (SCM l, SCM key, SCM val))
  * |key-delete| remove the |key| and its associated value of the keyword
  * list. The key can be absent of the list.
  * 
- * |key-delete!| does the same job than |key-delete| by physically 
+ * |key-delete!| does the same job as |key-delete| by physically
  * modifying its |list| argument.
  * @lisp
  * (key-delete '(:one 1 :two 2) :two)    => (:one 1)

--- a/src/keyword.c
+++ b/src/keyword.c
@@ -48,7 +48,7 @@ static void error_const_cell(SCM x)
   STk_error("changing the constant ~s is not allowed", x);
 }
 
-static SCM make_uninterned_keyword(char *name)
+static SCM make_uninterned_keyword(const char *name)
 {
   SCM z;
 
@@ -59,7 +59,7 @@ static SCM make_uninterned_keyword(char *name)
 }
 
 
-SCM STk_makekey(char *token)
+SCM STk_makekey(const char* token)
 {
   SCM res;
   MUT_DECL(lck);
@@ -94,7 +94,7 @@ doc>
  */
 DEFINE_PRIMITIVE("make-keyword", make_keyword, subr1, (SCM str))
 {
-  char *s = "";
+  const char *s = "";
 
   if (STRINGP(str))
     s = STRING_CHARS(str);

--- a/src/list.c
+++ b/src/list.c
@@ -747,7 +747,7 @@ DEFINE_PRIMITIVE("last-pair", last_pair, subr1, (SCM l))
  * |Filter| returns all the elements of |list| that satisfy predicate
  * |pred|. The |list| is not disordered: elements that appear in the
  * result list occur in the same order as they occur in the argument
- * list. |Filter!| does the same job than |filter| by physically
+ * list. |Filter!| does the same job as |filter| by physically
  * modifying its |list| argument
  * @lisp
  * (filter even? '(0 7 8 8 43 -4)) => (0 8 8 -4)
@@ -915,7 +915,7 @@ SCM STk_dremq(SCM obj, SCM list)
 
 /*
  *
- * Fast version of assq; for internal use only (alist must be well formed)
+ * Fast version of assq; for internal use only (alist must be well-formed)
  *
  */
 SCM STk_int_assq(SCM obj, SCM alist)

--- a/src/list.c
+++ b/src/list.c
@@ -540,7 +540,7 @@ doc>
 
 
 #define LMEMBER(compare)                                        \
-{                                                               \
+do{                                                             \
   register SCM ptr;                                             \
                                                                 \
   if (!CONSP(list) && !NULLP(list)) error_bad_list(list);       \
@@ -554,14 +554,18 @@ doc>
     if ((ptr=CDR(ptr)) == list) error_circular_list(ptr);       \
   }                                                             \
   return STk_false;                                             \
-}
+}while(0)
 
 
 DEFINE_PRIMITIVE("memq", memq, subr2, (SCM obj, SCM list))
-     LMEMBER(PTR_EQ)
+{
+    LMEMBER(PTR_EQ);
+}
 
 DEFINE_PRIMITIVE("memv", memv, subr2, (SCM obj, SCM list))
-     LMEMBER(PTR_EQV)
+{
+    LMEMBER(PTR_EQV);
+}
 
 DEFINE_PRIMITIVE("member", member, subr23, (SCM obj, SCM list, SCM cmp))
 {
@@ -615,7 +619,7 @@ doc>
  */
 
 #define LASSOC(compare)                                         \
-{                                                               \
+do{                                                             \
   register SCM l,tmp;                                           \
                                                                 \
   for(l=alist; CONSP(l); ) {                                    \
@@ -626,13 +630,17 @@ doc>
   if (NULLP(l)) return(STk_false);                              \
   STk_error("improper list ~W", alist);                         \
   return STk_void; /* never reached */                          \
-}
+}while(0)
 
 DEFINE_PRIMITIVE("assq", assq, subr2, (SCM obj, SCM alist))
-     LASSOC(PTR_EQ)
+{
+    LASSOC(PTR_EQ);
+}
 
 DEFINE_PRIMITIVE("assv", assv, subr2, (SCM obj, SCM alist))
-     LASSOC(PTR_EQV)
+{
+    LASSOC(PTR_EQV);
+}
 
 DEFINE_PRIMITIVE("assoc", assoc, subr23, (SCM obj, SCM alist, SCM cmp))
 {

--- a/src/md5.c
+++ b/src/md5.c
@@ -46,20 +46,20 @@ struct md5_context
 
 
 #define GET_UINT32(n,b,i)                                       \
-{                                                               \
+do{                                                             \
     (n) = (uint32) ((uint8 *) b)[(i)]                           \
       | (((uint32) ((uint8 *) b)[(i)+1]) <<  8)                 \
       | (((uint32) ((uint8 *) b)[(i)+2]) << 16)                 \
       | (((uint32) ((uint8 *) b)[(i)+3]) << 24);                \
-}
+}while(0)
 
 #define PUT_UINT32(n,b,i)                                       \
-{                                                               \
+do{                                                             \
     (((uint8 *) b)[(i)]  ) = (uint8) (((n)      ) & 0xFF);      \
     (((uint8 *) b)[(i)+1]) = (uint8) (((n) >>  8) & 0xFF);      \
     (((uint8 *) b)[(i)+2]) = (uint8) (((n) >> 16) & 0xFF);      \
     (((uint8 *) b)[(i)+3]) = (uint8) (((n) >> 24) & 0xFF);      \
-}
+}while(0)
 
 static void md5_starts( struct md5_context *ctx )
 {

--- a/src/md5.c
+++ b/src/md5.c
@@ -45,20 +45,20 @@ struct md5_context
 
 
 
-#define GET_UINT32(n,b,i)                                       \
-do{                                                             \
-    (n) = (uint32) ((uint8 *) b)[(i)]                           \
-      | (((uint32) ((uint8 *) b)[(i)+1]) <<  8)                 \
-      | (((uint32) ((uint8 *) b)[(i)+2]) << 16)                 \
-      | (((uint32) ((uint8 *) b)[(i)+3]) << 24);                \
+#define GET_UINT32(n,b,i)                                         \
+do{                                                               \
+    (n) = (uint32) ((uint8 *) (b))[(i)]                           \
+      | (((uint32) ((uint8 *) (b))[(i)+1]) <<  8)                 \
+      | (((uint32) ((uint8 *) (b))[(i)+2]) << 16)                 \
+      | (((uint32) ((uint8 *) (b))[(i)+3]) << 24);                \
 }while(0)
 
-#define PUT_UINT32(n,b,i)                                       \
-do{                                                             \
-    (((uint8 *) b)[(i)]  ) = (uint8) (((n)      ) & 0xFF);      \
-    (((uint8 *) b)[(i)+1]) = (uint8) (((n) >>  8) & 0xFF);      \
-    (((uint8 *) b)[(i)+2]) = (uint8) (((n) >> 16) & 0xFF);      \
-    (((uint8 *) b)[(i)+3]) = (uint8) (((n) >> 24) & 0xFF);      \
+#define PUT_UINT32(n,b,i)                                         \
+do{                                                               \
+    (((uint8 *) (b))[(i)]  ) = (uint8) (((n)      ) & 0xFF);      \
+    (((uint8 *) (b))[(i)+1]) = (uint8) (((n) >>  8) & 0xFF);      \
+    (((uint8 *) (b))[(i)+2]) = (uint8) (((n) >> 16) & 0xFF);      \
+    (((uint8 *) (b))[(i)+3]) = (uint8) (((n) >> 24) & 0xFF);      \
 }while(0)
 
 static void md5_starts( struct md5_context *ctx )
@@ -71,7 +71,7 @@ static void md5_starts( struct md5_context *ctx )
     ctx->state[3] = 0x10325476;
 }
 
-static void md5_process( struct md5_context *ctx, uint8 data[64] )
+static void md5_process( struct md5_context *ctx, const uint8 data[static 64] )
 {
     uint32 A, B, C, D, X[16];
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -72,7 +72,7 @@ void STk_add_primitive_in_module(struct primitive_obj *o, SCM module)
 
 
 
-SCM STk_eval_C_string(char *str, SCM module)
+SCM STk_eval_C_string(const char* str, SCM module)
 {
   SCM ref, eval = STk_lookup(STk_intern("eval-from-string"),
                              module,
@@ -82,7 +82,7 @@ SCM STk_eval_C_string(char *str, SCM module)
 }
 
 
-SCM STk_read_from_C_string(char *str)
+SCM STk_read_from_C_string(const char* str)
 {
   return STk_read(STk_open_C_string(str), STk_read_case_sensitive);
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -211,8 +211,8 @@ DEFINE_PRIMITIVE("%initialize-getopt", init_getopt, subr3, (SCM argv, SCM s, SCM
   int i, len;
 
   STk_start_getopt_from_scheme();
-  optind = 1;    /* Initialize optind, since it has already be used
-                  * by ouserlves  before initializing the VM.
+  optind = 1;    /* Initialize optind, since it has already been used
+                  * by ourselves before initializing the VM.
                   */
 
   /*
@@ -313,7 +313,7 @@ static char URI_regexp[] =
 <doc EXT uri-parse
  * (uri-parse str)
  *
- * Parses the string |str| as a RFC-2396 URI and return a keyed list with the
+ * Parses the string |str| as an RFC-2396 URI and return a keyed list with the
  * following components
  *
  * - |scheme| : the scheme used as a string (defaults to |"file"|)
@@ -384,7 +384,7 @@ DEFINE_PRIMITIVE("uri-parse", uri_parse, subr1, (SCM url_str))
     for (start = url; *url && *url != '/' && *url != '@'; url++) {
     }
     if (*url == '@') {
-      /* We have an user */
+      /* We have a user */
       user = STk_makestring(url-start, start);
       /* read the host now */
       for (start = ++url; *url && *url != '/' && *url != ':'; url++) {
@@ -461,7 +461,7 @@ Error:
  * (string->html str)
  *
  * This primitive is a convenience function; it returns a string where
- * the HTML special chars are properly translated. It can easily written
+ * the HTML special chars are properly translated. It can easily be written
  * in Scheme, but this version is fast.
  * @lisp
  * (string->html "Just a <test>")

--- a/src/number.c
+++ b/src/number.c
@@ -99,7 +99,7 @@ static int zerop(SCM n);
 static int negativep(SCM n);
 static int positivep(SCM n);
 static int isexactp(SCM z);
-static SCM gcd2(SCM o1, SCM o2);
+static SCM gcd2(SCM n1, SCM n2);
 
 EXTERN_PRIMITIVE("make-rectangular", make_rectangular, subr2, (SCM r, SCM i));
 EXTERN_PRIMITIVE("real-part", real_part, subr1, (SCM z));
@@ -118,10 +118,10 @@ EXTERN_PRIMITIVE("inexact->exact", inex2ex, subr1, (SCM z));
 #define inexact2exact STk_inex2ex
 
 
-static SCM int_quotient(SCM o1, SCM o2);
+static SCM int_quotient(SCM x, SCM y);
 static SCM my_cos(SCM z);
 static SCM my_sin(SCM z);
-static SCM STk_complexp(SCM n);
+static SCM STk_complexp(SCM x);
 
 
 /******************************************************************************
@@ -1001,7 +1001,7 @@ static SCM compute_exact_real(char *s, char *p1, char *p2, char *p3, char *p4)
  * (no double underscores, no leading or trailing underscores, and no
  * underscore close to anything that is not a digit).
  */
-static int remove_underscores(char *str, char *end, long base) {
+static int remove_underscores(char *str, const char *end, long base) {
   char *q;
   int just_saw_one = 0;
   for (char *p=str; p<end-1; p++)
@@ -1156,7 +1156,7 @@ static SCM read_rational(SCM num, char *str, long base, char exact_flag, char **
   return STk_false;             /* never reached */
 }
 
-SCM STk_Cstr2number(char *str, long base)
+SCM STk_Cstr2number(const char* str, long base)
 {
   int i, exact, radix, polar, is_signed;
   char *p = str;

--- a/src/number.c
+++ b/src/number.c
@@ -667,7 +667,7 @@ static type_cell convert(SCM *px, SCM *py)
     case tc_real:
             switch (TYPEOF(y)) {
               case tc_complex:  *px = Cmake_complex(x, MAKE_INT(0));    break;
-              case tc_real:    /*already done */ ;                      break;
+              case tc_real:    /*already done */                        break;
               case tc_rational: *py = rational2real(y);                 break;
               case tc_bignum:   *py = scheme_bignum2real(y);            break;
               case tc_integer:  *py = double2real((double) INT_VAL(y)); break;
@@ -678,7 +678,7 @@ static type_cell convert(SCM *px, SCM *py)
             switch (TYPEOF(y)) {
               case tc_complex:  *px = Cmake_complex(x, MAKE_INT(0));   break;
               case tc_real:     *px = rational2real(x);                break;
-              case tc_rational: /*already done */ ;                    break;
+              case tc_rational: /*already done */                      break;
               case tc_bignum:   /* no break */
               case tc_integer:  *py = Cmake_rational(y , MAKE_INT(1)); break;
               default:          error_bad_number(y);                   break;

--- a/src/number.c
+++ b/src/number.c
@@ -1156,7 +1156,7 @@ static SCM read_rational(SCM num, char *str, long base, char exact_flag, char **
   return STk_false;             /* never reached */
 }
 
-SCM STk_Cstr2number(const char* str, long base)
+SCM STk_Cstr2number(char* str, long base)
 {
   int i, exact, radix, polar, is_signed;
   char *p = str;

--- a/src/number.c
+++ b/src/number.c
@@ -182,7 +182,7 @@ static double make_nan(int neg, int quiet, unsigned long pay)
    * BUT
    *   +inf.0          is 0x7ff0000000000000
    * Consequently, clearing bit 51 is not sufficient (if the payload is 0, a
-   * signaling dille be seen as a positive infinity.
+   * signaling dille be seen as a positive infinity).
    * So, to make a signaling NaN, we clear the bit 51 and set the bit 50
    * ==> the payload can use only 50 bits
    */
@@ -397,7 +397,7 @@ static Inline SCM double2real(double x)
   return z;
 }
 
-static SCM double2integer(double n)     /* small or big depending of n's size */
+static SCM double2integer(double n)     /* small or big depending on n's size */
 {
   unsigned int i, j;
   size_t size = 30;
@@ -1084,7 +1084,7 @@ static SCM read_integer_or_real(char *str, long base, char exact_flag, char **en
      * digits expressed in base 10) are not read as bignums.
      * This optimisation is easily missed (e.g. 000000000000000001 will be
      * read as a bignum), but it avoids allocation for current numbers
-     * represented in an usual form.
+     * represented in a usual form.
      */
     mpz_t n;
 
@@ -1262,8 +1262,8 @@ SCM STk_Cstr2number(char *str, long base)
  * These numerical type predicates can be applied to any kind of
  * argument, including non-numbers. They return |#t| if the object is of
  * the named type, and otherwise they return |#f|. In general, if a type
- * predicate is true of a number then all higher type predicates are
- * also true of that number. Consequently, if a type predicate is
+ * predicate is true for a number then all higher type predicates are
+ * also true for that number. Consequently, if a type predicate is
  * false of a number, then all lower type predicates are also false of
  * that number.
  *
@@ -3349,7 +3349,7 @@ int STk_init_number(void)
                           reallocate_function,
                           deallocate_function);
 
-  /* register the extended types types for numbers */
+  /* register the extended types for numbers */
   DEFINE_XTYPE(bignum,   &xtype_bignum);
   DEFINE_XTYPE(rational, &xtype_rational);
   DEFINE_XTYPE(complex,  &xtype_complex);

--- a/src/object.c
+++ b/src/object.c
@@ -183,7 +183,7 @@ static int applicablep(SCM actual, SCM formal)
 
   /* We test that (memq formal (slot-ref actual 'cpl))
    * However, we don't call memq here since we already know that
-   * the list is well formed
+   * the list is well-formed
    */
   for (ptr=INST_SLOT(actual, S_cpl); !NULLP(ptr); ptr = CDR(ptr)) {
     if (CAR(ptr) == formal) return TRUE;
@@ -793,7 +793,7 @@ static SCM compute_getters_n_setters(SCM slots)
   /* Build a kind of A-list which is something like
    *     ( .... (slot-name #f . 3) ... )
    * where #f is the slot initialization function and 3 is the offset of a slot
-   * in a the vector of slots
+   * in a vector of slots
    */
   for (  ; !NULLP(slots); slots = CDR(slots))
     res = STk_cons(STk_cons(CAR(slots),

--- a/src/object.h
+++ b/src/object.h
@@ -93,7 +93,7 @@ struct instance_obj {
  * of the closure which implement method body.
  */
 #define SET_NEXT_METHOD(closure, value) \
-		{FRAME_LOCAL(CLOSURE_ENV(closure),0) = (value);}
+		FRAME_LOCAL(CLOSURE_ENV(closure),0) = (value)
 
 EXTERN_PRIMITIVE("method?", methodp, subr1, (SCM obj));
 EXTERN_PRIMITIVE("generic?", genericp, subr1, (SCM obj));

--- a/src/object.h
+++ b/src/object.h
@@ -129,7 +129,5 @@ struct next_method_obj {
 
 SCM STk_make_next_method(SCM gf, int argc, SCM *argv, SCM methods);
 
-SCM STk_int_call_gf(char *name, SCM val, int nargs); /* FIXME: Utilisée encore? */
-
 
 extern int STk_oo_initialized;			     /* FIXME: */

--- a/src/path.c
+++ b/src/path.c
@@ -36,7 +36,7 @@
  *
 \*===========================================================================*/
 
-static void tilde_expand(char *name, char *result, size_t result_len)
+static void tilde_expand(const char *name, char *result, size_t result_len)
 {
   char *p;
   struct passwd *pwPtr;
@@ -144,7 +144,7 @@ static void absolute(char *s, char *pathname)
 \*===========================================================================*/
 #define MAXLINK 50  /* Number max of link before declaring we have a loop */
 
-SCM STk_resolve_link(char *path, int count)
+SCM STk_resolve_link(const char* path, int count)
 {
 #ifdef WIN32
   return STk_Cstring2string(STk_expand_file_name(path));
@@ -203,7 +203,7 @@ SCM STk_resolve_link(char *path, int count)
  * STk_expand_file_name
  *
 \*===========================================================================*/
-char *STk_expand_file_name(char *s)
+char *STk_expand_file_name(const char* s)
 {
   char expanded[2 * MAX_PATH_LENGTH], abs[2 * MAX_PATH_LENGTH];
   /* Warning: absolute makes no control about path overflow. Hence the "2 *" */

--- a/src/path.c
+++ b/src/path.c
@@ -38,7 +38,7 @@
 
 static void tilde_expand(const char *name, char *result, size_t result_len)
 {
-  char *p;
+  const char *p;
   struct passwd *pwPtr;
 
   if (name[0] != '~') {

--- a/src/path.h
+++ b/src/path.h
@@ -42,7 +42,7 @@
 #  include <unistd.h>
 #  include <pwd.h>
 #  define ISDIRSEP(ch) 	 ((ch)=='/')
-#  define ISABSOLUTE(s) (ISDIRSEP(*s))
+#  define ISABSOLUTE(s) (ISDIRSEP(*(s)))
 #  define DIRSEP 	 '/'
 #  define SDIRSEP  	 "/"
 #  define PATHSEP	 ':'

--- a/src/port.c
+++ b/src/port.c
@@ -143,7 +143,7 @@ DEFINE_PRIMITIVE("output-port?", output_portp, subr1, (SCM port))
  * (textual-port? obj)
  * (binary-port? obj)
  *
- * Returns |#t| if |obj| is an textual port or binary port respectively,
+ * Returns |#t| if |obj| is a textual port or binary port respectively,
  * otherwise returns |#f|.
 doc>
  */
@@ -211,7 +211,7 @@ SCM STk_current_output_port(void){ return STk_get_current_vm()->oport; }
 SCM STk_current_error_port(void) { return STk_get_current_vm()->eport; }
 
 /* The setters for the standard port (since current-xxx-port are parameters
- * in R7RS.
+ * in R7RS).
  */
 static SCM STk_set_current_input_port(SCM port)
 {
@@ -1194,8 +1194,8 @@ DEFINE_PRIMITIVE("format", format, vsubr, (int argc, SCM *argv))
  * |format| (see _<<format, primitive `format`>>_); in this case this
  * procedure builds an error message according to the specification
  * given in |str|. Otherwise,
- * this procedure is conform to the |error| procedure defined in
- * {{link-srfi 23}} and  |str| is printed with the |display| procedure,
+ * this procedure is in conformance with the |error| procedure defined in
+ * {{link-srfi 23}} and |str| is printed with the |display| procedure,
  * whereas the |obj|s are printed  with the |write| procedure.
  *
  * Hereafter, are some calls of the |error| procedure using a formatted string
@@ -1385,7 +1385,7 @@ DEFINE_PRIMITIVE("port-open?", port_open, subr1, (SCM port))
  * (read-line port)
  *
  * Reads the next line available from the input port |port|. This function
- * returns 2 values: the first one is is the string which contains the line
+ * returns 2 values: the first one is the string which contains the line
  * read, and the second one is the end of line delimiter. The end of line
  * delimiter can be an end of file object, a character or a string in case
  * of a multiple character delimiter. If no more characters are available
@@ -1522,7 +1522,7 @@ DEFINE_PRIMITIVE("flush-output-port", port_flush, subr01, (SCM port))
  * the value returned by |current-input-port|.
  * @l
  * NOTE: The |port-seek|, |read-chars| and |read-chars!| procedures
- * generally break the line-number. After using one of theses procedures, the
+ * generally break the line-number. After using one of these procedures, the
  * value returned by |port-current-line| will be |-1| (except a |port-seek|
  * at the beginning of the port reinitializes the line counter).
 doc>

--- a/src/print.c
+++ b/src/print.c
@@ -157,7 +157,7 @@ static void printstring(SCM s, SCM port, int mode)
                       if (printable)
                         *buff++ = *p;
                       else {
-                        /* Non printable char. (It works only for char < 0xFF !!) */
+                        /* Non-printable char. (It works only for char < 0xFF !!) */
                         *buff++ = '\\';
                         *buff++ = 'x';
                         *buff++ = printhexa((unsigned char) *p / 16);

--- a/src/print.c
+++ b/src/print.c
@@ -33,7 +33,7 @@ static int pretty_quotes = 1;
 static void printlist(SCM exp, SCM port, int mode)
 {
   register SCM tmp;
-  char *s;
+  const char *s;
 
   if (pretty_quotes) {
     /* Special case for pretty printing of quoted expressions */
@@ -62,7 +62,7 @@ static void printlist(SCM exp, SCM port, int mode)
 
 static Inline void printsymbol(SCM symb, SCM port, int mode)
 {
-  char *s = SYMBOL_PNAME(symb);
+  const char *s = SYMBOL_PNAME(symb);
 
   if ((mode==WRT_MODE) &&
       ((BOXED_INFO(symb) & SYMBOL_NEEDS_BARS) ||

--- a/src/process.c
+++ b/src/process.c
@@ -81,7 +81,7 @@ static SCM all_processes = STk_nil;
 #endif
 
 #ifdef USE_SIGCHLD
-#  define PURGE_PROCESS_TABLE()                             /* Nothing to do */
+#  define PURGE_PROCESS_TABLE()   (void)0                          /* Nothing to do */
 #else
 #  define PURGE_PROCESS_TABLE() process_terminate_handler(0)/* Simulate a SIGCHLD */
 #endif

--- a/src/process.c
+++ b/src/process.c
@@ -62,7 +62,7 @@ struct process_obj {
   SCM streams[3];               /* standard ports for the process */
   int exited;                   /* Process is terminated */
   int exit_status;              /* Exit status of the processus */
-  int waited_on;                /* non zero if the process is being
+  int waited_on;                /* non-zero if the process is being
                                    waited on by a waitpid(..,..,0) */
 };
 
@@ -131,7 +131,7 @@ static void process_terminate_handler(int _UNUSED(sig)) /* called when a child d
   /* Delete the processes which are not alive from the global list
    * This loop may delete nobody if this the process has been deleted
    * before (a previous call to this function may have deleted more than
-   * one process.
+   * one process).
    * Note: No assumption is made on the process which has terminated;
    * we act blindly here since it does not seem that there is a POSIX way
    * to find the id of the process which died.
@@ -398,12 +398,12 @@ DEFINE_PRIMITIVE("%run-process", run_process, subr4,
  * call which permits to create a new (heavy) process.
  * When called without parameter, this procedure returns two times
  * (one time in the parent process and one time in the child process).
- * The value returned in the parent process is a process object
- * representing the child process and the value returned in the child
+ * The value returned to the parent process is a process object
+ * representing the child process and the value returned to the child
  * process is always the value |#f|.
  * When called with a parameter (which must be a thunk), the new process
  * excutes |thunk| and terminate it execution when |thunk| returns. The
- * value returned in the parent process is a process object representing
+ * value returned to the parent process is a process object representing
  * the child process.
 doc>
 */

--- a/src/process.c
+++ b/src/process.c
@@ -86,7 +86,7 @@ static SCM all_processes = STk_nil;
 #  define PURGE_PROCESS_TABLE() process_terminate_handler(0)/* Simulate a SIGCHLD */
 #endif
 
-MUT_DECL(process_table_mutex)
+MUT_DECL(process_table_mutex);
 
 /******************************************************************************/
 

--- a/src/promise.c
+++ b/src/promise.c
@@ -225,7 +225,7 @@ static struct extended_type_descr xtype_promise = {
 
 int STk_init_promise(void)
 {
-  /* register the extended type type for promises */
+  /* register the extended type for promises */
   DEFINE_XTYPE(promise,   &xtype_promise);
 
   /* Add primitives */

--- a/src/read.c
+++ b/src/read.c
@@ -148,7 +148,7 @@ static void warning_bad_escaped_sequence(SCM port, int c)
 }
 
 
-static int colon_position_value(char *str)
+static int colon_position_value(const char* str)
 {
   if      (strcmp(str, "none")   == 0) return COLON_NONE;
   else if (strcmp(str, "before") == 0) return COLON_BEFORE;
@@ -898,7 +898,7 @@ static SCM read_rec(SCM port, struct read_context *ctx, int inlist)
                          SCM word = read_token(port, c, FALSE);
 
                          if (SYMBOLP(word)) {
-                           char *s = SYMBOL_PNAME(word);
+                           const char *s = SYMBOL_PNAME(word);
 
                            /* Try to see if it is a DSSL keyword */
                            if ((strcmp(s, "optional") == 0) ||

--- a/src/read.c
+++ b/src/read.c
@@ -1170,7 +1170,7 @@ static SCM read_srfi10(SCM port, SCM l)
  * (read-case-sensitive value)
  *
  * This parameter object permits to change the default behaviour of
- * the |read| primitive when reading a symbol. If this parameter has a
+ * the |read| primitive when reading a symbol. If this parameter has
  * a true value a symbol is not converted to a default case when interned.
  * Since R7RS requires that symbol are case insignificant, the default
  * value  of this parameter is |#t|.

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -169,7 +169,7 @@ DEFINE_PRIMITIVE("regexp?", regexpp, subr1, (SCM obj))
  * These functions attempt to match |pattern| (a string or a regexp value)
  * to |str|. If the match fails, |#f| is returned. If the match succeeds,
  * a list (containing strings for |regexp-match| and positions for
- * |regexp-match-positions| is returned. The first string (or positions) in
+ * |regexp-match-positions|) is returned. The first string (or positions) in
  * this list is the portion of string that matched pattern. If two portions
  * of string can match pattern, then the earliest and longest match is found,
  * by default.
@@ -204,7 +204,7 @@ static SCM regexec_helper(SCM re, SCM str, int pos_only)
   int i, ret, depth, max;
   SCM result;
 
-  /* RE can be a string or a already compiled regexp */
+  /* RE can be a string or an already compiled regexp */
   if (STRINGP(re)) re = STk_str2regexp(re);
   else if (!REGEXPP(re)) STk_error("bad compiled regexp ~S", re);
 

--- a/src/signal.c
+++ b/src/signal.c
@@ -147,7 +147,7 @@ static void sigabort(int _UNUSED(i))
 
 int STk_get_signal_value(SCM sig)
 {
-  char *s;
+  const char *s;
   struct signal_info *p;
 
   if (!SYMBOLP(sig)) goto Error;

--- a/src/sio.c
+++ b/src/sio.c
@@ -140,7 +140,7 @@ STk_put_character(int c, SCM port)       /* c may be a wide char */
 
 
 int
-STk_puts(char *s, SCM port)
+STk_puts(const char* s, SCM port)
 {
   int n =  PORT_PUTS(port)(s, PORT_STREAM(port));
   if (n >= 0)
@@ -159,7 +159,7 @@ STk_putstring(SCM s, SCM port)
 
 
 int
-STk_nputs(SCM port, char *s, int len)
+STk_nputs(SCM port, const char* s, int len)
 {
   int n = PORT_NPUTS(port)(PORT_STREAM(port), s, len);
   if (n >= 0)

--- a/src/sio.c
+++ b/src/sio.c
@@ -64,7 +64,7 @@ STk_get_character(SCM port)  /* result may be a wide character */
     return (PORT_UNGETC(port) != EOF) ?
                   /* we have an ungetted char, call normal getc */
                   STk_getc(port):
-                  /* try to read it as an UTF-8 sequence */
+                  /* try to read it as a UTF-8 sequence */
                   // FIXME: on ne gère pas la ligne ici!!!
                   STk_utf8_read_char(port);
   else
@@ -176,7 +176,7 @@ STk_seek(SCM port, off_t offset, int whence)
 
   if (whence == SEEK_CUR) {
     //if (PORT_UNGETC(port) != EOF) offset -= 1;
-    /* Don't use relative access since fports stream does'nt know its cur. pos. */
+    /* Don't use relative access since fports stream doesn't know its cur. pos. */
     offset = PORT_POS(port) + offset;
     whence = SEEK_SET;
   }

--- a/src/socket.c
+++ b/src/socket.c
@@ -316,7 +316,7 @@ DEFINE_PRIMITIVE("make-client-socket", make_client_socket, subr23,
  * |Socket-shutdown| shutdowns the connection associated to
  * |socket|. If the socket is a server socket, |socket-shutdown| is called
  * on all the client sockets connected to this server.
- * |Close| indicates if the the socket must be closed or not, when
+ * |Close| indicates if the socket must be closed or not, when
  * the connection is destroyed. Closing the socket forbids further
  * connections on the same port with the |socket-accept| procedure.
  * Omitting a value for |close| implies the closing of socket.
@@ -358,7 +358,7 @@ DEFINE_PRIMITIVE("socket-shutdown", socket_shutdown, subr12, (SCM sock, SCM clos
   }
 
   /*
-   * Warning: input and output can have already be garbaged: if the
+   * Warning: input and output can have already been garbaged: if the
    * socket is no more used, the input and output are not marked as
    * used and can (eventually) be released before the call to shutdown
    * by the socket finalizer.
@@ -417,7 +417,7 @@ static void socket_finalizer(SCM socket, void _UNUSED(*client_data))
  * example, this can be achieved with `netcat localhost 12345`]
  *
  * Once the connection with the distant program is established, we read
- * a line on the input port  associated to the socket and we write the
+ * a line on the input port associated to the socket, and we write the
  * length of this line on its output port.
  * @lisp
  * (let* ((server (make-server-socket 12345))
@@ -548,7 +548,7 @@ DEFINE_PRIMITIVE("socket-port-number", socket_port_number, subr1, (SCM sock))
  *
  * The following example shows how to make a client socket. Here we
  * create a socket on port 13 of the machine 
- * |kaolin.unice.fr| footnote:[Port 13, if open,  can  used for testing:
+ * |kaolin.unice.fr| footnote:[Port 13, if open, can be used for testing:
  * making a connection to it permits to know the distant system's idea
  * of the time of day.]:
  * @lisp

--- a/src/sport.c
+++ b/src/sport.c
@@ -119,7 +119,7 @@ static Inline int Sputc(int c, void *stream)
 }
 
 
-static Inline int Swrite(void *stream, void *buffer, int count)
+static Inline int Swrite(void *stream, const void* buffer, int count)
 {
   int tmp, pos;
 
@@ -137,7 +137,7 @@ static Inline int Swrite(void *stream, void *buffer, int count)
   return count;
 }
 
-static Inline int Sputs(char *s, void *stream)
+static Inline int Sputs(const char* s, void *stream)
 {
   return Swrite(stream, s, strlen(s));
 }
@@ -341,7 +341,7 @@ make_bport(enum kind_port kind,  SCM str, int init_len, int flags)
 /*
  * open-input-string with a C string ...
  */
-SCM STk_open_C_string(char *str)
+SCM STk_open_C_string(const char* str)
 {
   return (SCM) make_sport(PREAD_C, (SCM) str, strlen(str),
                           PORT_IS_STRING | PORT_READ | PORT_TEXTUAL);

--- a/src/sport.c
+++ b/src/sport.c
@@ -147,7 +147,7 @@ static Inline int Sputstring(SCM s, void *stream)
   return Swrite(stream, STRING_CHARS(s), STRING_SIZE(s));
 }
 
-static Inline int Snputs(void *stream, char *s, int len)
+static Inline int Snputs(void *stream, const char* s, int len)
 {
   return Swrite(stream, s, len);
 }

--- a/src/sport.c
+++ b/src/sport.c
@@ -219,7 +219,7 @@ make_sport(enum kind_port kind,  SCM str, int init_len, int flags)
 
   /* Initialize the stream part */
   switch (kind) {
-    case PREAD:   /* this is a input string */
+    case PREAD:   /* this is an input string */
                   {
                     char *s = STRING_CHARS(str);
 
@@ -228,7 +228,7 @@ make_sport(enum kind_port kind,  SCM str, int init_len, int flags)
                     PORT_STR(ss)  = str;
                     break;
                   }
-    case PREAD_C: /* this is a input string (from a C string) */
+    case PREAD_C: /* this is an input string (from a C string) */
                   PORT_BASE(ss) = (char *) str;
                   PORT_END(ss)  = (char *) str + init_len;
                   PORT_STR(ss)  = str;
@@ -242,7 +242,7 @@ make_sport(enum kind_port kind,  SCM str, int init_len, int flags)
   PORT_PTR(ss)     = PORT_BASE(ss);
   PORT_BUFSIZE(ss) = init_len;
 
-  /* Set the case sensitive bit */
+  /* Set the case-sensitive bit */
   if (STk_read_case_sensitive) flags |= PORT_CASE_SENSITIVE;
 
   /* Initialize now the port itself */
@@ -287,7 +287,7 @@ make_bport(enum kind_port kind,  SCM str, int init_len, int flags)
 
   /* Initialize the stream part */
   switch (kind) {
-    case PREAD:   /* this is a input bytevector */
+    case PREAD:   /* this is an input bytevector */
                   {
                     char *s = UVECTOR_DATA(str);
 

--- a/src/stklos.c
+++ b/src/stklos.c
@@ -28,24 +28,24 @@
 #include <langinfo.h>
 #include "gnu-getopt.h"
 
-#define ADD_OPTION(o, k)                                        \
+#define ADD_OPTION(o, k)                                     do{\
   if (*o) options = STk_key_set(options,                        \
                                 STk_makekey(k),                 \
-                                STk_Cstring2string(o));
-
-#define ADD_BOOL_OPTION(o, k)                           \
+                                STk_Cstring2string(o));         \
+}while(0)
+#define ADD_BOOL_OPTION(o, k)                        do{\
   options = STk_key_set(options,                        \
                         STk_makekey(k),                 \
-                        MAKE_BOOLEAN(o));
-
-#define ADD_INT_OPTION(o, k)                            \
+                        MAKE_BOOLEAN(o));               \
+}while(0)
+#define ADD_INT_OPTION(o, k)                         do{\
   options = STk_key_set(options,                        \
                         STk_makekey(k),                 \
-                        MAKE_INT(o));
-
-#define ADD_SCM_OPTION(o, k)                            \
-  options = STk_key_set(options, STk_makekey(k),o);
-
+                        MAKE_INT(o));                   \
+}while(0)
+#define ADD_SCM_OPTION(o, k)                         do{\
+  options = STk_key_set(options, STk_makekey(k),o);     \
+}while(0)
 /*=============================================================================
  *
  * Program arguments

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -725,8 +725,8 @@ extern int STk_interactive_debug;
 char *STk_strdup(const char *s);
 void STk_add_primitive(struct primitive_obj *o);
 void STk_add_primitive_in_module(struct primitive_obj *o, SCM module);
-SCM STk_eval_C_string(char *str, SCM module);
-SCM STk_read_from_C_string(char *str);
+SCM STk_eval_C_string(const char* str, SCM module);
+SCM STk_read_from_C_string(const char* str);
 
 int STk_init_misc(void);
 
@@ -814,7 +814,7 @@ struct complex_obj {
   /****
    **** Conversions
    ****/
-SCM             STk_Cstr2number(char *str, long base);
+SCM             STk_Cstr2number(const char* str, long base);
 char           *STk_bignum2Cstring(SCM n, int base);
 SCM             STk_long2integer(long n);
 SCM             STk_ulong2integer(unsigned long n);
@@ -890,9 +890,9 @@ SCM STk_make_C_parameter2(SCM symbol,SCM (*value)(void),SCM (*proc)(SCM new_valu
   ----
   ------------------------------------------------------------------------------
 */
-char *STk_expand_file_name(char *s);
+char *STk_expand_file_name(const char* s);
 SCM STk_do_glob(int argc, SCM *argv);
-SCM STk_resolve_link(char *path, int count);
+SCM STk_resolve_link(const char* path, int count);
 
 
 /*
@@ -932,13 +932,13 @@ struct port_obj {
   int   (*cgetc)     (void *stream);
   int   (*ceofp)     (void *stream);
   int   (*cclose)    (void *stream);
-  int   (*cputc)     (int c, void * stream);
-  int   (*cputs)     (char *s, void * stream);
-  int   (*cnputs)    (void *stream, char *str, int len);
+  int   (*cputc)     (int c, void *stream);
+  int   (*cputs)     (const char *s, void *stream);
+  int   (*cnputs)    (void *stream, const char *str, int len);
   int   (*cputstring)(void *stream, SCM str);
   int   (*cflush)    (void *stream);
   int   (*read_buff) (void *stream, void *buf, int count);
-  int   (*write_buff)(void *stream, void *buf, int count);
+  int   (*write_buff)(void *stream, const void *buf, int count);
   off_t (*seek)      (void *stream, off_t offset, int whence);
 };
 
@@ -1020,9 +1020,9 @@ int STk_ungetc(int c, SCM port);
 int STk_close(SCM port);
 int STk_putc(int c, SCM port);
 int STk_put_character(int c, SCM port);   /* c may be a wide char */
-int STk_puts(char *s, SCM port);
+int STk_puts(const char* s, SCM port);
 int STk_putstring(SCM s, SCM port);
-int STk_nputs(SCM port, char *s, int len);
+int STk_nputs(SCM port, const char* s, int len);
 off_t STk_seek(SCM port, off_t offset, int whence);
 off_t STk_tell(SCM port);
 void STk_rewind(SCM port);
@@ -1039,7 +1039,7 @@ int STk_write_buffer(SCM port, void *buff, int count);
 SCM STk_rewind_file_port(SCM port);
 SCM STk_open_file(char *filename, char *mode);
 SCM STk_add_port_idle(SCM port, SCM idle_func);
-SCM STk_fd2scheme_port(int fd, char *mode, char *identification);
+SCM STk_fd2scheme_port(int fd, const char *mode, char *identification);
 void STk_set_line_buffered_mode(SCM port);
 int STk_init_fport(void);
 SCM STk_current_input_port(void);
@@ -1053,7 +1053,7 @@ void STk_close_all_ports(void);
  ****/
 EXTERN_PRIMITIVE("open-output-string", open_output_string, subr0, (void));
 SCM STk_get_output_string(SCM port);
-SCM STk_open_C_string(char *str);
+SCM STk_open_C_string(const char* str);
 int STk_init_sport(void);
 
 /****
@@ -1241,7 +1241,7 @@ struct string_obj {
 #define STRING_MONOBYTE(str)    (STRING_LENGTH(str) == STRING_SIZE(str))
 
 SCM STk_makestring(int len, char *init);
-SCM STk_Cstring2string(char *str);           /* Embed a C string in Scheme world  */
+SCM STk_Cstring2string(const char* str);           /* Embed a C string in Scheme world  */
 
 EXTERN_PRIMITIVE("string=?", streq, subr2, (SCM s1, SCM s2));
 EXTERN_PRIMITIVE("string-ref", string_ref, subr2, (SCM str, SCM index));
@@ -1279,9 +1279,9 @@ struct symbol_obj {
 
 EXTERN_PRIMITIVE("string->symbol", string2symbol, subr1, (SCM string));
 
-int STk_symbol_flags(char *s);
+int STk_symbol_flags(const char* s);
 SCM STk_intern(char *name);
-SCM STk_make_uninterned_symbol(char *name);
+SCM STk_make_uninterned_symbol(const char* name);
 int STk_init_symbol(void);
 
 
@@ -1334,7 +1334,7 @@ extern int STk_use_utf8;
 
 char *STk_utf8_grab_char(char *str, uint32_t *c);/* result = pos. after current one */
 int STk_char2utf8(int ch, char *str); /* result = length of the UTF-8 repr. */
-int STk_utf8_strlen(char *s, int max);
+int STk_utf8_strlen(const char* s, int max);
 int STk_utf8_read_char(SCM port);
 int STk_utf8_sequence_length(char *str); /* # of bytes of sequence starting at str */
 int STk_utf8_char_bytes_needed(unsigned int ch);/* # of bytes needed to represent ch*/

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -129,7 +129,7 @@ extern "C"
    * functions of the GC used in the interpreter must be declared here since
    * the file <gc.h> is not included in the source file in order to simplify
    * header file management (i.e. only this header file is necessary to use
-   * the stklos library.
+   * the stklos library)).
    * Don't use the functions GC_* they can be changed. The only allocation
    * functions that must be used are functions of the form STk_*
    */
@@ -614,7 +614,7 @@ int STk_init_fixnum(void);
 */
 struct keyword_obj {
   stk_header header;
-  char *pname;                  /* must be at the same offset than for symbols */
+  char *pname;                  /* must be at the same offset as for symbols */
 };
 
 #define KEYWORD_PNAME(p)        (((struct keyword_obj *) (p))->pname)
@@ -905,7 +905,7 @@ SCM STk_resolve_link(char *path, int count);
   ------------------------------------------------------------------------------
 */
 
-  /* Code for port is splitted in several files:
+  /* Code for port is split in several files:
    *    - s contains the low level IO functions which mimic the C IO. All
    *      these functions take Scheme ports as parameter instead of FILE *
    *    - fport.c contains the specific code for port associated to files
@@ -1267,7 +1267,7 @@ int STk_init_struct(void);
   ------------------------------------------------------------------------------
 */
 struct symbol_obj {
-  stk_header header;    /* must be at the same offset than for keywords */
+  stk_header header;    /* must be at the same offset as for keywords */
   char *pname;
 };
 

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -112,11 +112,11 @@ extern "C"
 #  define MUT_LOCK(lck)
 #  define MUT_UNLOCK(lck)
 #else
-#  define MUT_DECL(lck)    static pthread_mutex_t lck = PTHREAD_MUTEX_INITIALIZER;
+#  define MUT_DECL(lck)    static pthread_mutex_t lck = PTHREAD_MUTEX_INITIALIZER
 #  define MUT_FIELD(lck)   pthread_mutex_t lck
-#  define MUT_INIT(lck)    { pthread_mutex_init(&lck, NULL); }
-#  define MUT_LOCK(lck)    { pthread_mutex_lock(&lck); }
-#  define MUT_UNLOCK(lck)  { pthread_mutex_unlock(&lck); }
+#  define MUT_INIT(lck)    pthread_mutex_init(&lck, NULL)
+#  define MUT_LOCK(lck)    pthread_mutex_lock(&lck)
+#  define MUT_UNLOCK(lck)  pthread_mutex_unlock(&lck)
 #endif
 
 /*===========================================================================*\
@@ -229,23 +229,23 @@ typedef struct {
 #define STYPE(x)                (BOXED_OBJP(x)? BOXED_TYPE(x): tc_not_boxed)
 
 
-#define NEWCELL(_var, _type)    {                                               \
+#define NEWCELL(_var, _type)    do{                                               \
         _var = (SCM) STk_must_malloc(sizeof(struct CPP_CONCAT(_type,_obj)));    \
         BOXED_TYPE(_var) = CPP_CONCAT(tc_, _type);                              \
         BOXED_INFO(_var) = 0;                                                   \
-        }
+        }while(0)
 
-#define NEWCELL_WITH_LEN(_var, _type, _len)     {       \
+#define NEWCELL_WITH_LEN(_var, _type, _len)     do{       \
         _var = (SCM) STk_must_malloc(_len);             \
         BOXED_TYPE(_var) = CPP_CONCAT(tc_, _type);      \
         BOXED_INFO(_var) = 0;                           \
-        }
+        }while(0)
 
-#define NEWCELL_ATOMIC(_var, _type, _len)       {       \
+#define NEWCELL_ATOMIC(_var, _type, _len)       do{       \
         _var = (SCM) STk_must_malloc_atomic(_len);      \
         BOXED_TYPE(_var) = CPP_CONCAT(tc_, _type);      \
         BOXED_INFO(_var) = 0;                           \
-        }
+        }while(0)
 
   /*
    * PRIMITIVES

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -352,18 +352,6 @@ int STk_init_box(void);
 /*
   ------------------------------------------------------------------------------
   ----
-  ----                      B Y T E V E C T O R . C
-  ----
-  ------------------------------------------------------------------------------
-*/
-SCM STk_bytevector2u8list(SCM obj);
-SCM STk_u8list2bytevector(SCM obj);
-int STk_init_bytevector(void);
-
-
-/*
-  ------------------------------------------------------------------------------
-  ----
   ----                            C H A R  . C
   ----
   ------------------------------------------------------------------------------
@@ -381,8 +369,8 @@ int STk_init_bytevector(void);
 
 
 /* Comparison of characters. No test on types */
-int STk_charcomp(SCM c1, SCM c2);
-int STk_charcompi(SCM c1, SCM c2);
+int charcomp(SCM c1, SCM c2);
+int charcompi(SCM c1, SCM c2);
 
 /* Simple  character conversion functions */
 uint32_t STk_to_upper(uint32_t c);
@@ -626,7 +614,7 @@ struct keyword_obj {
 EXTERN_PRIMITIVE("key-set!", key_set, subr3, (SCM l, SCM key, SCM val));
 EXTERN_PRIMITIVE("key-get", key_get, subr23, (SCM l, SCM key, SCM dflt));
 
-SCM STk_makekey(char *tok);
+SCM STk_makekey(const char* token);
 int STk_init_keyword(void);
 
 /*
@@ -814,8 +802,7 @@ struct complex_obj {
   /****
    **** Conversions
    ****/
-SCM             STk_Cstr2number(const char* str, long base);
-char           *STk_bignum2Cstring(SCM n, int base);
+SCM             STk_Cstr2number(char* str, long base);
 SCM             STk_long2integer(long n);
 SCM             STk_ulong2integer(unsigned long n);
 SCM             STk_double2real(double d);
@@ -833,7 +820,6 @@ SCM STk_mul2(SCM o1, SCM o2);
 SCM STk_div2(SCM o1, SCM o2);
 
 long STk_numeq2(SCM o1, SCM o2);
-long STk_numdiff2(SCM o1, SCM o2);
 long STk_numlt2(SCM o1, SCM o2);
 long STk_numgt2(SCM o1, SCM o2);
 long STk_numle2(SCM o1, SCM o2);
@@ -1036,7 +1022,6 @@ int STk_write_buffer(SCM port, void *buff, int count);
 /****
  ****           fport.h primitives
  ****/
-SCM STk_rewind_file_port(SCM port);
 SCM STk_open_file(char *filename, char *mode);
 SCM STk_add_port_idle(SCM port, SCM idle_func);
 SCM STk_fd2scheme_port(int fd, const char *mode, char *identification);
@@ -1240,7 +1225,7 @@ struct string_obj {
 
 #define STRING_MONOBYTE(str)    (STRING_LENGTH(str) == STRING_SIZE(str))
 
-SCM STk_makestring(int len, char *init);
+SCM STk_makestring(int len, const char* init);
 SCM STk_Cstring2string(const char* str);           /* Embed a C string in Scheme world  */
 
 EXTERN_PRIMITIVE("string=?", streq, subr2, (SCM s1, SCM s2));
@@ -1268,7 +1253,7 @@ int STk_init_struct(void);
 */
 struct symbol_obj {
   stk_header header;    /* must be at the same offset as for keywords */
-  char *pname;
+  const char *pname;
 };
 
 #define SYMBOL_PNAME(p) (((struct symbol_obj *) (p))->pname)
@@ -1336,7 +1321,7 @@ char *STk_utf8_grab_char(char *str, uint32_t *c);/* result = pos. after current 
 int STk_char2utf8(int ch, char *str); /* result = length of the UTF-8 repr. */
 int STk_utf8_strlen(const char* s, int max);
 int STk_utf8_read_char(SCM port);
-int STk_utf8_sequence_length(char *str); /* # of bytes of sequence starting at str */
+int STk_utf8_sequence_length(const char* str); /* # of bytes of sequence starting at str */
 int STk_utf8_char_bytes_needed(unsigned int ch);/* # of bytes needed to represent ch*/
 int STk_utf8_verify_sequence(char *s, int len); /* s constitutes a valid UTF8? */
 char *STk_utf8_index(char *s, int i, int max);/* return the address of ith char of s*/
@@ -1436,7 +1421,6 @@ int STk_init_vector(void);
 */
 #define DEFAULT_STACK_SIZE 100000
 
-void STk_execute_current_handler(SCM kind, SCM location, SCM message);
 void STk_raise_exception(SCM cond);
 SCM STk_C_apply(SCM func, int nargs, ...);
 SCM STk_C_apply_list(SCM func, SCM l);

--- a/src/str.c
+++ b/src/str.c
@@ -29,8 +29,6 @@
 #include "stklos.h"
 
 
-extern SCM STk_make_bytevector_from_string(char *str, long len);
-
 
 /* min size added to a string when reallocated in a string-set! */
 #define UTF8_STRING_INCR        8
@@ -271,7 +269,7 @@ static SCM make_substring(SCM string, long from, long to)
 }
 
 
-SCM STk_makestring(int len, char *init)
+SCM STk_makestring(int len, const char* init)
 {
   register SCM z;
 

--- a/src/str.c
+++ b/src/str.c
@@ -787,7 +787,7 @@ int get_substring_size(SCM string, long from, long to) {
  * Replaces the characters of the variable-size string dst (between
  * dst-start and dst-end) with the characters of the string src
  * (between src-start and src-end). The number of characters from src
- * may be different than the number replaced in dst, so the string may
+ * may be different from the number replaced in dst, so the string may
  * grow or contract. The special case where dst-start is equal to
  * dst-end corresponds to insertion; the case where src-start is equal
  * to src-end corresponds to deletion. The order in which characters
@@ -795,7 +795,7 @@ int get_substring_size(SCM string, long from, long to) {
  * destination overlap, copying takes place as if the source is first
  * copied into a temporary string and then into the destination.
  * Returns string, appended with the characters form the concatenation
- * of the given arguments, which can be wither strings or characters.
+ * of the given arguments, which can be either strings or characters.
  *
  * It is guaranteed that string-replace! will return the same object that
  * was passed to it as first argument, whose size may be larger.
@@ -1302,7 +1302,7 @@ static SCM string_dxxcase(int argc, SCM *argv,
       copy_array(wchars, end-start, startp);
     }
     else {
-      /* This code is inefficient, but it seems that that the converted case
+      /* This code is inefficient, but it seems that the converted case
          character always use the same length encoding. It is likely that this
          code is never used in practice
       */

--- a/src/str.c
+++ b/src/str.c
@@ -297,7 +297,7 @@ SCM STk_makestring(int len, char *init)
 }
 
 
-SCM STk_Cstring2string(char *str) /* Embed a C string in Scheme world  */
+SCM STk_Cstring2string(const char* str) /* Embed a C string in Scheme world  */
 {
   SCM  z;
   size_t len = strlen(str);

--- a/src/struct.c
+++ b/src/struct.c
@@ -237,7 +237,7 @@ DEFINE_PRIMITIVE("struct-type-change-writer!",
 }
 
 
-static char *get_struct_type_name(SCM st)
+static const char* get_struct_type_name(SCM st)
 {
   SCM name = STRUCT_TYPE_NAME(st);
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -196,7 +196,7 @@ DEFINE_PRIMITIVE("struct-type-name", st_name, subr1, (SCM obj))
 <doc EXT struct-type-change-writer!
  * (struct-type-change-writer! structype proc)
  *
- * Change the default writer associated to structures of type |structype| to
+ * Change the default writer associated to structures of type |structype|
  * to the |proc| procedure. The |proc| procedure must accept 2 arguments
  * (the structure to write and the port wher the structure must be written
  * in that order). The value returned by |struct-type-change-writer!| is the
@@ -378,7 +378,7 @@ DEFINE_PRIMITIVE("struct-set!", struct_set, subr3, (SCM s, SCM slot, SCM val))
 <doc EXT struct-is-a?
  * (struct-is-a? s structype)
  *
- * Return a boolean that indicates if the structure |s| is a of type |structype|.
+ * Return a boolean that indicates if the structure |s| is of type |structype|.
  * Note that if |s| is an instance of a subtype of _S_, it is considered
  * also as an instance of type _S_.
  *

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -42,7 +42,7 @@ static void error_bad_string(SCM str)
   STk_error("bad string ~S", str);
 }
 
-int STk_symbol_flags(register char *s)
+int STk_symbol_flags(const register char* s)
 {
   if (!*s || (*s == '.' && !s[1])) {
     /* Special symbols || and |.| which always need bars */
@@ -68,7 +68,7 @@ int STk_symbol_flags(register char *s)
   }
 }
 
-SCM STk_make_uninterned_symbol(char *name)
+SCM STk_make_uninterned_symbol(const char* name)
 {
   SCM z;
 

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -135,7 +135,7 @@ doc>
 DEFINE_PRIMITIVE("symbol->string", symbol2string, subr1, (SCM symbol))
 {
   SCM str;
-  char *s;
+  const char *s;
 
   if (!SYMBOLP(symbol)) STk_error("bad symbol ~S", symbol);
 

--- a/src/system.c
+++ b/src/system.c
@@ -1029,12 +1029,12 @@ DEFINE_PRIMITIVE("glob", glob, vsubr, (int argc, SCM *argv))
  * reasons. ,(index "remove-file")
 doc>
 */
-#define do_remove(filename)                             \
+#define do_remove(filename)                          do{\
   if (!STRINGP(filename)) error_bad_string(filename);   \
   if (remove(STRING_CHARS(filename)) != 0)              \
     STk_error_posix(errno, "", filename, NULL);       \
   return STk_void;                                      \
-
+}while(0)
 DEFINE_PRIMITIVE("delete-file", delete_file, subr1, (SCM filename))
 {
   do_remove(filename);

--- a/src/system.c
+++ b/src/system.c
@@ -1093,7 +1093,7 @@ DEFINE_PRIMITIVE("directory-files", directory_files, subr12, (SCM dirname, SCM d
   if (!dir) STk_error_posix(errno, "", dirname, NULL);
 
   /* readdir and closedir can yield an error (EBADF) only on  when dir is incorrect
-   * This cannot occurs here since we have tested that opendir result is OK.
+   * This cannot occur here since we have tested that opendir result is OK.
    */
   for (d = readdir(dir); d ; d = readdir(dir)) {
     if (d->d_name[0] == '.') {
@@ -1304,7 +1304,7 @@ DEFINE_PRIMITIVE("exit", exit, subr01, (SCM retcode))
     }
   }
 
-  /* Raise a &exit-r7rs condition  with the numeric value of the exit code*/
+  /* Raise an &exit-r7rs condition  with the numeric value of the exit code*/
   cond = STk_make_C_cond(STk_exit_condition, 1, MAKE_INT(ret));
   STk_raise(cond);
 

--- a/src/system.c
+++ b/src/system.c
@@ -1249,7 +1249,7 @@ DEFINE_PRIMITIVE("create-temp-directory", create_tmp_dir, subr01, (SCM arg))
  * @end lisp
 doc>
 */
-MUT_DECL(at_exit_mutex)         /* The exit mutex */
+MUT_DECL(at_exit_mutex);         /* The exit mutex */
 
 DEFINE_PRIMITIVE("register-exit-function!", at_exit, subr1, (SCM proc))
 {

--- a/src/thread-pthreads.c
+++ b/src/thread-pthreads.c
@@ -38,7 +38,7 @@ static pthread_key_t vm_key;
 
 static void cleanup_vm_specific(void _UNUSED(*p))    /* Nothing to do for now */
 {
-  /* Do nothing */;
+  /* Do nothing */
 }
 
 static void initialize_vm_key(void)

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -80,7 +80,7 @@ int STk_utf8_read_char(SCM port)
   int c = STk_getc(port);
 
   if (STk_use_utf8 && (c >= 0x80)) {
-    /* Read an UTF-8 character */
+    /* Read a UTF-8 character */
     if ((c < 0xc0) || (c > 0xf7))
       return UTF8_INCORRECT_SEQUENCE;
     else if (c < 0xe0) {
@@ -143,7 +143,7 @@ int STk_utf8_char_bytes_needed(unsigned int ch)
 
 int STk_utf8_sequence_length(char *str)
 {
-  /* return length of a the UTF-8 sequence starting at given address */
+  /* return length of the UTF-8 sequence starting at given address */
   uint8_t c = *((uint8_t *) str);
 
   if (c < 0x80)                         return 1;

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -141,7 +141,7 @@ int STk_utf8_char_bytes_needed(unsigned int ch)
   return 1; /* to avoid infinite loop, but obiously incorrect */
 }
 
-int STk_utf8_sequence_length(char *str)
+int STk_utf8_sequence_length(const char* str)
 {
   /* return length of the UTF-8 sequence starting at given address */
   uint8_t c = *((uint8_t *) str);

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -29,7 +29,7 @@
 int STk_use_utf8 = -1;
 
 
-static void error_bad_sequence(char *str)
+static void error_bad_sequence(const char *str)
 {
   int i;
   char *buffer = STk_must_malloc_atomic(strlen(str) + 1);
@@ -154,10 +154,10 @@ int STk_utf8_sequence_length(char *str)
 }
 
 
-int STk_utf8_strlen(char *s, int max)
+int STk_utf8_strlen(const char* s, int max)
 {
   int len;
-  char *start = s, *end = s + max;
+  const char *start = s, *end = s + max;
 
   for (len = 0;  s < end; len++) {
     int sz =  STk_utf8_sequence_length(s);

--- a/src/uvector.c
+++ b/src/uvector.c
@@ -91,7 +91,7 @@ static void error_bad_list(SCM l)
 
 static int vector_element_size(int type)
 {
-  /* compute len of one element depending of type.  We assume here
+  /* compute len of one element depending on type.  We assume here
    * that characters use 8 bits and that we are at least on a 32 bits
    * architecture. Consquenetly, S8, S16 and S32 are represented
    * without boxing whereas S64 are represeneted by a bignum
@@ -166,7 +166,7 @@ static SCM control_index(int argc, SCM *argv, long *pstart, long *pend, SCM *pfi
 }
 
 
-/* Return the type of an uniform vector given its tag */
+/* Return the type of a uniform vector given its tag */
 int STk_uniform_vector_tag(char *s)
 {
   static char *table[] =
@@ -193,7 +193,7 @@ int STk_uvector_equal(SCM u1, SCM u2)
 }
 
 /*
- * Basic accessors to an uniform vector
+ * Basic accessors to a uniform vector
  *
  */
 static void uvector_set(int _UNUSED(type), SCM v, long i, SCM value)
@@ -310,7 +310,7 @@ static SCM makeuvect(int type, int len, SCM init)
   long i, size = 1;
   SCM  z;
 
-  /* compute len of one element depending of type.  We assume here
+  /* compute len of one element depending on type.  We assume here
    * that characters use 8 bits and that we are at least on a 32 bits
    * architecture. Consquenetly, S8, S16 and S32 are represented
    * without boxing whereas S64 are represeneted by a bignum

--- a/src/vector.c
+++ b/src/vector.c
@@ -165,7 +165,7 @@ DEFINE_PRIMITIVE("vector?", vectorp, subr1, (SCM obj))
  * (make-vector k fill)
  *
  * Returns a newly allocated vector of |k| elements. If a second argument is
- * given, then each element is initialized to |fill|. Otherwise the initial
+ * given, then each element is initialized to |fill|. Otherwise, the initial
  * contents of each element is unspecified.
 doc>
  */

--- a/src/vm.c
+++ b/src/vm.c
@@ -59,8 +59,8 @@ static int debug_level = 0;     /* 0 is quiet, 1, 2, ... are more verbose */
 #  define NEXT          continue;/* Be sure to not use continue elsewhere */
 #endif
 
-#define NEXT0           {vm->val = STk_void; vm->valc = 0; NEXT;}
-#define NEXT1           {vm->valc = 1; NEXT;}
+#define NEXT0           do{vm->val = STk_void; vm->valc = 0; NEXT;}while(0)
+#define NEXT1           do{vm->valc = 1; NEXT;}while(0)
 
 
 #ifdef sparc
@@ -176,28 +176,28 @@ vm_thread_t *STk_allocate_vm(int stack_size)
 #define VM_STATE_FP(reg)        ((reg)[3])
 #define VM_STATE_JUMP_BUF(reg)  ((reg)[4])
 
-#define SAVE_VM_STATE()                 {               \
+#define SAVE_VM_STATE()               do{               \
   vm->sp                   -= VM_STATE_SIZE;            \
   VM_STATE_PC(vm->sp)       = (SCM) vm->pc;             \
   VM_STATE_CST(vm->sp)      = (SCM) vm->constants;      \
   VM_STATE_ENV(vm->sp)      = (SCM) vm->env;            \
   VM_STATE_FP(vm->sp)       = (SCM) vm->fp;             \
   VM_STATE_JUMP_BUF(vm->sp) = (SCM) vm->top_jmp_buf;    \
-}
+}while(0)
 
-#define FULL_RESTORE_VM_STATE(p)        {                       \
+#define FULL_RESTORE_VM_STATE(p)      do{                       \
   vm->pc                     = (STk_instr *) VM_STATE_PC(p);    \
   RESTORE_VM_STATE(p);                                          \
-}
+}while(0)
 
-#define RESTORE_VM_STATE(p)             {                       \
+#define RESTORE_VM_STATE(p)           do{                       \
   /* pc is not restored here. See FULL_RESTORE_VM_STATE */      \
   vm->constants          = (SCM *)  VM_STATE_CST(p);            \
   vm->env                = (SCM)    VM_STATE_ENV(p);            \
   vm->fp                 = (SCM *)  VM_STATE_FP(p);             \
   vm->top_jmp_buf        = (jbuf *) VM_STATE_JUMP_BUF(p);       \
   vm->sp                += VM_STATE_SIZE;                       \
-}
+}while(0)
 
 
 /*
@@ -211,20 +211,20 @@ vm_thread_t *STk_allocate_vm(int stack_size)
 #define HANDLER_PREV(reg)       ((reg)[2])
 
 
-#define SAVE_HANDLER_STATE(proc, addr)  {               \
+#define SAVE_HANDLER_STATE(proc, addr)  do{             \
   vm->sp                   -= EXCEPTION_HANDLER_SIZE;   \
   HANDLER_PROC(vm->sp)  =  (SCM) (proc);                \
   HANDLER_END(vm->sp)   =  (SCM) (addr);                \
   HANDLER_PREV(vm->sp)  =  (SCM) vm->handlers;          \
   vm->handlers          = vm->sp;                       \
-}
+}while(0)
 
-#define UNSAVE_HANDLER_STATE()  {                       \
+#define UNSAVE_HANDLER_STATE()  do{                     \
   SCM *old = vm->handlers;                              \
                                                         \
   vm->handlers = (SCM *) HANDLER_PREV(vm->handlers);    \
   vm->sp       = old + EXCEPTION_HANDLER_SIZE;          \
-}
+}while(0)
 
 
 /*===========================================================================*\
@@ -233,7 +233,7 @@ vm_thread_t *STk_allocate_vm(int stack_size)
  *
 \*===========================================================================*/
 
-#define PREP_CALL() {                                   \
+#define PREP_CALL() do{                                 \
   SCM fp_save = (SCM)(vm->fp);                          \
                                                         \
   /* Push an activation record on the stack */          \
@@ -243,16 +243,16 @@ vm_thread_t *STk_allocate_vm(int stack_size)
   ACT_SAVE_PROC(vm->fp) = STk_false;                    \
   ACT_SAVE_INFO(vm->fp) = STk_false;                    \
   /* Other fields will be initialized later */          \
-}
+}while(0)
 
 
-#define RET_CALL() {                                    \
+#define RET_CALL() do{                                  \
   vm->sp        = vm->fp + ACT_RECORD_SIZE;             \
   vm->env       = ACT_SAVE_ENV(vm->fp);                 \
   vm->pc        = ACT_SAVE_PC(vm->fp);                  \
   vm->constants = ACT_SAVE_CST(vm->fp);                 \
   vm->fp        = ACT_SAVE_FP(vm->fp);                  \
-}
+}while(0)
 
 
 /*
@@ -273,34 +273,34 @@ MUT_DECL(global_lock);          /* the lock to access checked_globals */
 
 
 
-#define PUSH_ENV(nargs, func, next_env)  {      \
+#define PUSH_ENV(nargs, func, next_env)  do{    \
     BOXED_TYPE(vm->sp)   = tc_frame;            \
     FRAME_LENGTH(vm->sp) = nargs;               \
     FRAME_NEXT(vm->sp)   = next_env;            \
     FRAME_OWNER(vm->sp)  = func;                \
-}
+}while(0)
 
-#define CALL_CLOSURE(func) {                    \
+#define CALL_CLOSURE(func) do{                  \
     vm->pc        = CLOSURE_BCODE(func);        \
     vm->constants = CLOSURE_CONST(func);        \
     vm->env       = (SCM) vm->sp;               \
-}
+}while(0)
 
-#define CALL_PRIM(v, args) {                    \
+#define CALL_PRIM(v, args) do{                  \
     ACT_SAVE_PROC(vm->fp) = v;                  \
     v = PRIMITIVE_FUNC(v)args;                  \
-}
+}while(0)
 
-#define REG_CALL_PRIM(name) {                           \
+#define REG_CALL_PRIM(name) do{                           \
   extern struct primitive_obj CPP_CONCAT(STk_o_, name);         \
   ACT_SAVE_PROC(vm->fp) = &CPP_CONCAT(STk_o_, name);    \
-}
+}while(0)
 
 
-#define RETURN_FROM_PRIMITIVE() {               \
+#define RETURN_FROM_PRIMITIVE() do{             \
     vm->sp = vm->fp + ACT_RECORD_SIZE;          \
     vm->fp = (SCM *) ACT_SAVE_FP(vm->fp);       \
-}
+}while(0)
 
 static void run_vm(vm_thread_t *vm);
 
@@ -852,25 +852,26 @@ DEFINE_PRIMITIVE("%vm", set_vm_debug, vsubr, (int _UNUSED(argc), SCM _UNUSED(*ar
  *      operand at [n+1]
  *   4) Thread A resumes, updates operand at [n+1], releases lock
  */
-#define LOCK_AND_RESTART                        \
+#define LOCK_AND_RESTART                     do{\
   if (!have_global_lock) {                      \
     MUT_LOCK(global_lock);                      \
     have_global_lock=1;                         \
     (vm->pc)--;                                 \
     NEXT;                                       \
-  }
-
-#define RELEASE_LOCK                            \
+  }                                             \
+}while(0)
+#define RELEASE_LOCK                         do{\
    {                                            \
     MUT_UNLOCK(global_lock);                    \
     have_global_lock=0;                         \
-   }
-
-#define RELEASE_POSSIBLE_LOCK                   \
+   }                                            \
+}while(0)
+#define RELEASE_POSSIBLE_LOCK                do{\
   if (have_global_lock) {                       \
     MUT_UNLOCK(global_lock);                    \
     have_global_lock=0;                         \
-  }
+  }                                             \
+}while(0)
 
 static void run_vm(vm_thread_t *vm)
 {

--- a/src/vm.c
+++ b/src/vm.c
@@ -157,7 +157,7 @@ vm_thread_t *STk_allocate_vm(int stack_size)
 
 #define ACT_RECORD_SIZE    7
 
-#define ACT_VARARG(reg)    ((reg)[0]) /* place holder for &rest parameters */
+#define ACT_VARARG(reg)    ((reg)[0]) /* placeholder for &rest parameters */
 #define ACT_SAVE_ENV(reg)  ((reg)[1])
 #define ACT_SAVE_PC(reg)   ((reg)[2])
 #define ACT_SAVE_CST(reg)  ((reg)[3])
@@ -468,7 +468,7 @@ DEFINE_PRIMITIVE("apply", scheme_apply, apply, (void))
  *                              S T k _ C _ a p p l y
  *
  *
- * Execute a Scheme function from C. This function can be used as a
+ * Execute a Scheme function from C. This function can be used as
  * an "excv" or an "execl" function. If nargs is > 0 it is as a Unix "execl"
  * function:
  *    STk_C_apply(STk_cons, 2, MAKE_INT(1), MAKE_INT(2)) => (1 . 2)
@@ -569,7 +569,7 @@ DEFINE_PRIMITIVE("%execute", execute, subr23, (SCM code, SCM consts, SCM envt))
  * (values obj ...)
  *
  * Delivers all of its arguments to its continuation.
- * ,(bold "Note:") R5RS imposes to use multiple values in the context of
+ * ,(bold "Note:") R5RS imposes to use multiple values in the context
  * of a |call-with-values|. In STklos, if |values| is not used with
  * |call-with-values|, only the first value is used (i.e. others values are
  * ,(emph "ignored")).
@@ -613,7 +613,7 @@ DEFINE_PRIMITIVE("%call-for-values", call_for_values, subr1, (SCM prod))
   len = vm->valc;
   vm->valc = 1;
 
-  /* We don't use use STk_values2vector here since we will call apply with the
+  /* We don't use STk_values2vector here since we will call apply with the
    * values produced by "prod" ⟹ buil a list here. There are too much allocation
    * here :-(
    */
@@ -1784,7 +1784,7 @@ FUNCALL:  /* (int nargs, int tailp) */
         }
       }
 
-      /* Now we can call call "func" with "nargs" arguments */
+      /* Now we can call "func" with "nargs" arguments */
       vm->val = func;
       goto FUNCALL;
     }
@@ -1895,7 +1895,7 @@ void STk_raise_exception(SCM cond)
   vm->val = STk_C_apply(proc, 1, cond);
 
   /*
-   * Return in the good "run_vm" incarnation
+   * Return to the good "run_vm" incarnation
    */
   MY_LONGJMP(*(vm->top_jmp_buf), 1);
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -263,7 +263,7 @@ vm_thread_t *STk_allocate_vm(int stack_size)
 static SCM** checked_globals;
 static int   checked_globals_len  = CHECK_GLOBAL_INIT_SIZE;
 static int   checked_globals_used = 0;
-MUT_DECL(global_lock)          /* the lock to access checked_globals */
+MUT_DECL(global_lock);          /* the lock to access checked_globals */
 
 
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -71,7 +71,7 @@ struct continuation_obj {
 #define CONTP(k)        (BOXED_TYPE_EQ((k), tc_continuation))
 
 SCM STk_make_continuation(void);
-SCM STk_restore_continuation(SCM cont, SCM val);
+SCM STk_restore_cont(SCM cont, SCM val);
 
 
 /*===========================================================================*\

--- a/src/vport.c
+++ b/src/vport.c
@@ -123,7 +123,7 @@ static int call_user_close(void *stream)
  */
 
 static int call_user_putstring(SCM s, void *stream);
-static int vport_nputs(void *stream, char *s, int len);
+static int vport_nputs(void *stream, const char* s, int len);
 
 static int call_user_putc(int c, void *stream)
 {
@@ -184,10 +184,10 @@ static int vport_read(void *stream, void *buf, int count)
 }
 
 
-static int vport_write(void *stream, void *buf, int count)
+static int vport_write(void *stream, const void *buf, int count)
 {
   int i;
-  char *s = buf;
+  const char *s = buf;
 
   for (i = 0; i < count; i++) {
     int c = call_user_putc(*s++, stream);
@@ -204,7 +204,7 @@ static off_t vport_seek(void  _UNUSED(*stream),
   return 0;
 }
 
-static int vport_nputs(void *stream, char *s, int len)
+static int vport_nputs(void *stream, const char* s, int len)
 {
   int i;
 
@@ -213,7 +213,7 @@ static int vport_nputs(void *stream, char *s, int len)
   return len;
 }
 
-static int vport_puts(char *s, void *stream)
+static int vport_puts(const char *s, void *stream)
 {
   return vport_nputs(stream, s, strlen(s));
 }

--- a/src/vport.c
+++ b/src/vport.c
@@ -231,7 +231,7 @@ static int vport_puts(char *s, void *stream)
  * Returns a virtual port using the |read-char| procedure to read a
  * character from the port, |ready?| to know if there is any data to
  * read from the port, |eof?| to know if the end of file is reached
- * on the port and finally |close| to close the port. All theses
+ * on the port and finally |close| to close the port. All these
  * procedure takes one parameter which is the port from which the input
  * takes place.  |Open-input-virtual| accepts also the special value
  * |#f| for the I/O procedures with the following conventions:
@@ -319,7 +319,7 @@ DEFINE_PRIMITIVE("%open-input-virtual", open_input_vport, subr1, (SCM v))
  * for the I/O procedures. If a procedure is |#f| nothing is done
  * on the corresponding action.
  *
- * Hereafter is an (very inefficient) implementation of a variant of
+ * Hereafter is a (very inefficient) implementation of a variant of
  * |open-output-string| using virtual ports. The value of the output
  * string is printed when the port is closed:
  * @lisp


### PR DESCRIPTION
Multiline macros enclosed in braces are a footguns if used in single-line ifs, as in
```c
#define MACRO { code; }

if (x)
    MACRO;
else // breaks since the ; above counts as an additional statement
```
Replacing that with a `do { ... } while(0)` prevents this.