### PR TITLE
Enhance error message in STk_values2vector

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -675,8 +675,16 @@ SCM STk_values2vector(SCM obj, SCM vect)
 
   if (vect) {
     /* User has provided a vector for storing result */
-    if (!VECTORP(vect) || VECTOR_SIZE(vect) != len)
-      STk_error("bad vector ~S", vect);
+
+    /* "not a vector" is an error on the C side of things;
+       a wrong number of values could be triggered by
+       errors in C or on the Scheme side... We'll give
+       a clear message in this case (expected and given
+       number of values). */
+    if (!VECTORP(vect))
+	STk_error("bad vector ~S", vect);
+    if (VECTOR_SIZE(vect) != len)
+	STk_error("expected ~S values, but ~S were given", VECTOR_SIZE(vect), len);
     retval = vect;
   } else {
     /* Allocate a new vector for result */


### PR DESCRIPTION
Hi @egallesio !
A small fix to `STk_values2vector` (which is used in SRFI 25, and in the -- almost ready -- implementation of SRFI 160).

For example, suppose if we write, in C, a procedure similar to `map` or `fold`, which iterates through a structure, applying a procedure KONS (or PROC).
Also suppose PROC takes 2 arguments _**and produces 2 values**_.
In C, we'd do
```c
STk_values2vector ( STk_C_apply(PROC, 2, a, b),  res );
```
However, if later the user passed a procedure that produces the wrong quantity of values, then `STkvalues2vector` (as it is now) would signal an error with a cryptic message, _"bad vector"_.
(Indeed, it's a vector of the wrong size, which was passed to hold the values -- but the Scheme programmer may not even know
that this is how things are implemented internally).

Instead, this patch makes `STk_values2vector` raise an error with a more informative message,

_"expected ~S values, but ~S were given"_

when the vector size is wrong.

If a non-vector is passed, then we still throw the _"bad vector"_ message, because 1) it is actually correct, and 2) it represents an error from the C programmer, who would likely know what happened.