### PR TITLE
Fix off-by-one issue in conversion to 32 bits

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -764,7 +764,7 @@ long STk_integer2int32(SCM n, int *overflow)
 #else                             /* longs are more than 32 bits (probably 64) */
     long val = INT_VAL(n);
 
-    if ((- INT32_MAX - 1) <= val && val < INT32_MAX)
+    if ((- INT32_MAX - 1) <= val && val <= INT32_MAX)
       return val;
     else {
       *overflow = 1;
@@ -793,7 +793,7 @@ unsigned long STk_integer2uint32(SCM n, int *overflow)
 #if (ULONG_MAX == UINT32_MAX)   /* unsigned longs are on 32 bits */
       return (unsigned long) INT_VAL(n);
 #else                           /* longs are more than 32 bits (probably 64) */
-      if (val < UINT32_MAX)
+      if (val <= UINT32_MAX)
         return val;
       else {
         *overflow = 1;


### PR DESCRIPTION
Hello!

The functions `STk_integer2int32` and `STk_integer2uint32` determine if a number fits 32 bits as this:

For `int32`:
```c
if ((- INT32_MAX - 1) <= val && val < INT32_MAX)
```

For `uint32`:
```c
if (val < UINT32_MAX)
```

However, the constants `INT32_MAX` and `UINT32_MAX` are not the power of two (that would not fit into the number), they are the actual largest representable number. So both comparisons can be changed from `<` to `<=`, and we get one more  epresentable number in each.

Not really a big deal. However, the tests for SRFI 160, for example, check if the largest 32-bit number fits a 32-bit uniform vector, and they'll fail with the current implementation.

This patch changes both comparisons into `<=`.
