### PR TITLE
Optimize (void ...)

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -73,7 +73,8 @@
                          (string-set!    . ,string-set!)
                          (eq?            . ,eq?)
                          (eqv?           . ,eqv?)
-                         (equal?         . ,equal?)))
+                         (equal?         . ,equal?)
+                         (void           . ,void)))
 
 (define *inline-symbols* (map car *inline-table*))
 
@@ -1122,6 +1123,10 @@ doc>
       ((eq?)            (comp2 'IN-EQ))
       ((eqv?)           (comp2 'IN-EQV))
       ((equal?)         (comp2 'IN-EQUAL))
+      ((void)           (if (zero? len)
+                            (emit 'IM-VOID)
+                            (compile (append (cons 'begin actuals) (list (void)))
+                                     env epair #f)))
       (else             (panic "unimplemented inline primitive ~S" fct)))))
 
 

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -272,6 +272,18 @@ b|)
 (test/error "repeat.3"
             (repeat 'not-a-number (display "." p)))
 
+;;----------------------------------------------------------------------
+(test-subsection "(void)")
+
+(test "void.1" #t (eq? (void) #void))
+(test "void.2" #t (eq? (void 1 2 3) #void))
+(test "void.3"
+      '(-1 20 #void)
+      (let ((x 1)
+            (y 2))
+        (let ((z (void (set! x -1)
+                       (set! y (* y 10)))))
+          (list x y z))))
 
 ;;------------------------------------------------------------------
 (test-section-end)


### PR DESCRIPTION
Hi @egallesio !
I think the `void` procedure could be inlined.  Is there some reason for not doing it?

This is what STklos does, currently:

```
stklos> (disassemble-expr '(void))

000:  PREPARE-CALL
001:  GREF-INVOKE          0 0
004:

stklos> (disassemble-expr '(void 1 2))

000:  PREPARE-CALL
001:  ONE-PUSH
002:  INT-PUSH             2
004:  GREF-INVOKE          0 2
007:
```

After this patch -- not only we have less instructions, but we also avoid a procedure call.

```
stklos> (disassemble-expr '(void))

000:  IM-VOID
001:

stklos> (disassemble-expr '(void 1 2))

000:  IM-ONE
001:  SMALL-INT            2
003:  IM-VOID
004:
```

Which is the same as if we had no procedure call, and just either
used `#void` or `(begin  [args]  (void))` directly:

```
stklos> (disassemble-expr '#void)

000:  IM-VOID
001:

stklos> (disassemble-expr '(begin 1 2 #void))

000:  IM-ONE
001:  SMALL-INT            2
003:  IM-VOID
004:
```
