### PR TITLE
Add the R7RS "environment" procedure

### DIFF
--- a/lib/env.stk
+++ b/lib/env.stk
@@ -320,4 +320,105 @@ doc>
   (find-module 'R5RS))
 
 
+
+          
+#|
+<doc environment
+ * (environment [name] lib1 lib2 ...)
+ *
+ * This procedure returns a specifier for the environment that
+ * results by starting with an empty environment and then
+ * importing each lib (list or symbol), considered as an import
+ * set, into it. The bindings of the environment represented by
+ * the specifier, as is the environment itself.
+ *
+ * In STklos,
+ * - each |lib| argument can be a list (specifying an R7RS
+ *   library) or a symbol (specifying a module).
+ * - the return environment is an R7RS library (which can be
+ *   passed to |eval|).
+ * - if |name| is a string, it will be set as the new environment
+ *   (library) name.
+doc>
+|#
+(define (environment . args)
+
+  (define (check-module-names args)
+    (for-each (lambda (arg)
+                (unless (or (symbol? arg) (list? arg))
+                  (error "bad library or module name ~S" arg)))
+              args))
+
+  ;; Given a list of library or module names, return a list of
+  ;; modules.
+  (define (get-modules-from-names args)
+    (map (lambda (arg)
+           (let ((m (find-module arg #f)))
+             (if m m (error "bad library or module ~S" arg))))
+         (map %library-name->symbol args)))
+
+  ;; The user can include a name as first argument
+  (let ((name (if (and (pair? args) (string? (car args)))
+                  (string->symbol (car args))
+                  #f)))
+    (when name (set! args (cdr args)))
+
+    ;; Null environment?
+    (if (null? args)
+        (find-module 'NULL-MODULE)
+        
+        (begin
+          (check-module-names args)
+          
+          (let ((new-imported-modules (get-modules-from-names args)))
+            
+            ;; We create an R7RS library. Not a STklos module, since it would
+            ;; then import more than we'd like.
+            (let ((new (%make-library)))
+              (let ((new-exported-symbols
+                     
+                     (let loop ((exp-list '())
+                                (new-imported-modules new-imported-modules))
+                       
+                       (let* ((mod (car new-imported-modules))
+                              (mod-exported (map car (module-exports mod))))
+                           
+                         ;; Append here is not efficient, but... How many
+                         ;; modules and exported symbols will one include here?
+                         (let ((new-exported
+                                (append mod-exported exp-list)))
+                           
+                           ;; define the symbol in the module
+                           (for-each (lambda (sym)
+                                       (%symbol-define sym (symbol-value sym mod) new))
+                                     mod-exported)
+                             (if (null? (cdr new-imported-modules))
+                                 new-exported
+                                 (loop new-exported
+                                       (cdr new-imported-modules))))))))
+                
+                ;; The module is populated! We can now set its exported
+                ;; symbols and imported modules. (Setting the imported modules
+                ;; is relevant, because the standard says it should behave
+                ;; "starting with an empty environment and then importing each
+                ;; list, considered as an import set, into it" -- which would
+                ;; set the import list of the module.
+                (%module-exports-set! new new-exported-symbols)
+                (%module-imports-set! new new-imported-modules)
+                
+                (module-lock! new)  ;; immutability required by the standard
+                
+                ;; If the user passed a string as first argument,
+                ;; we use it as name. Otherwise, we can't give it
+                ;; a name.
+                ;; In the spec, the procedure does not take names as
+                ;; arguments, and we can't decide which one to give.
+                ;; Gensym doesn't help, because we'd create a name
+                ;; that the user can't refer to later.
+                (when name (%register-library-as-module new name))
+                
+                new)))))))
+    
+
+
 (provide "env")

--- a/lib/env.stk
+++ b/lib/env.stk
@@ -359,9 +359,10 @@ doc>
 
   ;; The user can include a name as first argument
   (let ((name (if (and (pair? args) (string? (car args)))
-                  (string->symbol (car args))
-                  #f)))
-    (when name (set! args (cdr args)))
+                  (let ((n (string->symbol (car args))))
+                    (set! args (cdr args))
+                    n)
+                  (gensym "unnamed-module-"))))
 
     ;; Null environment?
     (if (null? args)
@@ -374,7 +375,9 @@ doc>
             
             ;; We create an R7RS library. Not a STklos module, since it would
             ;; then import more than we'd like.
-            (let ((new (%make-library)))
+            ;; FIXME: is eval a good idea here?
+            (eval `(define-library ,name))
+            (let ((new (eval `(find-module (quote ,(string->symbol (symbol->string name)))))))
               (let ((new-exported-symbols
                      
                      (let loop ((exp-list '())
@@ -402,21 +405,12 @@ doc>
                 ;; is relevant, because the standard says it should behave
                 ;; "starting with an empty environment and then importing each
                 ;; list, considered as an import set, into it" -- which would
-                ;; set the import list of the module.
+                ;; set the import list of the module).
                 (%module-exports-set! new new-exported-symbols)
                 (%module-imports-set! new new-imported-modules)
-                
+
                 (module-lock! new)  ;; immutability required by the standard
-                
-                ;; If the user passed a string as first argument,
-                ;; we use it as name. Otherwise, we can't give it
-                ;; a name.
-                ;; In the spec, the procedure does not take names as
-                ;; arguments, and we can't decide which one to give.
-                ;; Gensym doesn't help, because we'd create a name
-                ;; that the user can't refer to later.
-                (when name (%register-library-as-module new name))
-                
+
                 new)))))))
     
 

--- a/lib/scheme/eval.stk
+++ b/lib/scheme/eval.stk
@@ -26,7 +26,101 @@
 ;;;;
 
 (define-module scheme/eval
+  (export environment)
   (%module-define-and-export eval))
+
+#|
+<doc environment
+ * (environment [name] lib1 lib2 ...)
+ *
+ * This procedure returns a specifier for the environment that
+ * results by starting with an empty environment and then
+ * importing each lib (list or symbol), considered as an import
+ * set, into it. The bindings of the environment represented by
+ * the specifier, as is the environment itself.
+ *
+ * In STklos,
+ * - each |lib| argument can be a list (specifying an R7RS
+ *   library) or a symbol (specifying a module).
+ * - the return environment is an R7RS library (which can be
+ *   passed to |eval|).
+ * - if |name| is a string, it will be set as the new environment
+ *   (library) name.
+doc>
+|#
+(define (environment . args)
+
+  (define (check-module-names args)
+    (for-each (lambda (arg)
+                (unless (or (symbol? arg) (list? arg))
+                  (error "bad library or module name ~S" arg)))
+              args))
+
+  ;; Given a list of library or module names, return a list of
+  ;; modules.
+  (define (get-modules-from-names args)
+    (map (lambda (arg)
+           (let ((m (find-module arg #f)))
+             (if m m (error "bad library or module ~S" arg))))
+         (map %library-name->symbol args)))
+
+  ;; The user can include a name as first argument
+  (let ((name (if (and (pair? args) (string? (car args)))
+                  (let ((n (string->symbol (car args))))
+                    (set! args (cdr args))
+                    n)
+                  (gensym "unnamed-module-"))))
+
+    ;; Null environment?
+    (if (null? args)
+        (find-module 'NULL-MODULE)
+        
+        (begin
+          (check-module-names args)
+          
+          (let ((new-imported-modules (get-modules-from-names args)))
+            
+            ;; We create an R7RS library. Not a STklos module, since it would
+            ;; then import more than we'd like.
+            ;; FIXME: is eval a good idea here?
+            (eval `(define-library ,name))
+            (let ((new (eval `(find-module (quote ,(string->symbol (symbol->string name)))))))
+              (let ((new-exported-symbols
+                     
+                     (let loop ((exp-list '())
+                                (new-imported-modules new-imported-modules))
+                       
+                       (let* ((mod (car new-imported-modules))
+                              (mod-exported (map car (module-exports mod))))
+                           
+                         ;; Append here is not efficient, but... How many
+                         ;; modules and exported symbols will one include here?
+                         (let ((new-exported
+                                (append mod-exported exp-list)))
+                           
+                           ;; define the symbol in the module
+                           (for-each (lambda (sym)
+                                       (%symbol-define sym (symbol-value sym mod) new))
+                                     mod-exported)
+                             (if (null? (cdr new-imported-modules))
+                                 new-exported
+                                 (loop new-exported
+                                       (cdr new-imported-modules))))))))
+                
+                ;; The module is populated! We can now set its exported
+                ;; symbols and imported modules. (Setting the imported modules
+                ;; is relevant, because the standard says it should behave
+                ;; "starting with an empty environment and then importing each
+                ;; list, considered as an import set, into it" -- which would
+                ;; set the import list of the module).
+                (%module-exports-set! new new-exported-symbols)
+                (%module-imports-set! new new-imported-modules)
+
+                (module-lock! new)  ;; immutability required by the standard
+
+                new)))))))
+    
+
 
 (provide "scheme/eval")
 

--- a/tests/test-r7rs.stk
+++ b/tests/test-r7rs.stk
@@ -1675,7 +1675,8 @@ a")
                        '(scheme write))) ; system lib
 
 
-(test "environment.0" #void (module-name e))
+;; All modules have names now...
+;;(test "environment.0" #void (module-name e))
 (test "environment.1" "aaa" (eval 'a e))
 (test "environment.2" "bbb" (eval 'b e))
 (test/error "environment.3" (eval 'c e))

--- a/tests/test-r7rs.stk
+++ b/tests/test-r7rs.stk
@@ -1639,6 +1639,81 @@ a")
            (list x aaa))))
 
 
+;;======================================================================
+(test-subsection "6.12 Environments and evaluation")
+
+(let ((scheme (find-module 'SCHEME)))
+  (test "eval.scheme.1" -1   (eval -1 (scheme-report-environment 5)))
+  (test "eval.scheme.2"
+        (symbol-value 'display scheme)
+        (eval 'display (scheme-report-environment 5)))
+  (let ((display print))
+    (test "eval.scheme.3"
+          (symbol-value 'display scheme)
+          (eval 'display (scheme-report-environment 5))))
+  (test/error "eval.null.1"  (eval -1 (null-environment 5))))
+
+(define-library (testing x y)
+  (export x) ;; but not y!
+  (begin (define x -1)
+         (define y -2)))
+
+(define-module testing-d
+  (export d)
+  (define d "ddd"))
+
+(define-module testing-a-b-c-d
+  (import testing-d)
+  (export a b d)
+  (define a "aaa")
+  (define b "bbb")
+  (define c "ccc"))
+
+;; without name
+(define e (environment '(testing x y)    ; user lib
+                       'testing-a-b-c-d  ; user module
+                       '(scheme write))) ; system lib
+
+
+(test "environment.0" #void (module-name e))
+(test "environment.1" "aaa" (eval 'a e))
+(test "environment.2" "bbb" (eval 'b e))
+(test/error "environment.3" (eval 'c e))
+(test "environment.4" "ddd" (eval 'd e))
+(test "environment.5" -1 (eval 'x e))
+(test/error "environment.6" (eval 'y e))
+
+;; with name
+(define e2 (environment "my-env"
+                        '(testing x y)    ; user lib
+                        'testing-a-b-c-d  ; user module
+                        '(scheme write))) ; system lib
+
+(test "environment.7" 'my-env (module-name e2))
+(test "environment.8" "aaa" (eval 'a e2))
+(test "environment.9" "bbb" (eval 'b e2))
+(test/error "environment.10" (eval 'c e2))
+(test "environment.11" "ddd" (eval 'd e2))
+(test "environment.12" -1 (eval 'x e2))
+(test/error "environment.13" (eval 'y e2))
+
+;; null
+(test "environment.null.1"
+      #t
+      (eq? (null-environment)
+           (environment)))
+
+(test "environment.null.2"
+      #t
+      (eq? (null-environment)
+           (environment "useless name")))
+
+(test/error "environment.null.3" (eval 'car (null-environment)))            
+
+;; bad arguments to environment
+(test/error "environment.badargs.1" (environment 1))     ; 1 not module
+(test/error "environment.badargs.2" (environment e 1))   ; 1 not module (2nd arg)
+(test/error "environment.badargs.3" (environment e "n")) ; name should be first arg
 
 ;;======================================================================
 (test-subsection "6.13 Input and Output")


### PR DESCRIPTION
This adds the R7RS environment procedure (an extended version, actually).

`(environment [name] lib1 lib2 ...)`
    
This procedure returns a specifier for the environment that
results by starting with an empty environment and then
importing each lib (list or symbol), considered as an import
set, into it. The bindings of the environment represented by
the specifier, as is the environment itself.
    
In STklos, it is extended so that:
- each |lib| argument can be a list (specifying an R7RS
  library) or a symbol (specifying a module).
- the return environment is an R7RS library (which can be
  passed to |eval|).
- if |name| is a string, it will be set as the new environment
  (library) name.

This PR also adds tests to it, and to the other procedures of section 6.12 or R7RS. I've added the tests in `test-r7rs.stk`. Not sure if they should go into `test-r7rs-libraries.stk`