### PR TITLE
OpenBSD support: Use $(MAKE) instead of 'make'; include OpenBSD in utils/shlib-options

### DIFF
--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -17,9 +17,9 @@ all:
 	@echo "***"
 
 clean-am:
-	for d in $(subdirs) ;do (cd $$d; make $@) ;done
+	for d in $(subdirs) ;do (cd $$d; $(MAKE) $@) ;done
 	rm -f *~
 
 distclean-am:
-	for d in $(subdirs) ;do (cd $$d; make $@) ;done
+	for d in $(subdirs) ;do (cd $$d; $(MAKE) $@) ;done
 	rm -f Makefile

--- a/lib/srfi/144.c
+++ b/lib/srfi/144.c
@@ -138,17 +138,21 @@ void STk_srfi_144_define_constants(SCM module) {
 
    DBL_MIN:
    [ 0 | 00000000001 | 0000000000000000000000000000000000000000000000000000 ]
-   DBL_MIN / 2:
-   [ 0 | 00000000000 | 1000000000000000000000000000000000000000000000000000 ]
-   DBL_MIN / 4:
-   [ 0 | 00000000000 | 0100000000000000000000000000000000000000000000000000 ]
    Signal = 0, Exponent = 1, Mantissa = 0.
+
+   DBL_MIN / 2.0:
+   [ 0 | 00000000000 | 1000000000000000000000000000000000000000000000000000 ]
+   Signal = 0, Exponent = 0, Mantissa = 2^52.
+
+   DBL_MIN / 4.0:
+   [ 0 | 00000000000 | 0100000000000000000000000000000000000000000000000000 ]
+   Signal = 0, Exponent = 0, Mantissa = 2^51.
    
    DBL_TRUE_MIN:
    [ 0 | 00000000000 | 0000000000000000000000000000000000000000000000000001 ]
    Signal = 0, Exponent = 0, Mantissa = 1.
 
-   Each time we divide DBL_MIN by 2, we do a right shift on the number.
+   Each time we divide DBL_MIN by 2.0, we do a right shift on the number.
    Eventually, it will become zero.
 
    Note that the first time that DBL_MIN is divided by zero already results in

--- a/lib/srfi/144.c
+++ b/lib/srfi/144.c
@@ -126,7 +126,57 @@ void STk_srfi_144_define_constants(SCM module) {
     DEFLOCONST("fl-gamma-2/3",tgamma(2.0/3.0), module);
 
     DEFLOCONST("fl-greatest", DBL_MAX, module);
+
+/* DBL_MIN is the least NORMAL positive number represented in IEEE format.
+   DBL_TRUE_MIN is the least SUBNORMAL positive number: the one that, when
+   divided by 2, is equal to zero.
+   Some platforms may not have DBL_TRUE_MIN defined (at this time, OpenBSD
+   doesn't), so we calculate DBL_TRUE_MIN.
+
+   Remark I: Using IEEE 754, the representations of DBL_MIN and DBL_TRUE_MIN
+   are as follows.
+
+   DBL_MIN:
+   [ 0 | 00000000001 | 0000000000000000000000000000000000000000000000000000 ]
+   DBL_MIN / 2:
+   [ 0 | 00000000000 | 1000000000000000000000000000000000000000000000000000 ]
+   DBL_MIN / 4:
+   [ 0 | 00000000000 | 0100000000000000000000000000000000000000000000000000 ]
+   Signal = 0, Exponent = 1, Mantissa = 0.
+   
+   DBL_TRUE_MIN:
+   [ 0 | 00000000000 | 0000000000000000000000000000000000000000000000000001 ]
+   Signal = 0, Exponent = 0, Mantissa = 1.
+
+   Each time we divide DBL_MIN by 2, we do a right shift on the number.
+   Eventually, it will become zero.
+
+   Note that the first time that DBL_MIN is divided by zero already results in
+   a subnormal number (the exponent becomes zero) -- because DBL_MIN is
+   indeed the least *normal* number.
+
+   Remark II: if we were to assume that numbers are always represented using
+   IEEE format, we could just take positive zero, set its first bit, and
+   that would be the same as DBL_TRUE_MIN. But we'll be more careful and
+   calculate it, dividing DBL_MIN by 2 successfully until it is zero.
+
+   -- jpellegrini          */
+#ifdef DBL_TRUE_MIN
     DEFLOCONST("fl-least", DBL_TRUE_MIN, module);
+#else
+    {
+	double x = DBL_MIN;
+	double res = x;
+	while (1) {
+	    if (x == 0.0) break;
+	    res = x;
+	    x = x / 2.0;
+	}
+        DEFLOCONST("fl-least", res, module);
+    }
+#endif
+
+
     DEFLOCONST("fl-epsilon", DBL_EPSILON, module);
 #ifdef FP_FAST_FMA
     DEFCONST("fl-fast-fl+*", STk_true, module);

--- a/utils/shlib-options
+++ b/utils/shlib-options
@@ -68,11 +68,11 @@ case $os in
       esac
       OS=FREEBSD
       SH_COMP_FLAGS='-fpic'
-          SH_LOAD_FLAGS='-shared -o'
-          SH_LOADER="$LD"
-          SH_SUFFIX='so'
-          SH_LIB_SUFFIX='so'
-          SH_MAIN_LOAD_FLAGS="-rdynamic"
+      SH_LOAD_FLAGS='-shared -o'
+      SH_LOADER="$LD"
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
+      SH_MAIN_LOAD_FLAGS="-rdynamic"
       ;;
   OpenBSD*)
       case $machine in
@@ -87,12 +87,12 @@ case $os in
       SH_MAIN_LOAD_FLAGS="-rdynamic"
       ;;
   HP*)
-          OS=HPUX
-          SH_COMP_FLAGS="+Z"
-          SH_LOAD_FLAGS="-b -o"
-          SH_LOADER="$LD"
-          SH_SUFFIX='sl'
-          SH_LIB_SUFFIX='sl'
+      OS=HPUX
+      SH_COMP_FLAGS="+Z"
+      SH_LOAD_FLAGS="-b -o"
+      SH_LOADER="$LD"
+      SH_SUFFIX='sl'
+      SH_LIB_SUFFIX='sl'
       SH_MAIN_LOAD_FLAGS="-Wl,-E"
       ;;
   IRIX*)
@@ -106,7 +106,7 @@ case $os in
       SH_LOAD_FLAGS="-shared -o"
       SH_LOADER="$CC"
       SH_SUFFIX='so'
-          SH_LIB_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
       ;;
   Linux*)
       case $version in
@@ -121,28 +121,28 @@ case $os in
       esac
       OS=LINUX
       SH_COMP_FLAGS='-fpic -nostdlib'
-          SH_LOAD_FLAGS='-shared -o'
-          SH_LOADER="$LD"
-          SH_SUFFIX='so'
-          SH_LIB_SUFFIX='so'
-          SH_MAIN_LOAD_FLAGS="-rdynamic"
+      SH_LOAD_FLAGS='-shared -o'
+      SH_LOADER="$LD"
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
+      SH_MAIN_LOAD_FLAGS="-rdynamic"
       ;;
   NetBSD*)
       OS=NETBSD
       SH_COMP_FLAGS="-fpic"
-          SH_LOAD_FLAGS="-Bshareable -o"
-          SH_LOADER="$LD"
-          SH_SUFFIX='so'
-          SH_LIB_SUFFIX='so'
+      SH_LOAD_FLAGS="-Bshareable -o"
+      SH_LOADER="$LD"
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
       ;;
   OSF*)
       OS=OSF
       if [ "$CC" = "gcc" ] ;then
          SH_COMP_FLAGS="-fpic"
-             SH_LOAD_FLAGS="-shared -o"
-             SH_LOADER="$LD"
+         SH_LOAD_FLAGS="-shared -o"
+         SH_LOADER="$LD"
          SH_SUFFIX='so'
-             SH_LIB_SUFFIX='so'
+         SH_LIB_SUFFIX='so'
        else
          die "I do not know how to dynamically load on $os with $CC"
        fi
@@ -156,17 +156,17 @@ case $os in
 #     SH_LOAD_FLAGS='-G -z text -h'
       SH_COMP_FLAGS="-fpic"
       SH_LOAD_FLAGS='-shared -o'
-          SH_LOADER="$LD"
-          SH_SUFFIX='so'
-          SH_LIB_SUFFIX='so'
+      SH_LOADER="$LD"
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
       ;;
   Darwin*)
       OS=DARWIN;
-          SH_COMP_FLAGS="-fPIC -fno-common"
+      SH_COMP_FLAGS="-fPIC -fno-common"
       SH_LOAD_FLAGS='-bundle -flat_namespace -undefined suppress -o'
-          SH_LOADER="$CC"
-          SH_SUFFIX='so'
-          SH_LIB_SUFFIX='dylib'
+      SH_LOADER="$CC"
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='dylib'
       ;;
   CYGWIN*)
       # Since I cannot figure yet how to use shared libraries in Cygwin
@@ -174,11 +174,11 @@ case $os in
       OS=CYGWIN;
       OS_FLAVOUR=WIN32;
       SH_COMP_FLAGS=
-          SH_LOAD_FLAGS='-shared -o'
-          SH_LOADER='true'
-          SH_SUFFIX='so'
-          SH_LIB_SUFFIX='so'
-          SH_MAIN_LOAD_FLAGS=""
+      SH_LOAD_FLAGS='-shared -o'
+      SH_LOADER='true'
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
+      SH_MAIN_LOAD_FLAGS=""
       ;;
   *)      OS=UNKNOWN;;
 esac

--- a/utils/shlib-options
+++ b/utils/shlib-options
@@ -74,6 +74,18 @@ case $os in
           SH_LIB_SUFFIX='so'
           SH_MAIN_LOAD_FLAGS="-rdynamic"
       ;;
+  OpenBSD*)
+      case $machine in
+        i*86) machine=ix86;;
+      esac
+      OS=OPENBSD
+      SH_COMP_FLAGS='-fpic'
+      SH_LOAD_FLAGS='-shared -o'
+      SH_LOADER="$LD"
+      SH_SUFFIX='so'
+      SH_LIB_SUFFIX='so'
+      SH_MAIN_LOAD_FLAGS="-rdynamic"
+      ;;
   HP*)
           OS=HPUX
           SH_COMP_FLAGS="+Z"


### PR DESCRIPTION
Hi @egallesio !

This PR brings three modifications to support OpenBSD:

* In `extensions/Makefile.am`, 'make' was hardcoded, and this fails when the name of GNU Make is `gmake` such as in BSD systems.
* Adds OpenBSD  to `utils/shlib-options`
* Calculate `DBL_TRUE_MIN` when necessary

Fixes #374 and fixes #375 .