### PR TITLE
Add immutability to hash tables, and adjust wording in other places ("locked" -> "immutable")

### DIFF
--- a/doc/refman/srfi.adoc
+++ b/doc/refman/srfi.adoc
@@ -334,7 +334,7 @@ NOTE: To obtain the symbol `:` in {{stklos}}, you must use `|:|`.
 {{insertdoc 'not-ipair?}}
 {{insertdoc 'null-ilist?}}
 {{insertdoc 'ilist=}}
-{{insertdoc 'list-lock!}}
+{{insertdoc 'list-immutable!}}
 
 {{insertdoc 'itenth}}
 {{insertdoc 'icar+icdr}}

--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1798,7 +1798,7 @@ doc>
     (if (= (length args) 2)
         `(begin                   ;; NOTE: this code should be atomic
            (define ,@args)
-           (symbol-lock! ',(car args)))
+           (symbol-immutable! ',(car args)))
         (error "bad constant definition ~S" `(define-constant ,@args)))))
 
 ;;;; ======================================================================

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -139,10 +139,10 @@ doc>
      ((struct-type? x)  (format port "the type structure named ~A"
                                 (struct-type-name x)))
      ((library? x)      (format port "~a R7RS library named ~A"
-                                (if (module-locked? x) "a locked" "an unlocked")
+                                (if (module-mutable? x) "a mutable" "an immutable")
                                 (library-name x)))
      ((module? x)       (format port "~a module named ~A"
-                                (if (module-locked? x) "a locked" "an unlocked")
+                                (if (module-mutable? x) "a mutable" "an immutable")
                                 (module-name x)))
      ((port? x)         (format port "an ~a ~a port"
                                 (if (input-port? x) "input" "output")

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -147,6 +147,12 @@ doc>
      ((port? x)         (format port "an ~a ~a port"
                                 (if (input-port? x) "input" "output")
                                 (if (binary-port? x) "binary" "textual")))
+     ((hash-table? x)   (format port "~a~a hash table~a"
+                                (if (hash-table-mutable? x)     "a mutable" "an immutable")
+                                (if (zero? (hash-table-size x)) ", empty"   "")
+                                (if (positive? (hash-table-size x))
+                                    (format #f " with ~a entries" (hash-table-size x))
+                                    "")))
      (else              (let ((user-type-name (%user-type-name x)))
                           (if user-type-name
                               ;; Object type is user defined.

--- a/lib/srfi/116.c
+++ b/lib/srfi/116.c
@@ -152,33 +152,33 @@ doc>
 /*                                   */
 
 void
-STk_lock_list(SCM l) {
+STk_immutable_list(SCM l) {
     for(;CONSP(l); l = CDR(l))
         BOXED_INFO(l) |= CONS_CONST;
 }
 
 void
-STk_unlock_list(SCM l) {
+STk_mutable_list(SCM l) {
     for(;CONSP(l); l = CDR(l))
         BOXED_INFO(l) &= (~CONS_CONST);
 }
 
 void
-STk_lock_tree(SCM l) {
+STk_immutable_tree(SCM l) {
     if (CONSP(l)) {
         BOXED_INFO(l) |= CONS_CONST;
-        STk_lock_tree(CAR(l));
-        STk_lock_tree(CDR(l));
+        STk_immutable_tree(CAR(l));
+        STk_immutable_tree(CDR(l));
     }
     return;
 }
 
 void
-STk_unlock_tree(SCM l) {
+STk_mutable_tree(SCM l) {
     if (CONSP(l)) {
         BOXED_INFO(l) &= (~CONS_CONST);
-        STk_lock_tree(CAR(l));
-        STk_lock_tree(CDR(l));
+        STk_immutable_tree(CAR(l));
+        STk_immutable_tree(CDR(l));
     }
     return;
 }
@@ -221,7 +221,7 @@ DEFINE_PRIMITIVE("iappend", srfi_116_iappend, vsubr, (int argc, SCM *argv))
     default: res = STk_append(argc, argv);
              break;
   }
-  if (CONSP(res)) STk_lock_list(res);
+  if (CONSP(res)) STk_immutable_list(res);
   return res;
 }
 
@@ -307,14 +307,14 @@ doc>
 DEFINE_PRIMITIVE("list->ilist", srfi_116_list_ilist, subr1, (SCM l))
 {
     SCM z = STk_list_copy(l);
-    STk_lock_list(z);
+    STk_immutable_list(z);
     return z;
 }
 
 DEFINE_PRIMITIVE("ilist->list", srfi_116_ilist_list, subr1, (SCM l))
 {
     SCM z = STk_list_copy(l);
-    STk_unlock_list(z);
+    STk_mutable_list(z);
     return z;
 }
 
@@ -338,14 +338,14 @@ doc>
 DEFINE_PRIMITIVE("tree->itree", srfi_116_tree_itree, subr1, (SCM l))
 {
     SCM z = STk_list_copy(l);
-    STk_lock_tree(z);
+    STk_immutable_tree(z);
     return z;
 }
 
 DEFINE_PRIMITIVE("itree->tree", srfi_116_itree_tree, subr1, (SCM l))
 {
     SCM z = STk_list_copy(l);
-    STk_unlock_tree(z);
+    STk_mutable_tree(z);
     return z;
 }
 
@@ -355,26 +355,26 @@ DEFINE_PRIMITIVE("itree->tree", srfi_116_itree_tree, subr1, (SCM l))
 /* EXTRA */
 
 /*
-<doc EXT list-lock+! list-lock!
- * (list-lock+! lst)
- * (list-lock! lst)
+<doc EXT list-immutable+! list-immutable!
+ * (list-immutable+! lst)
+ * (list-immutable! lst)
  *
  * Destructive versions of |list->ilist|: both procedures change their
  * argument so it will become an immutable list.
- * |List-lock+!| returns the list, while |list-lock!| returns |#void|.
+ * |List-immutable+!| returns the list, while |list-immutable!| returns |#void|.
 doc>
 */
-DEFINE_PRIMITIVE("list-lock+!", srfi_116_list_lock_plus, subr1, (SCM obj))
+DEFINE_PRIMITIVE("list-immutable+!", srfi_116_list_immutable_plus, subr1, (SCM obj))
 {
     if (!CONSP(obj)) STk_error("bad list ~S", obj);
-    STk_lock_list(obj);
+    STk_immutable_list(obj);
     return obj;
 }
 
-DEFINE_PRIMITIVE("list-lock!", srfi_116_list_lock, subr1, (SCM obj))
+DEFINE_PRIMITIVE("list-immutable!", srfi_116_list_immutable, subr1, (SCM obj))
 {
     if (!CONSP(obj)) STk_error("bad list ~S", obj);
-    STk_lock_list(obj);
+    STk_immutable_list(obj);
     return STk_void;
 }
 
@@ -401,8 +401,8 @@ MODULE_ENTRY_START("srfi/116")
   ADD_PRIMITIVE_IN_MODULE(srfi_116_replace_icar, module);
   ADD_PRIMITIVE_IN_MODULE(srfi_116_replace_icdr, module);
 
-  ADD_PRIMITIVE_IN_MODULE(srfi_116_list_lock_plus,    module);
-  ADD_PRIMITIVE_IN_MODULE(srfi_116_list_lock,    module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_116_list_immutable_plus,    module);
+  ADD_PRIMITIVE_IN_MODULE(srfi_116_list_immutable,    module);
 
   /* Export all the symbols we have just defined */
   STk_export_all_symbols(module);

--- a/lib/srfi/116.stk
+++ b/lib/srfi/116.stk
@@ -65,7 +65,7 @@
 ;;;   (the reference implementation has a simpler procedure that runs in
 ;;;   quadratic time).
 ;;;
-;;; * The list-lock+! procedure is used to change a list, in-place, so
+;;; * The list-immutable+! procedure is used to change a list, in-place, so
 ;;;   it becomes immutable.
 
 
@@ -242,7 +242,7 @@
                       ipair->pair pair->ipair
                       ilist->list list->ilist
                       tree->itree itree->tree
-                      list-lock+!)
+                      list-immutable+!)
 
 ;;;
 ;;; UTILITIES FROM THE REFRENCE IMPLEMENTATION
@@ -340,7 +340,7 @@ doc>
 doc>
 |#
 (define (make-ilist n :optional (fill #void))
-  (list-lock+! (make-list n fill)))
+  (list-immutable+! (make-list n fill)))
 
 
 #|
@@ -371,7 +371,7 @@ doc>
  * Copies the spine of the argument, including the ilist tail.
 doc>
 |#
-(define (ilist-copy x) (list-lock+! (list-copy x)))
+(define (ilist-copy x) (list-immutable+! (list-copy x)))
 
 #|
 <doc EXT iiota
@@ -820,7 +820,7 @@ doc>
  * @end lisp
 doc>
 |#
-(define (ireverse il) (list-lock+! (reverse il)))
+(define (ireverse il) (list-immutable+! (reverse il)))
 
 
 #|
@@ -1387,7 +1387,7 @@ doc>
  * @end lisp
 doc>
 |#
-(define (imap . args) (list-lock+! (apply map args)))
+(define (imap . args) (list-immutable+! (apply map args)))
 
 #|
 <doc EXT ifor-each
@@ -1515,7 +1515,7 @@ doc>
  * not specified.
 doc>
 |#
-(define (ifilter-map . args)  (list-lock+! (apply filter-map args)))
+(define (ifilter-map . args)  (list-immutable+! (apply filter-map args)))
 
 
 ;; FILTERING AND PARTITIONING
@@ -1537,7 +1537,7 @@ doc>
 doc>
 |#
 (define (ifilter p l)
-  (list-lock+! (filter p l)))
+  (list-immutable+! (filter p l)))
 
 #|
 <doc EXT ipartition
@@ -1592,7 +1592,7 @@ doc>
 doc>
 |#
 (define (iremove p l)
-  (list-lock+! (remove p l)))
+  (list-immutable+! (remove p l)))
 
 ;; SEARCHING
 
@@ -1895,19 +1895,19 @@ doc>
 doc>
 |#
 ;; We need to check if the result is #f, member/memq/memv
-;; returns #f when the element is not found, but list-lock+!
+;; returns #f when the element is not found, but list-immutable+!
 ;; expects a list.
 (define (imember x il :optional (e equal?))
   (let ((lst (member x il e)))
-    (if (list? lst) (list-lock+! lst) lst)))
+    (if (list? lst) (list-immutable+! lst) lst)))
 
 (define (imemq x il)
   (let ((lst (memq x il)))
-    (if (list? lst) (list-lock+! lst) lst)))
+    (if (list? lst) (list-immutable+! lst) lst)))
 
 (define (imemv  x il)
   (let ((lst (memv x il)))
-    (if (list? lst) (list-lock+! lst) lst)))
+    (if (list? lst) (list-immutable+! lst) lst)))
 
 
 ;; DELETION
@@ -1940,7 +1940,7 @@ doc>
 doc>
 |#
 (define (idelete x il :optional (= equal?))
-  (list-lock+! (delete x il =)))
+  (list-immutable+! (delete x il =)))
 
 
 #|

--- a/src/hash.c
+++ b/src/hash.c
@@ -452,6 +452,10 @@ static void error_bad_hash_table(SCM obj)
   STk_error("bad hash table ~S", obj);
 }
 
+static void error_hash_immutable(SCM obj)
+{
+  STk_error("hash table ~S is not mutable", obj);
+}
 
 static void error_bad_procedure(SCM obj)
 {
@@ -501,6 +505,38 @@ SCM STk_make_basic_hash_table(void) {
   HASH_TYPE(z)   = hash_eqp;
   return z;
 }
+
+
+/*
+<doc EXT hash-immutable!
+ * (hash-immutable! obj)
+ *
+ * If |obj| is a hash table, makes it immutable. Otherwise, raises
+ * an error.
+doc>
+*/
+DEFINE_PRIMITIVE("hash-table-immutable!", hash_table_lock, subr1, (SCM ht))
+{
+  if(!HASHP(ht)) error_bad_hash_table(ht);
+  BOXED_INFO(ht) |= HASH_CONST;
+  return STk_void;
+}
+
+/*
+<doc EXT hash-mutable?
+ * (hash-mutable? obj)
+ *
+ * Returns |#t| if |obj| is an immutable hash table, |#f| if it
+ * is a mutable hash table, and raises an error if |obj| is not a
+ * hash table.
+doc>
+*/
+DEFINE_PRIMITIVE("hash-table-mutable?", hash_table_mutablep, subr1, (SCM ht))
+{
+  if(!HASHP(ht)) error_bad_hash_table(ht);
+  return MAKE_BOOLEAN(!(HASH_CONSTP(ht)));
+}
+
 
 /*
 <doc EXT hash-table?
@@ -574,6 +610,8 @@ DEFINE_PRIMITIVE("hash-table-set!", hash_set, subr3, (SCM ht, SCM key, SCM val))
 
   if (!HASHP(ht)) error_bad_hash_table(ht);
 
+  if (HASH_CONSTP(ht)) error_hash_immutable(ht);
+  
   switch (HASH_TYPE(ht)) {
     case hash_eqp:
       index = RANDOM_INDEX(ht, key);
@@ -743,6 +781,8 @@ DEFINE_PRIMITIVE("hash-table-delete!", hash_delete, subr2, (SCM ht, SCM key))
   SCM func, l, prev;
 
   if (!HASHP(ht)) error_bad_hash_table(ht);
+
+  if (HASH_CONSTP(ht)) error_hash_immutable(ht);
 
   l = prev = STk_nil;
 
@@ -923,6 +963,8 @@ int STk_init_hash(void)
 
   /* Define primitives */
   ADD_PRIMITIVE(make_hash);
+  ADD_PRIMITIVE(hash_table_lock);
+  ADD_PRIMITIVE(hash_table_mutablep);
   ADD_PRIMITIVE(hashtablep);
   ADD_PRIMITIVE(hash_table_size);
   ADD_PRIMITIVE(hash_table_eqv_func);

--- a/src/hash.h
+++ b/src/hash.h
@@ -45,6 +45,8 @@
 #define HASH_OBARRAY_FLAG   1   /* Only for the symbol table      */
 #define HASH_VAR_FLAG       2   /* For modules (keys are symbols) */
 #define HASH_SCM_FLAG       3   /* For secheme hash tables        */
+/* 4, '100' means the table is constant. do NOT define macros for 5,6,7. */
+#define HASH_CONST          4
 
 typedef enum {hash_system, hash_eqp, hash_stringp, hash_general} hash_type;
 
@@ -71,6 +73,8 @@ struct hash_table_obj {
 #define HASH_NEWSIZE(h)         (((struct hash_table_obj *) (h))->rebuild_size)
 #define HASH_SHIFT(h)           (((struct hash_table_obj *) (h))->down_shift)
 #define HASH_MASK(h)            (((struct hash_table_obj *) (h))->mask)
+
+#define HASH_CONSTP(h)          (BOXED_INFO(h) & HASH_CONST)
 
 #define HASH_TYPE(h)            (((struct hash_table_obj *) (h))->type)
 #define HASH_COMPAR(h)          (((struct hash_table_obj *) (h))->comparison)

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -497,7 +497,7 @@ struct frame_obj {
 #define FRAME_LOCAL(p, i)       (FRAME_LOCALS(p)[i])
 #define FRAMEP(p)               (BOXED_TYPE_EQ((p), tc_frame))
 
-#define MODULE_LOCKED            (1 << 0)
+#define MODULE_CONST            (1 << 0)
 
 /* modules are defined in env.c but are private */
 #define MODULEP(p)              (BOXED_TYPE_EQ((p), tc_module))


### PR DESCRIPTION
Hi @egallesio !
This may be useful when implementing SRFI 125, which deals with immutable hash tables.

`(hash-table-immutable! h)` makes the hash table h immutable.
No entries can be added, removed or changed after that.

`(hash-table-mutable? h)` determines if a hash table is mutable.

`hash-table-copy` will create a mutable hash table.

`describe` also talks a bit more about hash tables now. :)

I have used 4 ("100") as `HASH_CONST`, although I suspect it would be a good idea to have a single "immutable" bit for all objects later.
