### PR TITLE
Add tab completion to readline

### DIFF
--- a/lib/stklos/Makefile.am
+++ b/lib/stklos/Makefile.am
@@ -38,9 +38,9 @@ SRC_OSTK = preproc.ostk
 #
 # Libraries written in C and Scheme
 #
-SRC_C     = itrie.c
-SRC_C_STK = itrie.stk
-SRC_SHOBJ = itrie.$(SO)
+SRC_C     = itrie.c     readline-complete.c
+SRC_C_STK = itrie.stk   readline-complete.stk
+SRC_SHOBJ = itrie.$(SO) readline-complete.$(SO)
 
 scheme_OBJS = $(SRC_OSTK) $(SRC_SHOBJ)
 
@@ -72,6 +72,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 # Dependencies
 
 itrie.$(SO): itrie-incl.c itrie.c
+readline-complete.$(SO): readline-complete-incl.c readline-complete.c
 
 # ======================================================================
 install-sources:

--- a/lib/stklos/readline-complete.c
+++ b/lib/stklos/readline-complete.c
@@ -49,7 +49,9 @@ generator(const char *text, int state) {
 			MAKE_BOOLEAN(state));
     if (s == STk_nil) return NULL;
     size_t size = STRING_SIZE(s);
-    char *res = STk_must_malloc(size+1);
+    /* We MUST call malloc, and not use libgc, because readline will attempt
+       to free the pointer (at least on FresBSD). */
+    char *res = malloc(size+1);
     strncpy(res,STRING_CHARS(s), size);
     res[size]=0;
     return res;

--- a/lib/stklos/readline-complete.c
+++ b/lib/stklos/readline-complete.c
@@ -49,7 +49,7 @@ generator(const char *text, int state) {
 			MAKE_BOOLEAN(state));
     if (s == STk_nil) return NULL;
     size_t size = STRING_SIZE(s);
-    char *res = malloc(size+1);
+    char *res = STk_must_malloc(size+1);
     strncpy(res,STRING_CHARS(s), size);
     res[size]=0;
     return res;

--- a/lib/stklos/readline-complete.c
+++ b/lib/stklos/readline-complete.c
@@ -1,0 +1,105 @@
+/*
+ * readline-complete.c   -- tab-completion for readline
+ *
+ * Copyright © 2022 Jerônimo Pellegrini <j_p@aleph0.info>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ *
+ *           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+ *    Creation date: 09-May-2022 09:22
+ * Last file update: 11-May-2022 08:06 (jpellegrini)
+ */
+
+#include <stklos.h>
+#include <readline/readline.h>
+#include "readline-complete-incl.c"
+
+
+SCM gen;
+
+/*
+  Calls the generator (gen) with two arguments:
+  1. the text to be matched
+  2. the state:
+     - #f if this is the first call (and we want the first match from
+       the list)
+     - #t if this is a subsequent call (and we want one more match).
+  This is how readline works.
+ */
+char *
+generator(const char *text, int state) {
+    /* We need to keep 'const' for the 'text' parameter,
+       so we use a cast when passing it to STk_Cstring2string. */
+    SCM s = STk_C_apply(gen,2,
+			STk_Cstring2string((char *)text),
+			MAKE_BOOLEAN(state));
+    if (s == STk_nil) return NULL;
+    size_t size = STRING_SIZE(s);
+    char *res = malloc(size+1);
+    strncpy(res,STRING_CHARS(s), size);
+    res[size]=0;
+    return res;
+}
+
+/* STk_completion is the function passed to libreadline to do tab
+   completion. Its arguments are
+   - The partially typed string
+   - The start and end positions, which we ignore.
+   The actualy work is done by the generator function in this file,
+   which in turn calls the Scheme procedure complete in
+   readline-complete.stk. */
+char **
+STk_completion(const char *str, int start, int end) {
+    rl_attempted_completion_over = 1;
+    return rl_completion_matches(str, generator);
+}
+
+/*
+  %init-readline-completion-function will:
+  1. set our C variable 'gen' to the STklos closure that is passed
+     as the 'generator' argument;
+  2. set the readline completion function to our C completion
+     function STk_completion.
+  It is called by the Scheme procedure 'init-readline-completion-function'.
+ */
+DEFINE_PRIMITIVE("%init-readline-completion-function",readline_init_completion,subr1,
+		 (SCM generator))
+{
+    gen = generator;
+    /* The word break chars are by default " \t\n\"\\'`@$><=;|&{(".
+       We adapt those here so they make sense in a Scheme environment.
+       It's not perfect, though: we'll ignore variables names starting
+       with \t, \n, ; etc, because if we matched them we'd have trouble
+       with separating tokens. */
+    rl_completer_word_break_characters = " \t\n'`;|(";
+	
+    rl_attempted_completion_function = STk_completion;
+    return STk_void;
+}
+
+MODULE_ENTRY_START("stklos/readline-complete")
+{
+  SCM module =  STk_create_module(STk_intern("stklos/readline-complete"));
+
+  ADD_PRIMITIVE_IN_MODULE(readline_init_completion, module);
+    
+  /* Execute Scheme code */
+  STk_execute_C_bytecode(__module_consts, __module_code);
+}
+MODULE_ENTRY_END
+
+DEFINE_MODULE_INFO

--- a/lib/stklos/readline-complete.stk
+++ b/lib/stklos/readline-complete.stk
@@ -1,0 +1,117 @@
+;;;;
+;;;; readline-complete.stk   -- tab completion for readline
+;;;;
+;;;; Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 08-May-2022 08:59
+;;;; Last file update: 11-May-2022 07:50 (jpellegrini)
+
+(select-module stklos/readline-complete)
+
+(export readline-completion-generator
+        readline-complete-get-modules
+        init-readline-completion-function)
+
+#|
+<doc EXT readline-complete-get-modules
+ * (readline-complete-get-modules)
+ *
+ * This is a parameter that holds one procedure. The procedure should
+ * return a list that specifies the modules that will be searched when
+ * doing tab completion, and which symbols should be considered from
+ * each module.
+ * The list returned from the procedure is a list of conses, where
+ * the CAR is a module, and the CDR is :export when only the exported
+ * symbols should be considered from that module.
+ *
+ * The default value is
+ * @lisp
+ * (lambda () (list (cons (find-module 'STklos) :export)
+ *             (cons (current-module)      :all)))
+ * @end lisp
+ * which will read all exported symbols in the STklos module and all
+ * symbols (exported or not) from the current module.
+doc>
+|#
+(define readline-complete-get-modules
+  (make-parameter
+   (lambda () (list (cons (find-module 'STklos) :export)
+               (cons (current-module)      :all)))))
+
+;; Returns a list with the symbols in 'module'.
+;; If 'inly-exports' is equal to #:export, only exported
+;; symbols are considered.
+(define (get-module-symbols module only-exports)
+  (map symbol->string
+       (if (eq? only-exports #:export)
+           (map car (module-exports module))
+           (module-symbols (current-module)))))
+
+;; Given a string 'str' (which is the partially typed string in the
+;; REPL), the 'complete' procedure uses the 'readline-complete-get-modules'
+;; parameter to get all completions for that string.
+(define (complete str)
+  ;; We need to bail out when the length is zero, otherwise the program crashes.
+  (if (zero? (string-length str))
+      '()
+      (let* ((modules ((readline-complete-get-modules)))
+             (symbols-lists (map (lambda (mod+ext)
+                                   (get-module-symbols (car mod+ext) (cdr mod+ext)))
+                                 modules))
+             (symbols (apply append symbols-lists)))
+        
+        ;; We just compare the prefix. Perhapes in the future we could optionally
+        ;; use a regexp so the user can decide to match any parts of the word (like,
+        ;; type 'polar', hit tab, and get the expansion 'make-polar')
+        ;; If we do that, we need to be careful to properly escape the matching string.
+        (let ((size (string-length str)))
+          (let ((match (lambda (s)
+                         (and (>= (string-length s) size)
+                          (string=? str (substring s 0 size))))))
+            ;;(write (format #f "str [~a] res ~a~%" str (filter match symbols)) (current-error-port))
+            (filter match symbols))))))
+
+;; readline-completion-generator is a generator of string completions.
+;; It takes as argument a string, 'str' and a state indicator, 'state'.
+;; 
+;; - Completions will be searched for 'str'.
+;; - When state is #f a fresh list of completions is searched, and the first
+;; item is returned.
+;; - When state is #t the next of the current list is returned.
+;; 
+;; This is written this way to match the expected behavior of the readline
+;; function rl_completion_matches.
+(define readline-completion-generator #f)
+
+(let ((ans '()))
+  (set! readline-completion-generator
+    (lambda (str state)
+      (when (not state) (set! ans (complete str)))
+      (if (null? ans)
+          ans
+          (let ((s (car ans)))
+            (set! ans (cdr ans))
+            s)))))
+
+;; init-readline-completion-function actually tells readline to start
+;; doing tab completion, and passes our completion function to it.
+(define (init-readline-completion-function)
+  (%init-readline-completion-function readline-completion-generator))
+
+(provide "stklos/readline-complete")

--- a/lib/stklos/readline-complete.stk
+++ b/lib/stklos/readline-complete.stk
@@ -112,6 +112,9 @@ doc>
 ;; init-readline-completion-function actually tells readline to start
 ;; doing tab completion, and passes our completion function to it.
 (define (init-readline-completion-function)
+  (unless (eq? (key-get *%system-state-plist* :readline 'no-readline)
+               'readline)
+    (error "readline completion requested, but readline not installed")
   (%init-readline-completion-function readline-completion-generator))
 
 (provide "stklos/readline-complete")

--- a/lib/stklos/readline-complete.stk
+++ b/lib/stklos/readline-complete.stk
@@ -84,7 +84,6 @@ doc>
           (let ((match (lambda (s)
                          (and (>= (string-length s) size)
                           (string=? str (substring s 0 size))))))
-            ;;(write (format #f "str [~a] res ~a~%" str (filter match symbols)) (current-error-port))
             (filter match symbols))))))
 
 ;; readline-completion-generator is a generator of string completions.

--- a/lib/stklos/readline-complete.stk
+++ b/lib/stklos/readline-complete.stk
@@ -113,7 +113,7 @@ doc>
 (define (init-readline-completion-function)
   (unless (eq? (key-get *%system-state-plist* :readline 'no-readline)
                'readline)
-    (error "readline completion requested, but readline not installed")
+    (error "readline completion requested, but readline not installed"))
   (%init-readline-completion-function readline-completion-generator))
 
 (provide "stklos/readline-complete")


### PR DESCRIPTION
Hi @egallesio !
I added simple tab completion to the STklos REPL -- but I think it still needs some work.
To use:

```scheme
(import (stklos readline-complete))
(init-readline-completion-function)
```

and try to hit tab after a partially-written symbol name.  Readline will bring several options to complete the word (the symbols extracted from the STklos module and the current module).

By default, **exported** symbols in the STklos module and **any** symbols in the current module are searched for completions. This behavior can be changed by changing the parameter `readline-complete-get-modules`.

Questions:

* There is a global `gen` variable in the C file that holds the Scheme procedure/generator that produces matches. I'm not sure what would be the best thing to do with it (make it thread-local, how?)
* <s>I didn't test it in a system without readline support (it would probably crash). How can I tell, programatically, if the running version of STklos has readline support?</s> Found it! `(key-get *%system-state-plist* :readline 'no-readline)`
* Should this really be a library, or should it be included in the standard readline REPL? (It's funny, it was easier to me to write it as a library)

Issues: 

* I didn't test it with the BSD version of `readline`, will do that soon. It' `libedit`. It works with `libedit` on FreeBSD, but I couldn't test `libedit` on Linux (STklos refuses to open it?)
* <s>The C code uses `malloc` to copy the Scheme string contents and send it to readline. (I tried to send `STRING_CHARS(s)` directly, and it crashed - but maybe I did something wrong there) I'll review this.</s> Fixed: `malloc` is needed because libreadline will `free` it.

I'll still work on it in the next days.