### PR TITLE
Add SRFI-160: Homogeneous numeric vector libraries

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -96,6 +96,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-154: First-class dynamic extents
     - SRFI-156: Syntactic combiners for binary predicates
     - SRFI-158: Generators and Accumulators
+    - SRFI-160: Homogeneous numeric vector libraries
     - SRFI-161: Unifiable Boxes
     - SRFI-169: Underscores in numbers
     - SRFI-170: POSIX API

--- a/configure
+++ b/configure
@@ -7417,7 +7417,7 @@ esac
 
 
 
-ac_config_files="$ac_config_files Makefile src/Makefile src/extraconf.h doc/Makefile doc/refman/Makefile doc/vm/Makefile doc/hacking/Makefile lib/Makefile utils/Makefile utils/stklos-config utils/stklos-script examples/Makefile lib/Match.d/Makefile lib/SILex.d/Makefile lib/Lalr.d/Makefile lib/ScmPkg.d/Makefile lib/scheme/Makefile lib/srfi/Makefile lib/stklos/Makefile lib/streams/Makefile tests/Makefile doc/stklos.1 doc/stklos-config.1 doc/stklos-compile.1 doc/stklos-genlex.1 doc/stklos-pkg.1 doc/stklos-script.1 pkgman/Makefile extensions/Makefile extensions/gtklos/Makefile extensions/gtklos/lib/stklos/Makefile extensions/gtklos/lib/stklos/gtklos-config.h extensions/gtklos/lib/stklos/gtklos.stk extensions/gtklos/demos/Makefile extensions/curl/Makefile extensions/curl/lib/stklos/Makefile extensions/curl/demos/Makefile extensions/curl/doc/Makefile extensions/fuse/Makefile extensions/fuse/lib/stklos/Makefile extensions/fuse/demos/Makefile"
+ac_config_files="$ac_config_files Makefile src/Makefile src/extraconf.h doc/Makefile doc/refman/Makefile doc/vm/Makefile doc/hacking/Makefile lib/Makefile utils/Makefile utils/stklos-config utils/stklos-script examples/Makefile lib/Match.d/Makefile lib/SILex.d/Makefile lib/Lalr.d/Makefile lib/ScmPkg.d/Makefile lib/scheme/Makefile lib/srfi/Makefile lib/stklos/Makefile lib/streams/Makefile tests/Makefile doc/stklos.1 doc/stklos-config.1 doc/stklos-compile.1 doc/stklos-genlex.1 doc/stklos-pkg.1 doc/stklos-script.1 pkgman/Makefile lib/srfi/160/Makefile extensions/Makefile extensions/gtklos/Makefile extensions/gtklos/lib/stklos/Makefile extensions/gtklos/lib/stklos/gtklos-config.h extensions/gtklos/lib/stklos/gtklos.stk extensions/gtklos/demos/Makefile extensions/curl/Makefile extensions/curl/lib/stklos/Makefile extensions/curl/demos/Makefile extensions/curl/doc/Makefile extensions/fuse/Makefile extensions/fuse/lib/stklos/Makefile extensions/fuse/demos/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -8177,6 +8177,7 @@ do
     "doc/stklos-pkg.1") CONFIG_FILES="$CONFIG_FILES doc/stklos-pkg.1" ;;
     "doc/stklos-script.1") CONFIG_FILES="$CONFIG_FILES doc/stklos-script.1" ;;
     "pkgman/Makefile") CONFIG_FILES="$CONFIG_FILES pkgman/Makefile" ;;
+    "lib/srfi/160/Makefile") CONFIG_FILES="$CONFIG_FILES lib/srfi/160/Makefile" ;;
     "extensions/Makefile") CONFIG_FILES="$CONFIG_FILES extensions/Makefile" ;;
     "extensions/gtklos/Makefile") CONFIG_FILES="$CONFIG_FILES extensions/gtklos/Makefile" ;;
     "extensions/gtklos/lib/stklos/Makefile") CONFIG_FILES="$CONFIG_FILES extensions/gtklos/lib/stklos/Makefile" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -600,6 +600,8 @@ AC_CONFIG_FILES([Makefile src/Makefile src/extraconf.h doc/Makefile
           doc/stklos-genlex.1 doc/stklos-pkg.1 doc/stklos-script.1
           pkgman/Makefile
 
+          lib/srfi/160/Makefile
+
           extensions/Makefile
 
           extensions/gtklos/Makefile

--- a/lib/srfi/160.stk
+++ b/lib/srfi/160.stk
@@ -1,0 +1,196 @@
+
+(define-module srfi/160
+
+  ;;;
+  ;;; IMPORTS
+  ;;;
+  
+  (import srfi/160/base)
+  
+  (import srfi/160/s8)
+  (import srfi/160/u8)
+  (import srfi/160/s16)
+  (import srfi/160/u16)
+  (import srfi/160/s32)
+  (import srfi/160/u32)
+  (import srfi/160/s64)
+  (import srfi/160/u64)
+  (import srfi/160/f32)
+  (import srfi/160/f64)
+  (import srfi/160/c64)
+  (import srfi/160/c128)
+
+  ;;;
+  ;;; EXPORTS
+  ;;;
+  
+  ;; We need to reexport everything we imported, but we don't do all that
+  ;; mechanically. The (srfi 160 base) export clause is copied ipsis literis,
+  ;; but the others are exported programatically.
+  
+  ;; Re-export symbols from (srfi 160 base)
+  (export s8vector? make-s8vector s8vector s8vector-length s8vector-ref
+        s8vector-set! s8vector->list list->s8vector
+
+        u8vector? make-u8vector u8vector u8vector-length u8vector-ref
+        u8vector-set! u8vector->list list->u8vector
+
+        s16vector? make-s16vector s16vector s16vector-length s16vector-ref
+        s16vector-set! s16vector->list list->s16vector
+
+        u16vector? make-u16vector u16vector u16vector-length u16vector-ref
+        u16vector-set! u16vector->list list->u16vector
+
+        s32vector? make-s32vector s32vector s32vector-length s32vector-ref
+        s32vector-set! s32vector->list list->s32vector
+
+        u32vector? make-u32vector u32vector u32vector-length u32vector-ref
+        u32vector-set! u32vector->list list->u32vector
+
+        s64vector? make-s64vector s64vector s64vector-length s64vector-ref
+        s64vector-set! s64vector->list list->s64vector
+
+        u64vector?  make-u64vector u64vector u64vector-length u64vector-ref
+        u64vector-set! u64vector->list list->u64vector
+
+        f32vector?  make-f32vector f32vector f32vector-length f32vector-ref
+        f32vector-set! f32vector->list list->f32vector
+
+        f64vector?  make-f64vector f64vector f64vector-length f64vector-ref
+        f64vector-set! f64vector->list list->f64vector
+
+        c64vector?  make-c64vector c64vector c64vector-length c64vector-ref
+        c64vector-set! c64vector->list list->c64vector
+
+        c128vector?  make-c128vector c128vector c128vector-length c128vector-ref
+        c128vector-set! c128vector->list list->c128vector)
+
+  ;; This is a list of symbols for all SRFI-160 TAG sublibraries.
+  ;; It is taken literally (copied and pasted) from the
+  ;; tagvector-template.stk file, which is the template used to produce
+  ;; the actual (srfi 160 TAG) libraries.
+  (define symbols
+    '(
+      ;; Constructors
+      make-TAGvector   
+      TAGvector        
+      TAGvector-unfold
+      TAGvector-unfold-right
+      TAGvector-copy
+      TAGvector-reverse-copy
+      TAGvector-append
+      TAGvector-concatenate
+      TAGvector-append-subvectors
+      
+      ;; Predicates
+      TAG?              
+      TAGvector?        
+      TAGvector-empty?
+      TAGvector=
+      
+      ;; Selectors
+      TAGvector-ref     
+      TAGvector-length  
+      
+      ;; Iteration
+      TAGvector-take
+      TAGvector-take-right
+      TAGvector-drop
+      TAGvector-drop-right
+      TAGvector-segment
+      TAGvector-fold
+      TAGvector-fold-right
+      TAGvector-map
+      TAGvector-map!
+      TAGvector-for-each
+      TAGvector-count
+      TAGvector-cumulate
+      
+      ;; Searching
+      TAGvector-take-while
+      TAGvector-take-while-right
+      TAGvector-drop-while
+      TAGvector-drop-while-right
+      TAGvector-index
+      TAGvector-index-right
+      TAGvector-skip
+      TAGvector-skip-right
+      TAGvector-any
+      TAGvector-every
+      TAGvector-partition
+      TAGvector-filter
+      TAGvector-remove
+      
+      ;; Mutators
+      TAGvector-set!            
+      TAGvector-swap!
+      TAGvector-fill!
+      TAGvector-reverse!
+      TAGvector-copy!
+      TAGvector-reverse-copy!
+      TAGvector-unfold!
+      TAGvector-unfold-right!
+
+      ;; Conversion
+      TAGvector->list           
+      reverse-TAGvector->list
+      list->TAGvector           
+      reverse-list->TAGvector
+      TAGvector->vector
+      vector->TAGvector
+      
+      ;; Generators
+      make-TAGvector-generator
+      
+      ;; Comparators
+      TAGvector-comparator
+
+      ;; Output
+      write-TAGvector))
+
+
+  ;; symbols-for-tag:
+  ;; Returns the symbols for one homogeneous vector tag.
+  ;; (It reads the 'symbols' list and changes TAG to the
+  ;;  actual tag name)
+  ;;
+  ;; (symbols-for-tag 's32)
+  ;; =>
+  ;;    (make-s32vector
+  ;;     s32vector
+  ;;     ...
+  ;;     s32vector-comparator
+  ;;     write-s32vector)
+  ;;
+  (define (symbols-for-tag symbol-tag)
+    (let ((tag (symbol->string symbol-tag)))
+      (let ((new-template (string-append "\\1" tag "\\2")))
+        (map string->symbol
+             (map (lambda (sym)
+                    (let ((template-name (symbol->string sym)))
+                      (regexp-replace "(.*)TAG(.*)" template-name new-template)))
+                  symbols)))))
+
+  ;; Just the 1-ary case of fold, that we need here...
+  (define (fold1 kons knil lis1)
+    (let lp ((lis lis1) (ans knil))
+      (if (null? lis) ans
+          (lp (cdr lis) (kons (car lis) ans)))))
+
+  (define tags '(s8 u8 s16 u16 s32 u32 s64 u64 f32 f64 c64 c128))
+
+  ;; all-symbols:
+  ;; Some basic map-reduce trick with append and --
+  ;; the magic is done! We have all the 684 symbols!
+  (define all-symbols
+    (fold1 append '() (map symbols-for-tag tags)))
+
+  
+  ;; HACK:
+  ;; This is the macro-expansion of 'export', which happens to not
+  ;; need to be a macro *in this case*. We get the list of symbols
+  ;; and export them, as the 'export' macro would itself:
+  (let ((s (%parse-exports all-symbols)))
+    (%do-exports (current-module) s)))
+
+(provide "srfi-160")

--- a/lib/srfi/160/Makefile.am
+++ b/lib/srfi/160/Makefile.am
@@ -1,0 +1,142 @@
+# Makefile for the SRFI 160
+#
+# Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+# Based on the SRFI Makefiles by Erick Gallesio.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
+#
+#           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+#    Creation date: 20-Jun-2022 09:24 (jpellegrini)
+# Last file update: 21-Jun-2022 08:47 (jpellegrini)
+
+#-======================================================================
+
+
+COMP ?= ../../../utils/tmpcomp
+STKLOS_BINARY ?= ../../../src/stklos
+STKLOS_FLAGS   = --no-init-file --case-sensitive
+SO = @SH_SUFFIX@
+
+# ORGANIZATION OF SRFI-160 IMPLEMENTATION:
+#
+# - base.c, base.stk: implementation of the base library,
+#   (srfi 160 base), where there's also much code that is
+#   used by the specific s8, u8, etc, libraries.
+#
+# - s8.stk, u8,stk, ..., c128.stk: the specific libraries
+#   (srfi 160 s8), and so on. They have thin wrappers over
+#   procedures defined in base.c
+#
+# - ../160.stk (in the directory above this one): the non-standard
+#   (srfi 160) library. It is useful for the tests.
+#
+# the s8.stk, etc files are generated (with sed) from the file
+# tagvector-template.stk.
+
+
+SRC_STK = base.stk \
+          tagvector-template.stk
+
+SRC_OSTK = base.ostk \
+           s8.ostk \
+           u8.ostk \
+           s16.ostk \
+           u16.ostk \
+           s32.ostk \
+           u32.ostk \
+           s64.ostk \
+           u64.ostk \
+           f32.ostk \
+           f64.ostk \
+           c64.ostk \
+           c128.ostk
+
+SRC_C     = base.c
+SRC_C_STK = base.stk
+SRC_SHOBJ = base.$(SO)
+
+srfi_OBJS = $(SRC_OSTK) $(SRC_SHOBJ)
+
+srfi_interm = s8.stk u8.stk s16.stk u16.stk \
+	      s32.stk u32.stk s64.stk u64.stk \
+	      f32.stk f64.stk c64.stk c128.stk
+
+
+DOCDB  = ../../DOCDB
+BASEDIR= ../../..
+SOURCES= $(SRC_C) $(SRC_STK) $(SRC_C_STK)
+
+
+#======================================================================
+srfidir       = $(prefix)/share/@PACKAGE@/@VERSION@/srfi/160
+srfilibdir    = $(prefix)/lib/@PACKAGE@/@VERSION@/srfi/160
+srfi_DATA     = $(SRC_OSTK)
+srfilib_DATA  = $(SRC_SHOBJ)
+srfi_sources  = $(SRC_STK)
+#======================================================================
+SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
+
+# The procedures defined are exactly the same for all data types,
+# only the type changes. So we generate them from a template.
+#
+# We use a multiple-target rule, which calls sed to change the
+# string "TAG" in the template into s8, u8, etc, writing it to
+# a new file "s8.stk", "u8.stk" etc.
+s8.stk  u8.stk  s16.stk u16.stk \
+s32.stk u32.stk s64.stk u64.stk \
+f32.stk f64.stk c64.stk c128.stk: tagvector-template.stk base.so
+	sed 's/TAG/$(basename $@)/g'   tagvector-template.stk > $@
+
+#======================================================================
+
+.stk.ostk:
+	$(COMP) -o $*.ostk $*.stk
+
+.stk-incl.c:
+	$(COMP) -C -o $*-incl.c $*.stk
+
+.c.$(SO) :
+	@CC@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
+	@SH_LOADER@ @SH_LOAD_FLAGS@  $*.$(SO) $*.o @DLLIBS@
+	@/bin/rm -f $*.o
+
+#======================================================================
+# Dependencies
+
+base.$(SO): base-incl.c base.c
+
+#======================================================================
+
+
+install-sources:
+	install $(srfi_sources) $(srfidir)
+
+# we also clean the TAG.stk files -- $(srfi-interm) --, which are NOT
+# srfi_OBJS (should not be installed with other objects):
+clean:
+	rm -f $(srfi_OBJS) *-incl.c *~ $(srfi_interm)
+
+distclean: clean
+	/bin/rm -f Makefile
+
+uninstall-hook:
+	(cd $(srfidir); rm -f $(srfi_sources))
+	rmdir $(srfidir) || true
+
+# no docs...
+# doc:
+# 	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
+# 		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)

--- a/lib/srfi/160/Makefile.in
+++ b/lib/srfi/160/Makefile.in
@@ -14,9 +14,10 @@
 
 @SET_MAKE@
 
-# Makefile for the R7RS SRFI standard libraries
+# Makefile for the SRFI 160
 #
-# Copyright © 2021-2022 Erick Gallesio - I3S-CNRS/ESSI <eg@unice.fr>
+# Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+# Based on the SRFI Makefiles by Erick Gallesio.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,9 +34,9 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
 # USA.
 #
-#           Author: Erick Gallesio [eg@unice.fr]
-#    Creation date:  8-Oct-2021 11:54 (eg)
-# Last file update:  8-Jun-2022 11:52 (eg)
+#           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+#    Creation date: 20-Jun-2022 09:24 (jpellegrini)
+# Last file update: 21-Jun-2022 08:47 (jpellegrini)
 
 #-======================================================================
 
@@ -113,7 +114,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-subdir = lib/srfi
+subdir = lib/srfi/160
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
@@ -136,14 +137,6 @@ am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
 am__v_at_1 = 
 DIST_SOURCES =
-RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
-	ctags-recursive dvi-recursive html-recursive info-recursive \
-	install-data-recursive install-dvi-recursive \
-	install-exec-recursive install-html-recursive \
-	install-info-recursive install-pdf-recursive \
-	install-ps-recursive install-recursive installcheck-recursive \
-	installdirs-recursive pdf-recursive ps-recursive \
-	tags-recursive uninstall-recursive
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -178,14 +171,6 @@ am__uninstall_files_from_dir = { \
   }
 am__installdirs = "$(DESTDIR)$(srfidir)" "$(DESTDIR)$(srfilibdir)"
 DATA = $(srfi_DATA) $(srfilib_DATA)
-RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
-  distclean-recursive maintainer-clean-recursive
-am__recursive_targets = \
-  $(RECURSIVE_TARGETS) \
-  $(RECURSIVE_CLEAN_TARGETS) \
-  $(am__extra_recursive_targets)
-AM_RECURSIVE_TARGETS = $(am__recursive_targets:-recursive=) TAGS CTAGS \
-	distdir distdir-am
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
 # and print each of them once, without duplicates.  Input order is
@@ -203,34 +188,8 @@ am__define_uniq_tagged_files = \
   unique=`for i in $$list; do \
     if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
   done | $(am__uniquify_input)`
-DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
-am__relativize = \
-  dir0=`pwd`; \
-  sed_first='s,^\([^/]*\)/.*$$,\1,'; \
-  sed_rest='s,^[^/]*/*,,'; \
-  sed_last='s,^.*/\([^/]*\)$$,\1,'; \
-  sed_butlast='s,/*[^/]*$$,,'; \
-  while test -n "$$dir1"; do \
-    first=`echo "$$dir1" | sed -e "$$sed_first"`; \
-    if test "$$first" != "."; then \
-      if test "$$first" = ".."; then \
-        dir2=`echo "$$dir0" | sed -e "$$sed_last"`/"$$dir2"; \
-        dir0=`echo "$$dir0" | sed -e "$$sed_butlast"`; \
-      else \
-        first2=`echo "$$dir2" | sed -e "$$sed_first"`; \
-        if test "$$first2" = "$$first"; then \
-          dir2=`echo "$$dir2" | sed -e "$$sed_rest"`; \
-        else \
-          dir2="../$$dir2"; \
-        fi; \
-        dir0="$$dir0"/"$$first"; \
-      fi; \
-    fi; \
-    dir1=`echo "$$dir1" | sed -e "$$sed_rest"`; \
-  done; \
-  reldir="$$dir2"
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@
 AMTAR = @AMTAR@
@@ -381,244 +340,62 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-
-# We have SUBDIRS_SRFIS and SUBDIRS.
-#
-# SUBDIRS_SRFIS must *not* include the current directory,
-# otherwise the clean target enters an infinite loop.
-# But SUBDIRS *does* need to include the current directory.
-# We can control the build order in the SUBDIRS variable.
-#
-# NOTE: 160.ostk needs the sublibraries to be built first.
-#
-SUBDIRS_SRFIS = 160
-# Build this directory before others:
-SUBDIRS = $(SUBDIRS_SRFIS) .
 STKLOS_FLAGS = --no-init-file --case-sensitive
 SO = @SH_SUFFIX@
 
+# ORGANIZATION OF SRFI-160 IMPLEMENTATION:
 #
-# SRFI written in Scheme
+# - base.c, base.stk: implementation of the base library,
+#   (srfi 160 base), where there's also much code that is
+#   used by the specific s8, u8, etc, libraries.
 #
-SRC_STK = 1.stk   \
-            2.stk   \
-            4.stk   \
-            5.stk   \
-            6.stk   \
-            7.stk   \
-            8.stk   \
-            9.stk   \
-            10.stk  \
-            11.stk  \
-            13.stk  \
-            14.stk  \
-            15.stk  \
-            16.stk  \
-            17.stk  \
-            18.stk  \
-            22.stk  \
-            23.stk  \
-            26.stk  \
-            28.stk  \
-            29.stk  \
-            31.stk  \
-            34.stk  \
-            35.stk  \
-            36.stk  \
-            37.stk  \
-            38.stk  \
-            39.stk  \
-            41.stk  \
-            45.stk  \
-            48.stk  \
-            51.stk  \
-            54.stk  \
-            55.stk  \
-            59.stk  \
-            60.stk  \
-            61.stk  \
-            62.stk  \
-            64.stk  \
-            66.stk  \
-            69.stk  \
-            70.stk  \
-            74.stk  \
-            87.stk  \
-            88.stk  \
-            89.stk  \
-            94.stk  \
-            95.stk  \
-            96.stk  \
-            100.stk \
-            111.stk \
-            113.stk \
-            117.stk \
-            118.stk \
-            127.stk \
-            128.stk \
-            129.stk \
-            130.stk \
-            134.stk \
-            135.stk \
-            137.stk \
-            141.stk \
-            143.stk \
-            151.stk \
-            152.stk \
-            154.stk \
-            156.stk \
-            158.stk \
-            160.stk \
-            161.stk \
-            169.stk \
-            171.stk \
-            173.stk \
-            174.stk \
-            176.stk \
-            180.stk \
-            185.stk \
-            189.stk \
-            190.stk \
-            193.stk \
-            195.stk \
-            196.stk \
-            207.stk \
-            208.stk \
-            214.stk \
-            215.stk \
-            216.stk \
-            217.stk \
-            219.stk \
-            221.stk \
-            223.stk \
-            224.stk \
-            229.stk \
-            230.stk
+# - s8.stk, u8,stk, ..., c128.stk: the specific libraries
+#   (srfi 160 s8), and so on. They have thin wrappers over
+#   procedures defined in base.c
+#
+# - ../160.stk (in the directory above this one): the non-standard
+#   (srfi 160) library. It is useful for the tests.
+#
+# the s8.stk, etc files are generated (with sed) from the file
+# tagvector-template.stk.
+SRC_STK = base.stk \
+          tagvector-template.stk
 
-SRC_OSTK = 1.ostk   \
-            2.ostk   \
-            4.ostk   \
-            5.ostk   \
-            6.ostk   \
-            7.ostk   \
-            8.ostk   \
-            9.ostk   \
-            10.ostk  \
-            11.ostk  \
-            13.ostk  \
-            14.ostk  \
-            15.ostk  \
-            16.ostk  \
-            17.ostk  \
-            18.ostk  \
-            22.ostk  \
-            23.ostk  \
-            26.ostk  \
-            28.ostk  \
-            29.ostk  \
-            31.ostk  \
-            34.ostk  \
-            35.ostk  \
-            36.ostk  \
-            37.ostk  \
-            38.ostk  \
-            39.ostk  \
-            41.ostk  \
-            45.ostk  \
-            48.ostk  \
-            51.ostk  \
-            54.ostk  \
-            55.ostk  \
-            59.ostk  \
-            60.ostk  \
-            61.ostk  \
-            62.ostk  \
-            64.ostk  \
-            66.ostk  \
-            69.ostk  \
-            70.ostk  \
-            74.ostk  \
-            87.ostk  \
-            88.ostk  \
-            89.ostk  \
-            94.ostk  \
-            95.ostk  \
-            96.ostk  \
-            100.ostk \
-            111.ostk \
-            117.ostk \
-            118.ostk \
-            113.ostk \
-            127.ostk \
-            128.ostk \
-            129.ostk \
-            130.ostk \
-            134.ostk \
-            135.ostk \
-            137.ostk \
-            141.ostk \
-            143.ostk \
-            151.ostk \
-            152.ostk \
-            154.ostk \
-            156.ostk \
-            158.ostk \
-            160.ostk \
-            161.ostk \
-            169.ostk \
-            171.ostk \
-            173.ostk \
-            174.ostk \
-            176.ostk \
-            180.ostk \
-            185.ostk \
-            189.ostk \
-            190.ostk \
-            193.ostk \
-            195.ostk \
-            196.ostk \
-            207.ostk \
-            208.ostk \
-            214.ostk \
-            215.ostk \
-            216.ostk \
-            217.ostk \
-            219.ostk \
-            221.ostk \
-            223.ostk \
-            224.ostk \
-            229.ostk \
-            230.ostk
+SRC_OSTK = base.ostk \
+           s8.ostk \
+           u8.ostk \
+           s16.ostk \
+           u16.ostk \
+           s32.ostk \
+           u32.ostk \
+           s64.ostk \
+           u64.ostk \
+           f32.ostk \
+           f64.ostk \
+           c64.ostk \
+           c128.ostk
 
-
-#
-# SRFIs written in C and Scheme
-#
-SRC_C = 25.c     27.c     116.c     132.c     133.c      144.c      170.c      175.c
-SRC_C_STK = 25.stk   27.stk   116.stk   132.stk   133.stk    144.stk    170.stk    175.stk
-SRC_SHOBJ = 25.$(SO) 27.$(SO) 116.$(SO) 132.$(SO) 133.$(SO)  144.$(SO)  170.$(SO)  175.$(SO)
+SRC_C = base.c
+SRC_C_STK = base.stk
+SRC_SHOBJ = base.$(SO)
 srfi_OBJS = $(SRC_OSTK) $(SRC_SHOBJ)
-DOCDB = ../DOCDB
-BASEDIR = ../..
+srfi_interm = s8.stk u8.stk s16.stk u16.stk \
+	      s32.stk u32.stk s64.stk u64.stk \
+	      f32.stk f64.stk c64.stk c128.stk
+
+DOCDB = ../../DOCDB
+BASEDIR = ../../..
 SOURCES = $(SRC_C) $(SRC_STK) $(SRC_C_STK)
 
 #======================================================================
-srfidir = $(prefix)/share/@PACKAGE@/@VERSION@/srfi
-srfilibdir = $(prefix)/lib/@PACKAGE@/@VERSION@/srfi
+srfidir = $(prefix)/share/@PACKAGE@/@VERSION@/srfi/160
+srfilibdir = $(prefix)/lib/@PACKAGE@/@VERSION@/srfi/160
 srfi_DATA = $(SRC_OSTK)
 srfilib_DATA = $(SRC_SHOBJ)
 srfi_sources = $(SRC_STK)
 #======================================================================
 SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
-
-#======================================================================
-# CLEAN
-#
-# SUBDIRS_SRFIS is the list of subdirectories, *excluding* this
-# one (so we don't enter an infinite loop).
-SUBCLEAN = $(addsuffix .clean,$(SUBDIRS_SRFIS) )
-SUBDISTCLEAN = $(addsuffix .distclean,$(SUBDIRS_SRFIS) )
-all: all-recursive
+all: all-am
 
 .SUFFIXES:
 .SUFFIXES: .stk .ostk .stk -incl.c .$(SO) .c
@@ -631,9 +408,9 @@ $(srcdir)/Makefile.in:  $(srcdir)/Makefile.am  $(am__configure_deps)
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu lib/srfi/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu lib/srfi/160/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu lib/srfi/Makefile
+	  $(AUTOMAKE) --gnu lib/srfi/160/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \
@@ -694,61 +471,14 @@ uninstall-srfilibDATA:
 	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
 	dir='$(DESTDIR)$(srfilibdir)'; $(am__uninstall_files_from_dir)
 
-# This directory's subdirectories are mostly independent; you can cd
-# into them and run 'make' without going through this Makefile.
-# To change the values of 'make' variables: instead of editing Makefiles,
-# (1) if the variable is set in 'config.status', edit 'config.status'
-#     (which will cause the Makefiles to be regenerated when you run 'make');
-# (2) otherwise, pass the desired values on the 'make' command line.
-$(am__recursive_targets):
-	@fail=; \
-	if $(am__make_keepgoing); then \
-	  failcom='fail=yes'; \
-	else \
-	  failcom='exit 1'; \
-	fi; \
-	dot_seen=no; \
-	target=`echo $@ | sed s/-recursive//`; \
-	case "$@" in \
-	  distclean-* | maintainer-clean-*) list='$(DIST_SUBDIRS)' ;; \
-	  *) list='$(SUBDIRS)' ;; \
-	esac; \
-	for subdir in $$list; do \
-	  echo "Making $$target in $$subdir"; \
-	  if test "$$subdir" = "."; then \
-	    dot_seen=yes; \
-	    local_target="$$target-am"; \
-	  else \
-	    local_target="$$target"; \
-	  fi; \
-	  ($(am__cd) $$subdir && $(MAKE) $(AM_MAKEFLAGS) $$local_target) \
-	  || eval $$failcom; \
-	done; \
-	if test "$$dot_seen" = "no"; then \
-	  $(MAKE) $(AM_MAKEFLAGS) "$$target-am" || exit 1; \
-	fi; test -z "$$fail"
-
 ID: $(am__tagged_files)
 	$(am__define_uniq_tagged_files); mkid -fID $$unique
-tags: tags-recursive
+tags: tags-am
 TAGS: tags
 
 tags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
 	set x; \
 	here=`pwd`; \
-	if ($(ETAGS) --etags-include --version) >/dev/null 2>&1; then \
-	  include_option=--etags-include; \
-	  empty_fix=.; \
-	else \
-	  include_option=--include; \
-	  empty_fix=; \
-	fi; \
-	list='$(SUBDIRS)'; for subdir in $$list; do \
-	  if test "$$subdir" = .; then :; else \
-	    test ! -f $$subdir/TAGS || \
-	      set "$$@" "$$include_option=$$here/$$subdir/TAGS"; \
-	  fi; \
-	done; \
 	$(am__define_uniq_tagged_files); \
 	shift; \
 	if test -z "$(ETAGS_ARGS)$$*$$unique"; then :; else \
@@ -761,7 +491,7 @@ tags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
 	      $$unique; \
 	  fi; \
 	fi
-ctags: ctags-recursive
+ctags: ctags-am
 
 CTAGS: ctags
 ctags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
@@ -774,7 +504,7 @@ GTAGS:
 	here=`$(am__cd) $(top_builddir) && pwd` \
 	  && $(am__cd) $(top_srcdir) \
 	  && gtags -i $(GTAGS_ARGS) "$$here"
-cscopelist: cscopelist-recursive
+cscopelist: cscopelist-am
 
 cscopelist-am: $(am__tagged_files)
 	list='$(am__tagged_files)'; \
@@ -825,48 +555,22 @@ distdir-am: $(DISTFILES)
 	    || exit 1; \
 	  fi; \
 	done
-	@list='$(DIST_SUBDIRS)'; for subdir in $$list; do \
-	  if test "$$subdir" = .; then :; else \
-	    $(am__make_dryrun) \
-	      || test -d "$(distdir)/$$subdir" \
-	      || $(MKDIR_P) "$(distdir)/$$subdir" \
-	      || exit 1; \
-	    dir1=$$subdir; dir2="$(distdir)/$$subdir"; \
-	    $(am__relativize); \
-	    new_distdir=$$reldir; \
-	    dir1=$$subdir; dir2="$(top_distdir)"; \
-	    $(am__relativize); \
-	    new_top_distdir=$$reldir; \
-	    echo " (cd $$subdir && $(MAKE) $(AM_MAKEFLAGS) top_distdir="$$new_top_distdir" distdir="$$new_distdir" \\"; \
-	    echo "     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)"; \
-	    ($(am__cd) $$subdir && \
-	      $(MAKE) $(AM_MAKEFLAGS) \
-	        top_distdir="$$new_top_distdir" \
-	        distdir="$$new_distdir" \
-		am__remove_distdir=: \
-		am__skip_length_check=: \
-		am__skip_mode_fix=: \
-	        distdir) \
-	      || exit 1; \
-	  fi; \
-	done
 check-am: all-am
-check: check-recursive
+check: check-am
 all-am: Makefile $(DATA)
-installdirs: installdirs-recursive
-installdirs-am:
+installdirs:
 	for dir in "$(DESTDIR)$(srfidir)" "$(DESTDIR)$(srfilibdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
-install: install-recursive
-install-exec: install-exec-recursive
-install-data: install-data-recursive
-uninstall: uninstall-recursive
+install: install-am
+install-exec: install-exec-am
+install-data: install-data-am
+uninstall: uninstall-am
 
 install-am: all-am
 	@$(MAKE) $(AM_MAKEFLAGS) install-exec-am install-data-am
 
-installcheck: installcheck-recursive
+installcheck: installcheck-am
 install-strip:
 	if test -z '$(STRIP)'; then \
 	  $(MAKE) $(AM_MAKEFLAGS) INSTALL_PROGRAM="$(INSTALL_STRIP_PROGRAM)" \
@@ -892,86 +596,98 @@ clean-am: clean-generic mostlyclean-am
 
 distclean-am: clean-am distclean-generic distclean-tags
 
-dvi: dvi-recursive
+dvi: dvi-am
 
 dvi-am:
 
-html: html-recursive
+html: html-am
 
 html-am:
 
-info: info-recursive
+info: info-am
 
 info-am:
 
 install-data-am: install-srfiDATA install-srfilibDATA
 
-install-dvi: install-dvi-recursive
+install-dvi: install-dvi-am
 
 install-dvi-am:
 
 install-exec-am:
 
-install-html: install-html-recursive
+install-html: install-html-am
 
 install-html-am:
 
-install-info: install-info-recursive
+install-info: install-info-am
 
 install-info-am:
 
 install-man:
 
-install-pdf: install-pdf-recursive
+install-pdf: install-pdf-am
 
 install-pdf-am:
 
-install-ps: install-ps-recursive
+install-ps: install-ps-am
 
 install-ps-am:
 
 installcheck-am:
 
-maintainer-clean: maintainer-clean-recursive
+maintainer-clean: maintainer-clean-am
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 
-mostlyclean: mostlyclean-recursive
+mostlyclean: mostlyclean-am
 
 mostlyclean-am: mostlyclean-generic
 
-pdf: pdf-recursive
+pdf: pdf-am
 
 pdf-am:
 
-ps: ps-recursive
+ps: ps-am
 
 ps-am:
 
 uninstall-am: uninstall-srfiDATA uninstall-srfilibDATA
 	@$(NORMAL_INSTALL)
 	$(MAKE) $(AM_MAKEFLAGS) uninstall-hook
-.MAKE: $(am__recursive_targets) install-am install-strip uninstall-am
+.MAKE: install-am install-strip uninstall-am
 
-.PHONY: $(am__recursive_targets) CTAGS GTAGS TAGS all all-am check \
-	check-am clean clean-generic cscopelist-am ctags ctags-am \
-	distclean distclean-generic distclean-tags distdir dvi dvi-am \
-	html html-am info info-am install install-am install-data \
-	install-data-am install-dvi install-dvi-am install-exec \
-	install-exec-am install-html install-html-am install-info \
-	install-info-am install-man install-pdf install-pdf-am \
-	install-ps install-ps-am install-srfiDATA install-srfilibDATA \
-	install-strip installcheck installcheck-am installdirs \
-	installdirs-am maintainer-clean maintainer-clean-generic \
-	mostlyclean mostlyclean-generic pdf pdf-am ps ps-am tags \
-	tags-am uninstall uninstall-am uninstall-hook \
-	uninstall-srfiDATA uninstall-srfilibDATA
+.PHONY: CTAGS GTAGS TAGS all all-am check check-am clean clean-generic \
+	cscopelist-am ctags ctags-am distclean distclean-generic \
+	distclean-tags distdir dvi dvi-am html html-am info info-am \
+	install install-am install-data install-data-am install-dvi \
+	install-dvi-am install-exec install-exec-am install-html \
+	install-html-am install-info install-info-am install-man \
+	install-pdf install-pdf-am install-ps install-ps-am \
+	install-srfiDATA install-srfilibDATA install-strip \
+	installcheck installcheck-am installdirs maintainer-clean \
+	maintainer-clean-generic mostlyclean mostlyclean-generic pdf \
+	pdf-am ps ps-am tags tags-am uninstall uninstall-am \
+	uninstall-hook uninstall-srfiDATA uninstall-srfilibDATA
 
 .PRECIOUS: Makefile
 
 
-COMP ?= ../../utils/tmpcomp
-STKLOS_BINARY ?= ../../src/stklos
+COMP ?= ../../../utils/tmpcomp
+STKLOS_BINARY ?= ../../../src/stklos
+
+# The procedures defined are exactly the same for all data types,
+# only the type changes. So we generate them from a template.
+#
+# We use a multiple-target rule, which calls sed to change the
+# string "TAG" in the template into s8, u8, etc, writing it to
+# a new file "s8.stk", "u8.stk" etc.
+s8.stk  u8.stk  s16.stk u16.stk \
+s32.stk u32.stk s64.stk u64.stk \
+f32.stk f64.stk c64.stk c128.stk: tagvector-template.stk base.so
+	sed 's/TAG/$(basename $@)/g'   tagvector-template.stk > $@
+
+#======================================================================
 
 .stk.ostk:
 	$(COMP) -o $*.ostk $*.stk
@@ -980,78 +696,36 @@ STKLOS_BINARY ?= ../../src/stklos
 	$(COMP) -C -o $*-incl.c $*.stk
 
 .c.$(SO) :
-	@CC@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
+	@CC@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@  $*.$(SO) $*.o @DLLIBS@
 	@/bin/rm -f $*.o
 
 #======================================================================
 # Dependencies
-DEPEND_1:  51.ostk 134.ostk 171.ostk 189.ostk 196.ostk 207.ostk
-DEPEND_9:  37.ostk  64.ostk 113.ostk 117.ostk 128.ostk 134.ostk 135.ostk 154.ostk \
-	      161.ostk 171.ostk 173.ostk 180.ostk 189.ostk 196.ostk 207.ostk 230.ostk
 
-$(DEPEND_1): 1.ostk
-$(DEPEND_9): 9.ostk
-13.ostk: 14.ostk
-37.ostk: 13.ostk
-41.ostk: ../streams/primitive.ostk ../streams/derived.ostk
-74.ostk: 4.ostk 26.ostk 60.ostk 66.ostk
-94.ostk: 60.ostk
-95.ostk:  132.ostk 132.$(SO)
-113.ostk: 128.ostk
-130.ostk: 13.ostk
-133.ostk: ../stklos/itrie.so
-134.ostk: 158.ostk
-135.ostk: 129.ostk
-152.ostk: 130.ostk
-160.ostk: 160
-190.ostk: 158.ostk
-216.ostk: 27.$(SO)
-217.ostk: ../stklos/itrie.so
-221.ostk: 41.ostk 158.ostk
-
-25.$(SO):  25-incl.c  25.c
-27.$(SO):  27-incl.c  27.c
-116.$(SO): 128.ostk 116-incl.c 116.c
-132.$(SO): 132-incl.c 132.c
-133.$(SO): 133-incl.c 133.c
-144.$(SO): 144-incl.c 144.c
-170.$(SO): 170-incl.c 170.c
-175.$(SO): 175-incl.c 175.c
+base.$(SO): base-incl.c base.c
 
 #======================================================================
 
 install-sources:
 	install $(srfi_sources) $(srfidir)
-.PHONY: clean distclean $(SUBCLEAN) $(SUBDISTCLEAN)
 
-### CLEAN
-# How to clean each subdir:
-$(SUBCLEAN): %.clean:
-	$(MAKE) -C $* clean
+# we also clean the TAG.stk files -- $(srfi-interm) --, which are NOT
+# srfi_OBJS (should not be installed with other objects):
+clean:
+	rm -f $(srfi_OBJS) *-incl.c *~ $(srfi_interm)
 
-# To clean this one, first clean the subdirs, then execute
-# our clean rule:
-clean: $(SUBCLEAN)
-	rm -f $(srfi_OBJS) *-incl.c *~
-
-### DISTCLEAN
-# How to clean each subdir:
-$(SUBDISTCLEAN): %.distclean:
-	$(MAKE) -C $* distclean
-
-distclean: $(SUBDISTCLEAN) clean
+distclean: clean
 	/bin/rm -f Makefile
-
-#======================================================================
 
 uninstall-hook:
 	(cd $(srfidir); rm -f $(srfi_sources))
 	rmdir $(srfidir) || true
 
-doc:
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
-		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
+# no docs...
+# doc:
+# 	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../../src/boot.img \
+# 		-f ../../doc/extract-doc $(SOURCES) >> $(DOCDB)
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/lib/srfi/160/base.c
+++ b/lib/srfi/160/base.c
@@ -115,7 +115,7 @@ void check_type(SCM v, int type) {
 
 static inline
 void check_procedure(SCM proc) {
-    if (! (STk_procedurep(proc) ))
+    if ( (STk_procedurep(proc) == STk_false ))
 	STk_error("bad procedure ~S", proc);
 }
 

--- a/lib/srfi/160/base.c
+++ b/lib/srfi/160/base.c
@@ -1,0 +1,1046 @@
+/*
+ * 160/base.c --  SRFI-160: Homogeneous numeric vector libraries
+ *                          (base sublibrary)
+ *
+ * Copyright © 2022 Jerônimo Pellegrini <j_p@aleph0.info>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ *
+ *           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+ *    Creation date: 17-Jun-2022 09:10
+ * Last file update: 20-Jun-2022 10:17 (jpellegrini)
+ */
+
+#include <float.h>
+#include <math.h>
+#include "stklos.h"
+#include "base-incl.c"
+
+/***
+    UTILITIES FOR SRFI-160
+ ***/
+
+#define UVECTOR_C64  10
+#define UVECTOR_C128 11
+
+extern SCM get_u64_max();
+extern SCM get_s64_min();
+extern SCM get_s64_max();
+extern SCM makeuvect(int type, int len, SCM init);
+extern int vector_element_size(int type);
+extern void uvector_set(int _UNUSED(type), SCM v, long i, SCM value);
+extern SCM uvector_ref(int _UNUSED(type), SCM v, long i);
+    
+EXTERN_PRIMITIVE("list?", listp, subr1, (SCM x));
+EXTERN_PRIMITIVE("length", list_length, subr1, (SCM l));
+
+/*
+ * We use exact->inexact to cast complex vectors in c64 and c128 types
+ * (possibly resultingin +inf.0 or -inf.0)
+ */
+EXTERN_PRIMITIVE("exact->inexact", ex2inex, subr1, (SCM z));
+
+/*
+ * We use nanp in the TAG? predicates.
+ */
+EXTERN_PRIMITIVE("nan?", nanp, subr1, (SCM z));
+
+static char *type_vector(int tip)
+{
+  switch (tip) {
+    case UVECT_S8:   return "s8";
+    case UVECT_U8:   return "u8";
+    case UVECT_S16:  return "s16";
+    case UVECT_U16:  return "u16";
+    case UVECT_S32:  return "s32";
+    case UVECT_U32:  return "u32";
+    case UVECT_S64:  return "s64";
+    case UVECT_U64:  return "u64";
+    case UVECT_F32:  return "f32";
+    case UVECT_F64:  return "f64";
+    case UVECT_C64:  return "c64";
+    case UVECT_C128: return "c128";
+    default:        return ""; /* never reached */
+  }
+}
+
+/*********************
+ * Arguments checking
+ *********************/
+
+static inline
+void check_argc(int argc, int n) {
+    if (argc !=n) STk_error("Exactly ~A arguments required, got ~A",
+			    MAKE_INT(n), MAKE_INT(argc));
+}
+
+static inline
+void check_int(SCM n) {
+    if (!INTP(n)) STk_error("bad integer ~S", n);
+}
+
+static inline
+void check_uvector(SCM v) {
+    if (!UVECTORP(v)) STk_error("bad uvector ~S", v);
+}
+
+
+static inline
+void check_indices(SCM v, long i) {
+    if (i < 0)               STk_error ("negative index ~A", MAKE_INT(i));
+    if (i > UVECTOR_SIZE(v)) STk_error ("index ~A out of bounds", MAKE_INT(i));
+}
+
+static inline
+void check_type(SCM v, int type) {
+    if (type < 0 || type > UVECT_C128)
+	STk_error("bad uvector type", MAKE_INT(type));
+    if(UVECTOR_TYPE(v) != type)
+	STk_error("expected ~Avector, got ~Avector",
+		  STk_Cstring2string(type_vector(type)),
+		  STk_Cstring2string(type_vector(UVECTOR_TYPE(v))));
+}
+
+static inline
+void check_procedure(SCM proc) {
+    if (! (STk_procedurep(proc) ))
+	STk_error("bad procedure ~S", proc);
+}
+
+static inline
+void check_boolean(SCM proc) {
+    if (! (BOOLEANP(proc) ))
+	STk_error("bad boolean ~S", proc);
+}
+
+
+/******************
+ * Other utilities
+ ******************/
+
+SCM
+resize_uvector(SCM w, long len, int stride) {
+    w = STk_must_realloc(w, sizeof(struct uvector_obj) + stride*len - 1);
+    UVECTOR_SIZE(w) = len;
+    return w;
+}
+
+/*********
+  UVECTOR_GET and UVECTOR_COPY - macros around memcpy.
+  
+  We use memcpy and not uvector_set+uvector-ref because
+  using uvector_set+uvector-ref is around 2.2x slower:
+
+  (define v (u64vector-unfold
+              (lambda (x y) (values x 0))
+              6000000
+              0))
+
+  (time (begin (u64vector-remove odd? v) #void))
+
+  This runs in around 600ms with memcpy, and 1400ms with
+  the C API.
+
+  Vector-fill! becomes even faster.
+*/
+
+#define UVECTOR_GET(dstaddr,v,i,stride) do{                       \
+    memcpy((dstaddr),&UVECTOR_DATA(v)[(i) * (stride)], (stride)); \
+    }while(0)
+
+#define UVECTOR_SET(v,i,srcaddr,stride) do{                        \
+    memcpy(&UVECTOR_DATA(v)[(i) * (stride)], (srcaddr), (stride)); \
+    }while(0)
+
+#define UVECTOR_COPY_ELT(to,i,from,j,stride) do{ \
+    memcpy(&UVECTOR_DATA(to)[(i) * (stride)],    \
+           &UVECTOR_DATA(from)[(j) * (stride)],  \
+           (stride));			         \
+    }while(0)
+
+
+/* This function does the copying work for %uvector-copy
+ * after the arguments are already checked and adjusted: */
+SCM
+STk_uvector_copy_contents(int type,
+			  SCM to, long to_start, long to_end,
+			  SCM from, long from_start, long from_end,
+			  SCM reverse, long stride) {
+    if (to == from &&
+	(from_end >= to_start ||
+	 to_end <= from_start ||
+	 (from_end == to_end && from_start == to_start))) {
+	/* THE CHUNKS OVERLAP *_AND_* the SRFI spec requires us to
+	   do as if we had copied the vector before proceeding, so...
+	   We do copy it! (Calling -copy! or -reverse-copy! with
+	   overlapping chunks shouldn't be common, and not good
+	   practice in my opinion, so even if there is some small
+	   room for improvement, let's do the simpler thing here. */
+	SCM new = makeuvect(type, from_end - from_start, NULL);
+	memcpy(UVECTOR_DATA(new),
+	       &UVECTOR_DATA(from)[from_start * stride],
+	       stride * UVECTOR_SIZE(new));
+	return STk_uvector_copy_contents(type,
+					 to, to_start, to_end,
+					 new, 0, UVECTOR_SIZE(new),
+					 reverse, stride);
+    }
+    
+    if (reverse == STk_true) {
+	from_end -= 1;
+	while (from_end >= from_start) {
+	    memcpy(&UVECTOR_DATA(to)[to_start * stride],
+		   &UVECTOR_DATA(from)[from_end * stride],
+		   stride);
+	    to_start += 1;
+	    from_end -= 1;
+	}
+    } else {
+	memcpy(&UVECTOR_DATA(to)[to_start * stride],
+	       &UVECTOR_DATA(from)[from_start * stride],
+	       stride * (from_end - from_start));
+    }
+    return to;
+}
+
+/**********************************
+ *
+ * SCHEME-VISIBLE PRIMITIVES
+ *
+ **********************************/
+
+/*
+ * %uvector-copy is a versatile procedure that can do different things
+ * while copying uvector chunks:
+ *
+ *  (%uvector-copy type
+ *                 to at
+ *                 from s e
+ *                 reverse)
+ *
+ * Basically, copies the elements of the UVECTOR `from` with indices
+ *  s <= idx < e.
+ *
+ * - `type` is the uvector type
+ * - If `reverse` is #t, the elements are copied in reverse order
+ * - If `to` is NOT a uvector, then a new uvector is allocator
+ * - If `to` IS a uvector, then the elements are copied into it,
+ *   beginning at index `at`
+ * - Care is taken to not overwrite the uvector itself when copying,
+ *   as per the comment in SRFI 133's 'vector-reverse-copy!' (the
+ *   procedures of SRFI 133 are mentioned in SRFI 160, and we're
+ *   supposed to mimic their behavior).
+ *
+ * This is used to implement:
+ * - vector-take
+ * - vector-copy
+ * - vector-reverse-copy
+ * - vector-copy!
+ * - vector-reverse-copy!
+ */
+DEFINE_PRIMITIVE("%uvector-copy", srfi_160_uvector_copy, vsubr, (int argc, SCM *argv))
+{
+    check_argc(argc, 7);
+    SCM type    = *argv--;
+    SCM to      = *argv--;
+    SCM at      = *argv--;
+    SCM from    = *argv--;
+    SCM s       = *argv--;
+    SCM e       = *argv--;
+    SCM reverse = *argv--;
+
+    /* Basic argument checking: */
+
+    check_int(type);
+    check_uvector(from);
+    check_int(s);
+    check_int(e);
+    check_indices(from,INT_VAL(s));
+    check_type(from,INT_VAL(type));
+
+    /* Get correct bounds and stride: */
+    
+    long from_start = INT_VAL(s);
+    long from_end   = INT_VAL(e);
+
+    if (from_end < from_start)
+	STk_error("end index ~A is smaller than start index ~A", s, e);
+    
+    long to_start = 0;
+    long to_end   = 0;  /* Won't be used*/
+    
+    long stride = vector_element_size(UVECTOR_TYPE(from));
+
+
+    /* Check if we have a destinatio to mutate, then do some more bounds
+       computation and argument checking: */
+    if (UVECTORP(to)) {
+
+	check_int(at);
+	check_indices(to,INT_VAL(at));
+
+	to_start = INT_VAL(at);
+	to_end   = INT_VAL(at) + (from_end - from_start);
+
+	check_type(to, INT_VAL(type));
+	
+	if( (UVECTOR_SIZE(to) - INT_VAL(at)) < (from_end - from_start) )
+	    STk_error("target vector not large enough for specified chunk: need ~A cells, ~A available",
+		      UVECTOR_SIZE(to) - INT_VAL(at),
+		      from_end - from_start);
+    }
+    else
+	to = makeuvect(INT_VAL(type), from_end - from_start, NULL);
+
+    /* Do the real work! */
+    return STk_uvector_copy_contents(INT_VAL(type),
+				     to, to_start, to_end,
+				     from, from_start, from_end,
+				     reverse, stride);
+}
+
+
+/*
+ * %uvector-unfold is the basic unfolding procedure for uvectors.
+ * Its arguments are:
+ *
+ * - type (the uvector type)
+ * - vec (the uvector)
+ * - f (the function used to generate values)
+ * - end (either end in unfold! or the length of the uvector to be created
+ *        in unfold).
+ * - seed, (similar to knil in unfold)
+ * - right (boolean: #t if unfolding is to be done from right to left) 
+ */
+DEFINE_PRIMITIVE("%uvector-unfold", uvector_unfold, vsubr, (int argc, SCM *argv))
+{
+    if (argc < 6 || argc > 7)
+	STk_error("wrong number of arguments ~A", argc);
+    SCM sstart = MAKE_INT(0);
+    
+    SCM type = *argv--;
+    SCM f = *argv--;
+    SCM vec = *argv--;
+    if (argc == 7) { sstart =  *argv--; check_int(sstart); }
+    SCM eend = *argv--;
+    SCM seed = *argv--;
+    SCM right = *argv--;
+
+    check_int(type);
+    check_int(eend);
+    check_procedure(f);
+    
+    long start = INT_VAL(sstart);
+    long end   = INT_VAL(eend);
+
+    SCM to = (UVECTORP(vec))
+	? vec
+	: makeuvect(INT_VAL(type), end, NULL);
+
+    /* the srfi says that f will return two VALUES, so we need a vector to
+       hold them... */
+    SCM res = STk_makevect(2, NULL);
+
+    long idx, step;
+    if (right == STk_true) {
+	idx = end-1;
+	step  = -1;
+    } else {
+	idx = start;
+	step  = +1;
+    }
+	
+    for (long i = 0;
+	 i < end - start;
+	 i++, idx += step) {
+	/* FIXME: we mark both values as #f, so we can tell if the procedure
+                  really returned at least two values (if we use NULL, then
+		  STklos would crash).
+
+	   HOWEVER:
+           ========
+
+	   1. if the procedure doesn't return two values, we'll get
+              a not useful error:
+	   
+              stklos> (c128vector-unfold (lambda (x y) 1-1i) 3 0.0+0.0i)
+              **** Error:
+              %uvector-unfold: bad vector `#(#f #f)'
+
+	   2. An error is also signaled if there are too many values.
+	      (Although Chicken, Gauche and Sagittarius also do this)
+	*/
+	VECTOR_DATA(res)[0] = STk_false;
+	VECTOR_DATA(res)[1] = STk_false;
+	STk_values2vector ( STk_C_apply(f,2,MAKE_INT(idx),seed),
+			    res );
+	uvector_set(INT_VAL(type), to, idx, VECTOR_DATA(res)[0]);
+	seed = VECTOR_DATA(res)[1];
+    }
+    return to;
+}
+
+
+/*
+ * %uvector-append-subvectors implements concatenate, append and
+ * append-subvectors for uvectors.
+ *
+ * - t (the uvector type)
+ * - bounds (#t for the -subvectors variant, where the bounds are intercalated
+ *   with the vectors, and #f when the list only contains uvectors)
+ * - vecs (the list of vectors)
+ *
+ * All three procedures are easily implemented:
+ * (define (u64vector-append . vecs)
+ *   (%uvector-append-subvectors 7 #f vecs))
+ *
+ * (define (u64vector-concatenate vecs)
+ *   (%uvector-append-subvectors 7 #f vecs))
+ *
+ * (define (u64vector-append-subvectors . vecs)
+ *   (%uvector-append-subvectors 7 #t vecs))
+ *
+ */
+DEFINE_PRIMITIVE("%uvector-append-subvectors", uvector_append_subs, subr3, (SCM t, SCM bounds, SCM vecs))
+{
+    check_int(t);
+    int type = INT_VAL(t);
+    check_boolean(bounds);
+    if (NULLP(vecs))       return makeuvect(type, 0, NULL);
+    if (!CONSP(vecs))      STk_error("bad list ~S", vecs);
+
+    /* Get the total size AND check types before we begin.
+       We can't go operating yet, since we need to know the
+       final vector size to allocate. */
+    if (bounds == STk_true) {
+	int l = STk_int_length(vecs);
+	if (l % 3)
+	    STk_error ("vector list of wrong length ~A (should be multiple of three, [ vec, start, end ] for each", l);
+    }
+    SCM ptr = vecs;
+    SCM v;
+    SCM ss, ee;
+    long s, e;
+    long len = 0;
+    while (ptr != STk_nil) {
+	v = CAR(ptr);
+	check_type(v,type);
+	if (bounds == STk_true) {
+	    ss = CAR(CDR(ptr));
+	    ee = CAR(CDR(CDR(ptr)));
+	    check_int(ss);
+	    check_int(ee);
+	    s = INT_VAL(ss);
+	    e = INT_VAL(ee);
+	    check_indices(v, s);
+	    check_indices(v, e);
+	    /* No problem if e < s */
+	} else {
+	    s = 0;
+	    e = UVECTOR_SIZE(v);
+	}
+	len += e - s;
+	ptr = CDR(ptr);
+	if (bounds == STk_true) ptr = CDR(CDR(ptr));
+    }
+
+    /* allocate the new vector */
+    SCM res = makeuvect(type, len, NULL);
+    SCM from;
+    long to_start = 0;
+    long to_end, from_start, from_end;
+    long stride = vector_element_size(type);
+
+    /* copy each chunk */
+    for (; vecs != STk_nil ; vecs = CDR(vecs)) {
+	from = CAR(vecs);
+	if (bounds == STk_true) {
+	    from_start = INT_VAL(CAR(CDR(vecs)));
+	    from_end   = INT_VAL(CAR(CDR(CDR(vecs))));
+	} else {
+	    from_start = 0;
+	    from_end   = UVECTOR_SIZE(from);
+	}
+	to_end = to_start + (from_end - from_start);
+	STk_uvector_copy_contents(type,
+				  res, to_start,  to_end,
+				  from, from_start, from_end,
+				  STk_false, stride);
+	to_start = to_end;
+	if (bounds == STk_true) vecs = CDR(CDR(vecs));
+    }
+    return res;
+}
+
+/*
+ * PREDICATES
+ */
+
+DEFINE_PRIMITIVE("s8?", s8p, subr1, (SCM x))
+{
+    long v = STk_integer_value(x);
+    return MAKE_BOOLEAN (-128 <= v && v < +128);
+}
+
+DEFINE_PRIMITIVE("u8?", u8p, subr1, (SCM x))
+{
+    long v = STk_integer_value(x);
+    return MAKE_BOOLEAN (0 <= v && v < +256);
+}
+
+DEFINE_PRIMITIVE("s16?", s16p, subr1, (SCM x))
+{
+    long v = STk_integer_value(x);
+    return MAKE_BOOLEAN (-32768 <= v && v < +32768);
+}
+
+DEFINE_PRIMITIVE("u16?", u16p, subr1, (SCM x))
+{
+    long v = STk_integer_value(x);
+    return MAKE_BOOLEAN (0 <= v && v < +65536);
+}
+
+DEFINE_PRIMITIVE("s32?", s32p, subr1, (SCM x))
+{
+    int overflow;
+    STk_integer2int32(x, &overflow);
+    return MAKE_BOOLEAN (!overflow);
+}
+
+DEFINE_PRIMITIVE("u32?", u32p, subr1, (SCM x))
+{
+    int overflow;
+    STk_integer2uint32(x, &overflow);
+    return MAKE_BOOLEAN (!overflow);
+}
+
+DEFINE_PRIMITIVE("s64?", s64p, subr1, (SCM x))
+{
+    return MAKE_BOOLEAN ( (INTP(x) || BIGNUMP(x)) &&
+			  (STk_numle2(get_s64_min(), x) && STk_numle2(x, get_s64_max())) );
+}
+
+DEFINE_PRIMITIVE("u64?", u64p, subr1, (SCM x))
+{
+    return MAKE_BOOLEAN ( (INTP(x) || BIGNUMP(x)) &&
+			  (STk_numle2(MAKE_INT(0), x) && STk_numle2(x, get_u64_max())) );
+}
+
+DEFINE_PRIMITIVE("f32?", f32p, subr1, (SCM x))
+{
+    if (REALP(x) &&                      /* MUST be inexact */
+	( (REAL_VAL(x) >= -FLT_MAX &&
+	   REAL_VAL(x) <= +FLT_MAX) ||   /* 1. within bounds, OR */
+	  STk_nanp(x) ||                 /* 2. NaN, OR */ 
+	  !isfinite(REAL_VAL(x)) ))      /* 3. infinite */
+	return STk_true;
+    
+    return STk_false;
+}
+
+DEFINE_PRIMITIVE("f64?", f64p, subr1, (SCM x))
+{
+    return MAKE_BOOLEAN(REALP(x));
+}
+
+DEFINE_PRIMITIVE("c64?", c64p, subr1, (SCM x))
+{
+    if ( (STk_f32p(x) == STk_true) ||
+	 ( COMPLEXP(x) &&
+	   STk_f32p(COMPLEX_REAL(x)) == STk_true &&
+	   STk_f32p(COMPLEX_IMAG(x)) == STk_true))
+	return STk_true;
+
+    return STk_false;
+}
+
+DEFINE_PRIMITIVE("c128?", c128p, subr1, (SCM x))
+{
+    if ( (STk_f64p(x) == STk_true) ||
+	 ( COMPLEXP(x) &&
+	   STk_f64p(COMPLEX_REAL(x)) == STk_true &&
+	   STk_f64p(COMPLEX_IMAG(x)) == STk_true))
+	return STk_true;
+
+    return STk_false;
+}
+
+DEFINE_PRIMITIVE("%uvector-empty?", uvector_emptyp, subr2,
+		 (SCM tip, SCM vec))
+{
+    check_uvector(vec);
+    check_type(vec, INT_VAL(tip));
+    return MAKE_BOOLEAN(UVECTOR_SIZE(vec) == 0);
+}
+
+DEFINE_PRIMITIVE("%uvector=", u_vector_equal, subr2, (SCM t, SCM vecs))
+{
+    check_int(t);
+    int type = INT_VAL(t);
+    if (NULLP(vecs)) return STk_true;
+    if (!STk_listp(vecs))
+	STk_error("bad uvector list ~S", vecs);
+	
+    SCM vec2;
+    SCM vec1 = CAR(vecs);
+    check_uvector(vec1);
+    check_type(vec1, type);
+    vecs = CDR(vecs);
+    while (vecs != STk_nil) {
+	vec2 = CAR(vecs);
+	check_uvector(vec2);
+	check_type(vec2,type);
+	if (UVECTOR_SIZE(vec2) != UVECTOR_SIZE(vec1))
+	    return STk_false;
+	if (!STk_uvector_equal(vec1, vec2))
+	    return STk_false;
+	vec1 = vec2;
+	vecs = CDR(vecs);
+    }
+    return STk_true;
+}
+
+/***
+ * SUPER-ITERATOR:
+ *
+ * %uvector-iterate.
+ *
+ * A single function that implements map, for-each, take, drop, fold, and more...
+ * Since this function does a Scheme procedure call in each iteration, the impact
+ * of having a " switch (operation) { "  at each operation too isn't large.
+ * And it's worth it, since there are some interesting mechanism that would
+ * be duplicated otherwise (the reversing of traversal for the -right procedures,
+ * the application of proc etc).
+ *
+ * IMPORTANT: The operation tag is passed as first argument. See the #defines below,
+ * =========  and also the code in the TAG.stk libraries.
+ *
+ * ARGUMENTS:
+ *
+ * - t    (uvector type)
+ * - proc (a procedure)
+ * - vecs (the list of vectors)
+ * - mutate (if #t, map! will write on the first vector; if not, a new one
+ *           is allocated)
+ * - oper (the operation tag)
+ * - from_right (#t if vectors should be traversed from right to left)
+ * - seed (a seed -- "knil", when it makes sense)
+ *
+ *
+ * The following procedures are implemented as minimal wrappers on top of
+ * %uvector-iterate:
+ *
+ * - TAGvector-fold
+ * - TAGvector-map
+ * - TAGvector-for-eaach
+ * - TAGvector-count
+ * - TAGvector-cumulate
+ * - TAGvector-index
+ * - TAGvector-skip
+ * - TAGvector-any
+ * - TAGvector-every
+ * - TAGvector-partition
+ * - TAGvector-filter
+ * - TAGvector-remove
+ ***/
+
+#define MAP       0
+#define ANY       1
+#define EVERY     2
+#define INDEX     3
+#define SKIP      4
+#define COUNT     5
+#define PARTITION 6
+#define FILTER    7
+#define REMOVE    8
+#define FOR_EACH  9
+#define FOLD      10
+#define CUMULATE  11
+
+DEFINE_PRIMITIVE("%uvector-iterate", uvector_iterate, vsubr, (int argc, SCM* argv))
+{
+    check_argc(argc,7);
+    SCM t = *argv--;
+    SCM proc = *argv--;
+    SCM vecs = *argv--;
+    SCM mutate = *argv--;
+    SCM oper = *argv--;
+    SCM from_right = *argv--;
+    SCM seed = *argv--;
+    
+    check_int(t);
+    int type = INT_VAL(t);
+    if (type < 0 || type > UVECTOR_C128) STk_error ("bad uvector type descriptor ~A, out of bounds!", t);
+
+    check_procedure(proc);
+
+    /* Fixme: actually check if it's a list? */
+    if (!STk_listp(vecs)) STk_error ("bad list ~S", vecs);
+
+    check_boolean(mutate);
+    
+    for (SCM ptr = vecs; ptr != STk_nil; ptr = CDR(ptr)) {
+	check_uvector(CAR(ptr));
+	check_type(CAR(ptr), type);
+    }
+
+    long arity = INT_VAL(STk_list_length(vecs));
+    
+    /* vecs should have at least one element, so CAR and CDR are available: */
+    long vec_len = UVECTOR_SIZE(CAR(vecs));
+    for (SCM ptr = CDR(vecs); ptr != STk_nil; ptr = CDR(ptr)) {
+	if (UVECTOR_SIZE(CAR(ptr)) < vec_len)
+	    vec_len = UVECTOR_SIZE(CAR(ptr));
+    }
+
+
+    SCM w;
+    /* If we're going to mutate the first vector (as in map!) then
+       we set w to it. Otherwise (for map), we need a newly allocated
+       vector. */
+    if (mutate == STk_true)
+	w = CAR(vecs);
+    else
+	w = makeuvect(type, vec_len, NULL);
+
+    /* We will allocate a vector od SCM, ONCE, and then turn each of its cells
+     * into CONS cells. This will be the argument list for proc.
+     *
+     * args will be a C array of cons cells, each pointing to the next.
+     *
+     * +------------+-------------+         +------------+
+     * |  _____ ___ |   _____ ___ |         |  _____ ___ |
+     * | | car | ----->| car | ------> ...  | | car | -------> nil
+     * |  ----- --- |   ----- --- |         |  ----- --- |
+     * +------------+-------------+         +------------+
+     *    args[0]      args[1]         ...     args[n-1]
+     *
+     * In each iteration, we will copy the i-th element of each vector in vecs
+     * onto its place in the list, and call STk_C_apply_list.
+     *
+     * I can't think of a more efficient way to do this.
+     */
+
+    struct cons_obj *args = STk_must_malloc(arity * sizeof(struct cons_obj));
+
+	
+    /* Adust CDR pointers */
+    int i;
+    for (i=0; i<arity-1; i++) {
+	/* We do the same as NEWCELL would do after allocating each
+	   cons cell: */
+	BOXED_TYPE(&args[i]) = tc_cons;
+	BOXED_INFO(&args[i]) = 0;
+
+	/* And set cdr: */
+	CDR(&args[i]) = &args[i+1];
+    }
+    CAR(&args[arity-1]) = MAKE_INT(- 999);
+    CDR(&args[arity-1]) = STk_nil;
+
+    int op = INT_VAL(oper);
+    
+    long counter = 0;
+    long step = +1;
+    long idx = 0;
+    long stride = vector_element_size(UVECTOR_TYPE(CAR(vecs)));
+
+    
+    if (from_right == STk_true) {
+	idx = vec_len - 1;
+	step  = -1;
+    }
+
+    long left_idx  = 0;
+    long right_idx = vec_len - 1;
+
+    SCM res = STk_Cstring2string("WARNING! res returned unchanged from %uvector-iterate.");
+    
+    for(long i=0; i<vec_len; i++, idx += step) {
+	SCM vecs_ptr = vecs;
+	for (int j=0; j<arity; j++) {
+	    res = CAR(vecs_ptr);
+	    CAR(&args[j]) = uvector_ref(type, res, idx); /* idx-th element of current vector */
+	    vecs_ptr = CDR(vecs_ptr);                    /* next vector */
+	}
+
+	/* FIXME: we wouldn't need to CONS here, but it's just one cell... */
+	if (op == FOLD || op == CUMULATE)
+	    res = STk_C_apply_list(proc, STk_cons(seed,(SCM)&args[0]));
+	else
+	    res = STk_C_apply_list(proc, (SCM)&args[0]);
+
+	/* NO case for FOR_EACH, since nothing should be done anyway! */
+	switch (op) {
+	case MAP:
+	    uvector_set(type, w, idx, res);
+	    break;
+	case ANY:
+	    if (res != STk_false) return res;
+	    break;
+	case EVERY:
+	    if (res == STk_false) return STk_false;
+	    break;
+	case INDEX:
+	    if (res != STk_false) return MAKE_INT(idx);
+	    break;
+	case SKIP:
+	    if (res == STk_false) return MAKE_INT(idx);
+	    break;
+	case COUNT:
+	    if (res != STk_false) counter++;
+	    break;
+	case FOLD:
+	    seed = res;
+	    break;
+	case CUMULATE:
+	    seed = res;
+	    uvector_set(type, w, idx, seed);
+	    break;
+
+       /* Two remarks:
+
+          - In the following cases there is only ONE uvector
+            being traversed, CAR(vecs), so we can access it
+            directly.
+
+
+       */
+	case FILTER:
+	    if (res != STk_false) {
+                /* Slow:
+                   uvector_set(type, w, left_idx,
+                               uvector_ref(type, CAR(vecs), idx)); */
+                /* Fast: */
+                UVECTOR_COPY_ELT(w, left_idx, CAR(vecs), idx, stride);
+		left_idx++;
+	    }
+	    break;
+	case PARTITION:
+	    if (res != STk_false) {
+                UVECTOR_COPY_ELT(w, left_idx, CAR(vecs), idx, stride);
+		left_idx++;
+	    } else {
+                UVECTOR_COPY_ELT(w, right_idx, CAR(vecs), idx, stride);
+		right_idx--;
+	    }
+	    break;
+	case REMOVE:
+	    if (res == STk_false) {
+                UVECTOR_COPY_ELT(w, left_idx, CAR(vecs), idx, stride);
+		left_idx++;
+	    }
+	    break;
+	}
+    }
+	
+    switch (op) {
+    case MAP:
+	return (mutate == STk_true)
+	    ? STk_void /* map! */
+	    : w;       /* map  */
+    case ANY:       return STk_false;
+    case EVERY:     return (vec_len == 0)? STk_true : res;
+    case INDEX:     return STk_false;
+    case SKIP:      return STk_false;
+    case COUNT:     return MAKE_INT(counter);
+    case FOLD:      return seed;
+    case CUMULATE:  return w;
+    case FILTER:    return resize_uvector(w, left_idx, stride);
+    case PARTITION:
+	/* need to reverse the second part of the vector... */
+	SCM tmp;
+	long max = UVECTOR_SIZE(w);
+	right_idx++;
+	for (long i=0; i < (max - right_idx)/2; i++) {
+	    tmp = uvector_ref(-1, w,right_idx + i);
+            
+	    uvector_set(-1, w, right_idx + i, uvector_ref(-1, w,max - i - 1));
+	    uvector_set(-1, w, max - i - 1, tmp);
+            
+	}
+	return w;	
+    case REMOVE:    return resize_uvector(w, left_idx, stride);
+    case FOR_EACH:  return STk_void;
+    }
+    return MAKE_INT(-1); /* just to check if we ever get here... */
+}
+
+
+/*
+ * %uvector-segment:
+ * This is TAGvector-segment, just with an extra first argument for the uvector type.
+ */
+DEFINE_PRIMITIVE("%uvector-segment", uvector_segment, subr3, (SCM t, SCM v, SCM nn))
+{
+    check_int(t);
+    check_int(nn);
+    check_uvector(v);
+    int type   = INT_VAL(t);
+    check_type(v,type);
+
+    long n     = INT_VAL(nn);
+    if (n < 1) STk_error("number of segments should be at least 1, got ~A", nn);
+    long vlen  = UVECTOR_SIZE(v);
+    long nlast = vlen % n;
+
+    
+    SCM res, tmp;
+    long idx;
+    int stride = vector_element_size(type);
+    
+    if (nlast == 0)  {
+	res = STk_nil;
+	idx = vlen - n;
+    } else {
+	idx = vlen - nlast;
+	res = makeuvect(type, nlast, NULL);
+	res = LIST1(STk_uvector_copy_contents(type,
+					      res, 0, nlast,
+					      v, idx, idx + nlast,
+					      STk_false, stride));
+	idx -=n;
+    }
+    
+    while (idx >= 0) {
+	tmp = makeuvect(type, n, NULL);
+	tmp = STk_uvector_copy_contents(type,
+					tmp, 0, n,
+					v, idx, idx + n,
+					STk_false, stride);
+
+	res = STk_cons(tmp, res);
+	idx -= n;
+    }
+
+    return res;
+}
+
+/*
+ * %uvector-swap! is *exactly* TAG-vector-swap!
+ */
+DEFINE_PRIMITIVE("%uvector-swap!", uvector_swap, subr3,
+		 (SCM vec, SCM i, SCM j))
+{
+    check_int(i);
+    check_int(j);
+    check_uvector(vec);
+    check_indices(vec,INT_VAL(i));
+    check_indices(vec,INT_VAL(j));
+
+    char buf[16];
+    int stride = vector_element_size(UVECTOR_TYPE(vec));
+    int pos_i = INT_VAL(i);
+    int pos_j = INT_VAL(j);
+    /* No big difference from using the XOR method... */
+    UVECTOR_GET(&buf[0], vec,pos_i, stride);
+    UVECTOR_COPY_ELT(vec,pos_i, vec,pos_j, stride);
+    UVECTOR_SET(vec,pos_j, &buf[0], stride);
+    return STk_void;
+}
+
+/*
+ * %uvector-fill! is *exactly* TAG-vector-fill!
+ */
+DEFINE_PRIMITIVE("%uvector-fill!", uvector_fill, vsubr, (int argc, SCM *argv))
+{
+  if (argc < 2 || argc >4)
+      STk_error("wrong number of arguments ~A", argc);
+  SCM vec = *argv--;
+  check_uvector(vec);
+  SCM fill = *argv--;
+  SCM s, e;
+  long start, end;
+  if (argc > 2) {
+      s = *argv--;
+      check_int(s);
+      start = INT_VAL(s);
+  } else start = 0;
+  if (argc > 3) {
+      e = *argv--;
+      check_int(e);
+      end = INT_VAL(e);
+  } else end = UVECTOR_SIZE(vec);
+  
+  check_indices(vec,start);
+  check_indices(vec,end);
+
+  int stride = vector_element_size(UVECTOR_TYPE(vec));
+
+  /* Call uvector_set ONCE only, then use UVECTOR_COPY_ELT
+     to copy the first element onto the rest of the vector.
+     This makes filling incredibly faster!
+
+     Bonus:
+     
+     - uvector_set will also check the fill argument and
+       the vector type for us!  */
+  
+  uvector_set(-1, vec, start, fill);
+  for (long i=start+1; i<end; i++)
+      UVECTOR_COPY_ELT(vec,i,
+		       vec,start,
+		       stride);
+
+  return STk_void;
+}
+
+		 
+
+
+MODULE_ENTRY_START("srfi/160/base")
+{
+  SCM module =  STk_create_module(STk_intern("srfi/160/base"));
+
+  ADD_PRIMITIVE_IN_MODULE(s8p,   module);
+  ADD_PRIMITIVE_IN_MODULE(u8p,   module);
+  ADD_PRIMITIVE_IN_MODULE(s16p,  module);
+  ADD_PRIMITIVE_IN_MODULE(u16p,  module);
+  ADD_PRIMITIVE_IN_MODULE(s32p,  module);
+  ADD_PRIMITIVE_IN_MODULE(u32p,  module);
+  ADD_PRIMITIVE_IN_MODULE(s64p,  module);
+  ADD_PRIMITIVE_IN_MODULE(u64p,  module);
+  ADD_PRIMITIVE_IN_MODULE(f32p,  module);
+  ADD_PRIMITIVE_IN_MODULE(f64p,  module);
+  ADD_PRIMITIVE_IN_MODULE(c64p,  module);
+  ADD_PRIMITIVE_IN_MODULE(c128p, module);
+
+  /* Export all the symbols we have just defined */
+  STk_export_all_symbols(module);
+
+  /********************************************************
+   * The following are not exported, they will be used to *
+   * make procedures exported by separate libraries --    *
+   * as per the SRFI text.                                *
+   ********************************************************/
+  
+  ADD_PRIMITIVE_IN_MODULE(srfi_160_uvector_copy,   module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_unfold, module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_append_subs, module);
+  ADD_PRIMITIVE_IN_MODULE(u_vector_equal,     module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_emptyp,     module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_iterate,        module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_segment,    module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_swap,       module);
+  ADD_PRIMITIVE_IN_MODULE(uvector_fill,       module);
+
+  /* Execute Scheme code */
+  STk_execute_C_bytecode(__module_consts, __module_code);
+}
+MODULE_ENTRY_END
+
+DEFINE_MODULE_INFO

--- a/lib/srfi/160/base.stk
+++ b/lib/srfi/160/base.stk
@@ -1,0 +1,128 @@
+;;;;
+;;;; 160/base.stk         -- SRFI-160: Homogeneous numeric vector libraries
+;;;;                                   (base sublibrary)
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 17-Jun-2022 09:03
+;;;; Last file update: 20-Jun-2022 12:31 (jpellegrini)
+;;;;
+
+
+(select-module srfi/160/base)
+
+;; The srfi requires us to offer uvectors for *all* types,
+;; so we load SRFI 4.
+(import (srfi 4)
+        (srfi 128))
+
+(export s8vector? make-s8vector s8vector s8vector-length s8vector-ref
+        s8vector-set! s8vector->list list->s8vector
+
+        u8vector? make-u8vector u8vector u8vector-length u8vector-ref
+        u8vector-set! u8vector->list list->u8vector
+
+        s16vector? make-s16vector s16vector s16vector-length s16vector-ref
+        s16vector-set! s16vector->list list->s16vector
+
+        u16vector? make-u16vector u16vector u16vector-length u16vector-ref
+        u16vector-set! u16vector->list list->u16vector
+
+        s32vector? make-s32vector s32vector s32vector-length s32vector-ref
+        s32vector-set! s32vector->list list->s32vector
+
+        u32vector? make-u32vector u32vector u32vector-length u32vector-ref
+        u32vector-set! u32vector->list list->u32vector
+
+        s64vector? make-s64vector s64vector s64vector-length s64vector-ref
+        s64vector-set! s64vector->list list->s64vector
+
+        u64vector?  make-u64vector u64vector u64vector-length u64vector-ref
+        u64vector-set! u64vector->list list->u64vector
+
+        f32vector?  make-f32vector f32vector f32vector-length f32vector-ref
+        f32vector-set! f32vector->list list->f32vector
+
+        f64vector?  make-f64vector f64vector f64vector-length f64vector-ref
+        f64vector-set! f64vector->list list->f64vector
+
+        c64vector?  make-c64vector c64vector c64vector-length c64vector-ref
+        c64vector-set! c64vector->list list->c64vector
+
+        c128vector?  make-c128vector c128vector c128vector-length c128vector-ref
+        c128vector-set! c128vector->list list->c128vector)
+
+
+(%compile-time-define %list->uvector %uvector->list)
+
+;; FIXME: we are re-defining a macro already defined in SRFI-4...
+(define-macro (%uniform-vector-functions tag type)
+  (let ((pred   (string->symbol (format #f "~Avector?" tag)))
+        (make   (string->symbol (format #f "make-~Avector" tag)))
+        (constr (string->symbol (format #f "~Avector" tag)))
+        (len    (string->symbol (format #f "~Avector-length" tag)))
+        (ref    (string->symbol (format #f "~Avector-ref" tag)))
+        (set    (string->symbol (format #f "~Avector-set!" tag)))
+        (v->l   (string->symbol (format #f "~Avector->list" tag)))
+        (l->v   (string->symbol (format #f "list->~Avector" tag)))
+        (dfl    (cond ((memv tag '(f32 f64)) 0.0)
+                      ((memv tag '(c64 c128)) 0.0+0.0i)
+                      (else 0))))
+    `(begin
+       ;; (TAGvector? obj)
+       (define (,pred obj)
+         (%uvector? ,type obj))
+
+       ;; (make-TAGvector n [ TAGvalue ])
+       (define (,make size :optional (default ,dfl))
+         (%make-uvector ,type size default))
+
+       ;; (TAGvector TAGvalue...)
+       (define (,constr . l)
+         (%uvector ,type l))
+
+       ;; (TAGvector-length TAGvect)
+       (define (,len vect)
+         (%uvector-length ,type vect))
+
+       ;; (TAGvector-ref TAGvect i)
+       (define (,ref vect i)
+         (%uvector-ref ,type vect i))
+
+       ;; (TAGvector-set! TAGvect i TAGvalue)
+       (define (,set vect i val)
+         (%uvector-set! ,type vect i val))
+
+       ;; (set! (setter TAGvector-ref) TAGvector-set!)
+       (set! (setter ,ref) ,set)
+
+       ;; (TAGvector->list TAGvect)
+       (define (,v->l vect)
+         (%uvector->list ,type vect))
+
+       ;; (list->TAGvector TAGlist)
+       (define (,l->v lst)
+         (%list->uvector ,type lst)))))
+
+(%uniform-vector-functions c64  10)
+(%uniform-vector-functions c128 11)
+
+
+(provide "srfi-160/base")

--- a/lib/srfi/160/tagvector-template.stk
+++ b/lib/srfi/160/tagvector-template.stk
@@ -1,0 +1,475 @@
+;;;;
+;;;; 160/TAG.stk         -- SRFI-160: Homogeneous numeric vector libraries
+;;;;                                  (TAG sublibrary)
+;;;;
+;;;; Copyright © 2021 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 17-Jun-2022 15:54
+;;;; Last file update: 20-Jun-2022 11:24 (jpellegrini)
+;;;;
+
+(define-module srfi/160/TAG
+
+  (import (srfi 4)
+          (srfi 128)
+          (srfi 160 base))
+  (export
+   ;; Constructors
+   make-TAGvector   ;; BASE
+   TAGvector        ;; BASE
+   TAGvector-unfold
+   TAGvector-unfold-right
+   TAGvector-copy
+   TAGvector-reverse-copy
+   TAGvector-append
+   TAGvector-concatenate
+   TAGvector-append-subvectors
+
+   ;; Predicates
+   TAG?              ;; BASE
+   TAGvector?        ;; BASE
+   TAGvector-empty?
+   TAGvector=
+   
+   ;; Selectors
+   TAGvector-ref     ;; BASE
+   TAGvector-length  ;; BASE
+   
+   ;; Iteration
+   TAGvector-take
+   TAGvector-take-right
+   TAGvector-drop
+   TAGvector-drop-right
+   TAGvector-segment
+   TAGvector-fold
+   TAGvector-fold-right
+   TAGvector-map
+   TAGvector-map!
+   TAGvector-for-each
+   TAGvector-count
+   TAGvector-cumulate
+   
+   ;; Searching
+   TAGvector-take-while
+   TAGvector-take-while-right
+   TAGvector-drop-while
+   TAGvector-drop-while-right
+   TAGvector-index
+   TAGvector-index-right
+   TAGvector-skip
+   TAGvector-skip-right
+   TAGvector-any
+   TAGvector-every
+   TAGvector-partition
+   TAGvector-filter
+   TAGvector-remove
+   
+   ;; Mutators
+   TAGvector-set!            ;; BASE
+   TAGvector-swap!
+   TAGvector-fill!
+   TAGvector-reverse!
+   TAGvector-copy!
+   TAGvector-reverse-copy!
+   TAGvector-unfold!
+   TAGvector-unfold-right!
+
+   ;; Conversion
+   TAGvector->list           ;; BASE
+   reverse-TAGvector->list
+   list->TAGvector           ;; BASE
+   reverse-list->TAGvector
+   TAGvector->vector
+   vector->TAGvector
+   
+   ;; Generators
+   make-TAGvector-generator
+   
+   ;; Comparators
+   TAGvector-comparator
+
+   ;; Output
+   write-TAGvector)
+
+
+;; A case of "macros for performance"... Not the best thing to do, we could
+;; actually have done a more sofisticated job in generating the output from
+;; the template, but this keeps it simple.
+;; The macro (uvector-tag) will expand to TAG in the template.
+;; However, in the generated file, the TAG will be replaed by the tag name.
+;; So the macro will expand to the VALUE of the tag, which is the
+;; fastest thing we can do. Not even access to a global will be done, the
+;; correct constant will be pushed onto the stack.
+;;
+;;  (%s32vector-something (uvector-tag) args)
+;; EXPANDS into
+;;  (u8vector-something 4 args)
+;; and NOT into
+;;  (%u8vector-something s32 args)
+
+(define-macro (uvector-tag)
+  (let ((s8   0)
+        (u8   1)
+        (s16  2)
+        (u16  3)
+        (s32  4)
+        (u32  5)
+        (s64  6)
+        (u64  7)
+        (f32  8)
+        (f64  9)
+        (c64  10)
+        (c128 11))
+    TAG))
+
+;; We'll be accessing the base module to get some procedures from it:
+(define base (find-module 'srfi/160/base))
+
+;; These are implemented in C, and used here to build the actual procedures:
+(define %uvector-unfold            (symbol-value '%uvector-unfold base))
+(define %uvector-copy              (symbol-value '%uvector-copy base))
+(define %uvector-append-subvectors (symbol-value '%uvector-append-subvectors base))
+(define %uvector-empty?            (symbol-value '%uvector-empty? base))
+(define %uvector=                  (symbol-value '%uvector= base))
+(define %uvector-iterate           (symbol-value '%uvector-iterate base))
+(define %uvector-segment           (symbol-value '%uvector-segment base))
+
+;;;
+;;; Constructors OK
+;;;
+
+;; make-vector OK
+;; vector      OK
+
+(define (TAGvector-unfold f len seed)
+  (%uvector-unfold (uvector-tag) f #f len seed #f))
+
+(define (TAGvector-unfold-right f len seed)
+  (%uvector-unfold (uvector-tag) f #f len seed #t))
+
+(define (TAGvector-copy v :optional (start 0) (end (TAGvector-length v)))
+  (%uvector-copy (uvector-tag) #f 0 v start end #f))
+
+(define (TAGvector-reverse-copy v :optional (start 0) (end (TAGvector-length v)))
+  (%uvector-copy (uvector-tag) #f 0 v start end #t))
+
+(define (TAGvector-append . vecs)
+  (%uvector-append-subvectors (uvector-tag) #f vecs))
+
+(define (TAGvector-concatenate vecs)
+  (%uvector-append-subvectors (uvector-tag) #f vecs))
+
+(define (TAGvector-append-subvectors . vecs)
+  (%uvector-append-subvectors (uvector-tag) #t vecs))
+
+;;;
+;;; Predicates OK
+;;;
+
+(define (TAGvector-empty? v) (%uvector-empty? (uvector-tag) v))
+
+(define (TAGvector= . args) (%uvector= (uvector-tag) args))
+
+;;;
+;;; Selectors OK
+;;;
+
+;; vector-ref    OK
+;; vector-length OK
+
+;; Iteration OK
+
+(define (TAGvector-take v n) (TAGvector-copy v 0 n))
+(define (TAGvector-take-right v n)
+  (TAGvector-copy v (- (TAGvector-length v) n))) ; FIXME: optimize?
+
+(define (TAGvector-drop v n)       (TAGvector-copy v n))
+(define (TAGvector-drop-right v n)
+  (%uvector-copy (uvector-tag) #f 0 v 0 (- (TAGvector-length v) n) #f)) ; FIXME: optimize?
+
+(define (TAGvector-segment v n) (%uvector-segment (uvector-tag) v n))
+
+(define (TAGvector-fold kons knil v1 . v2)
+  (%uvector-iterate (uvector-tag) kons (cons v1 v2)
+   #f   ;; do NOT mutate
+   10   ;; operation (10 = fold)
+   #f   ;; NOT from-right
+   knil ;; seed
+   ))
+
+(define (TAGvector-fold-right kons knil v1 . v2)
+  (%uvector-iterate (uvector-tag) kons (cons v1 v2)
+   #f   ;; do NOT mutate
+   10   ;; operation (10 = fold)
+   #t   ;; YES from-right
+   knil ;; seed
+   ))
+
+(define (TAGvector-map proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   0  ;; operation (0 = map)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-map! proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #t ;; DO mutate
+   0  ;; operation (0 = map)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-for-each proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   9  ;; operation (9 = for-each)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-count proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   5  ;; operation (5 = count)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-cumulate kons knil v1)
+  (%uvector-iterate (uvector-tag) kons (list v1)
+   #f   ;; do NOT mutate
+   11   ;; operation (11 = cumulate)
+   #f   ;; NOT from-right
+   knil ;; seed
+   ))
+
+;;;
+;;; Searching OK
+;;;
+
+(define (TAGvector-take-while pred? vec)
+  (TAGvector-take vec (TAGvector-skip pred? vec)))
+
+(define (TAGvector-take-while-right pred? vec)
+  (TAGvector-drop vec (+ 1 (TAGvector-skip-right pred? vec))))
+
+(define (TAGvector-drop-while pred? vec)
+  (TAGvector-drop vec (TAGvector-skip pred? vec)))
+
+(define (TAGvector-drop-while-right pred? vec)
+  (TAGvector-take vec (+ 1 (TAGvector-skip-right pred? vec))))
+
+
+(define (TAGvector-index proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   3  ;; operation (3 = index)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-index-right proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   3  ;; operation (3 = index)
+   #t ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-skip proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   4  ;; operation (4 = skip)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-skip-right proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   4  ;; operation (4 = skip)
+   #t ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-any proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   1  ;; operation (1 = any)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-every proc v1 . vs)
+  (%uvector-iterate (uvector-tag) proc (cons v1 vs)
+   #f ;; do NOT mutate
+   2  ;; operation (2 = every)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-partition proc v1)
+  (%uvector-iterate (uvector-tag) proc (list v1)
+   #f ;; do NOT mutate
+   6  ;; operation (6 = partition)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+(define (TAGvector-filter proc v1)
+  (%uvector-iterate (uvector-tag) proc (list v1)
+   #f ;; do NOT mutate
+   7  ;; operation (7 = filter)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+(define (TAGvector-remove proc v1)
+  (%uvector-iterate (uvector-tag) proc (list v1)
+   #f ;; do NOT mutate
+   8  ;; operation (8 = remove)
+   #f ;; NOT from-right
+   #f ;; NO seed
+   ))
+
+
+;;;
+;;; Mutators OK
+;;;
+
+;; vector-set! OK
+
+;; FIXME:
+;; vector-fill! and vector-swap! do not depend on vector type,
+;; but vector-fill! does some type checking for each element
+;; written. Maybe this could be optimized...
+(define TAGvector-swap! (symbol-value '%uvector-swap!         base))
+(define TAGvector-fill! (symbol-value '%uvector-fill!         base))
+
+(define (TAGvector-reverse! v :optional (start 0) (end (TAGvector-length v)))
+  (%uvector-copy (uvector-tag) v start v start end #t)
+  #void)
+
+(define (TAGvector-copy! to at from :optional (start 0) (end (TAGvector-length from)))
+  (%uvector-copy (uvector-tag) to at from start end #f)
+  #void)
+
+(define (TAGvector-reverse-copy! to at from :optional (start 0) (end (TAGvector-length from)))
+  (%uvector-copy (uvector-tag) to at from start end #t)
+  #void)
+
+(define (TAGvector-unfold! f v start end seed)
+  (%uvector-unfold (uvector-tag) f v start end seed #f)
+  #void)
+
+(define (TAGvector-unfold-right! f v start end seed)
+  (%uvector-unfold (uvector-tag) f v start end seed #t)
+  #void)
+
+;;;
+;;; Conversion OK
+;;;
+
+(define (vector->TAGvector v :optional (start 0) (end (vector-length v)))
+  (let* ((w (make-TAGvector (- end start))))
+    (do ((i start (+ i 1)))
+        ((= i end))
+      (TAGvector-set! w (- i start) (vector-ref v i)))
+    w))
+
+(define (TAGvector->vector v :optional (start 0) (end (TAGvector-length v)))
+  (let* ((w (make-vector (- end start))))
+    (do ((i start (+ i 1)))
+        ((= i end))
+      (vector-set! w (- i start) (TAGvector-ref v i)))
+    w))
+
+
+(define (TAGvector->list v :optional (start 0) (end (TAGvector-length v)))
+  (let ((v (TAGvector-copy v start end)))
+    (let loop ((i (fx- (TAGvector-length v) 1))
+               (lst '()))
+      (if (fx< i 0)
+          lst
+          (loop (fx- i 1) (cons (TAGvector-ref v i) lst))))))
+
+
+(define (reverse-list->TAGvector lst)
+  (TAGvector-reverse-copy (list->TAGvector lst)))
+  
+(define (reverse-TAGvector->list v :optional (start 0) (end (TAGvector-length v)))
+  (TAGvector->list (TAGvector-reverse-copy v start end)))
+
+;;;
+;;; Generators OK
+;;;
+
+(define (make-TAGvector-generator v :optional (start 0) (end (TAGvector-length v)))
+  (lambda () (if (fx>= start end)
+            (eof-object)
+            (let ((x (TAGvector-ref v start)))
+              (set! start (fx+ 1 start))
+              x))))
+
+;;;
+;;; Comparators OK
+;;;
+
+;; Adapted from reference implementation in Chicken:
+(define (TAGvector< vec1 vec2)
+     (let ((len1 (TAGvector-length vec1))
+           (len2 (TAGvector-length vec2)))
+       (cond
+         ((fx< (TAGvector-length vec1)
+               (TAGvector-length vec2))
+          #t)
+         ((fx> (TAGvector-length vec1)
+               (TAGvector-length vec2))
+          #f)
+         (else
+          (let loop ((i 0))
+            (cond
+              ((fx= i len1) #f)
+              ((< (TAGvector-ref vec1 i) (TAGvector-ref vec2 i))
+               #t)
+              ((> (TAGvector-ref vec1 i) (TAGvector-ref vec2 i))
+               #f)
+              (else
+               (loop (fx+ i 1)))))))))
+
+(define TAGvector-comparator
+  (make-comparator TAGvector? TAGvector= TAGvector< hash-table-hash))
+
+;;;
+;;; Output OK
+;;;
+
+(define (write-TAGvector v :optional port)
+  (unless ()
+    (error))
+  (if port
+      (write v port)
+      (write v)))
+
+  )
+
+(provide "srfi-160/TAG")
+

--- a/lib/srfi/4.stk
+++ b/lib/srfi/4.stk
@@ -78,8 +78,15 @@
 ;;  UVECT_F32   8
 ;;  UVECT_F64   9
 
+;; NOTE: SRFI 160 also defines
+;; UVECT_C64    10
+;; UVECT_C128   11
+;; See lib/srfi/160/base.stk
+;; --jpellegrini
 
-  ;; Avoid warnings
+
+;; Avoid warnings 
+
   (%compile-time-define %list->uvector %uvector->list)
 
 (define-macro (%uniform-vector-functions tag type)

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -23,6 +23,19 @@
 
 #-======================================================================
 
+# We have SUBDIRS_SRFIS and SUBDIRS.
+#
+# SUBDIRS_SRFIS must *not* include the current directory,
+# otherwise the clean target enters an infinite loop.
+# But SUBDIRS *does* need to include the current directory.
+# We can control the build order in the SUBDIRS variable.
+#
+# NOTE: 160.ostk needs the sublibraries to be built first.
+#
+SUBDIRS_SRFIS = 160
+# Build this directory before others:
+SUBDIRS = $(SUBDIRS_SRFIS) .
+
 COMP ?= ../../utils/tmpcomp
 STKLOS_BINARY ?= ../../src/stklos
 STKLOS_FLAGS   = --no-init-file --case-sensitive
@@ -99,6 +112,7 @@ SRC_STK   = 1.stk   \
             154.stk \
             156.stk \
             158.stk \
+            160.stk \
             161.stk \
             169.stk \
             171.stk \
@@ -193,6 +207,7 @@ SRC_OSTK =  1.ostk   \
             154.ostk \
             156.ostk \
             158.ostk \
+            160.ostk \
             161.ostk \
             169.ostk \
             171.ostk \
@@ -273,6 +288,7 @@ $(DEPEND_9): 9.ostk
 134.ostk: 158.ostk
 135.ostk: 129.ostk
 152.ostk: 130.ostk
+160.ostk: 160
 190.ostk: 158.ostk
 216.ostk: 27.$(SO)
 217.ostk: ../stklos/itrie.so
@@ -288,18 +304,39 @@ $(DEPEND_9): 9.ostk
 170.$(SO): 170-incl.c 170.c
 175.$(SO): 175-incl.c 175.c
 
-
-
 #======================================================================
 
 install-sources:
 	install $(srfi_sources) $(srfidir)
 
-clean:
+#======================================================================
+# CLEAN
+#
+# SUBDIRS_SRFIS is the list of subdirectories, *excluding* this
+# one (so we don't enter an infinite loop).
+SUBCLEAN = $(addsuffix .clean,$(SUBDIRS_SRFIS) )
+SUBDISTCLEAN = $(addsuffix .distclean,$(SUBDIRS_SRFIS) )
+.PHONY: clean distclean $(SUBCLEAN) $(SUBDISTCLEAN)
+
+### CLEAN
+# How to clean each subdir:
+$(SUBCLEAN): %.clean:
+	$(MAKE) -C $* clean
+
+# To clean this one, first clean the subdirs, then execute
+# our clean rule:
+clean: $(SUBCLEAN)
 	rm -f $(srfi_OBJS) *-incl.c *~
 
-distclean: clean
+### DISTCLEAN
+# How to clean each subdir:
+$(SUBDISTCLEAN): %.distclean:
+	$(MAKE) -C $* distclean
+
+distclean: $(SUBDISTCLEAN) clean
 	/bin/rm -f Makefile
+
+#======================================================================
 
 uninstall-hook:
 	(cd $(srfidir); rm -f $(srfi_sources))

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -198,7 +198,7 @@
     ;; 157  Continuation marks
     (158 "Generators and Accumulators" () "srfi-158")
     ;; 159  Combinator Formatting
-    ;; 160  Homogeneous numeric vector libraries
+    (160 "Homogeneous numeric vector libraries" () "srfi-160")
     (161 "Unifiable Boxes" () "srfi-161")
     ;; 162  Comparators sublibrary
     ;; 163  Enhanced array literals

--- a/src/read.c
+++ b/src/read.c
@@ -803,7 +803,7 @@ static SCM maybe_read_uniform_vector(SCM port, int c, struct read_context *ctx)
     return STk_false;
   } else {
     if ((!STk_uvectors_allowed &&  (strcmp(tok, "u8") == 0)) ||
-        (STk_uvectors_allowed && (len == 2 || len == 3))) {
+        (STk_uvectors_allowed && (len >= 2 || len <= 4))) {
       c = STk_getc(port);
       if (c == '"')
         return read_srfi207_bytevector(port, ctx->constant);
@@ -888,6 +888,10 @@ static SCM read_rec(SCM port, struct read_context *ctx, int inlist)
           // FIXME:
           case 'F' :
           case 'f' : if (STk_uvectors_allowed)
+                       return maybe_read_uniform_vector(port, c, ctx);
+                     goto default_sharp;
+          case 'C' :
+          case 'c' : if (STk_uvectors_allowed)
                        return maybe_read_uniform_vector(port, c, ctx);
                      goto default_sharp;
           case '\\': return read_char(port, STk_getc(port));

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -1387,6 +1387,7 @@ int STk_uniform_vector_tag(char *s);
 int STk_uvector_equal(SCM u1, SCM u2);
 SCM STk_list2uvector(int type, SCM l);
 SCM STk_uvector_get(SCM v, long i);
+void STk_uvector_put(SCM v, long i, SCM value);
 int STk_init_uniform_vector(void);
 
 SCM STk_make_C_bytevector(int len);

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -1362,10 +1362,12 @@ struct uvector_obj {
 #define UVECT_U64       7
 #define UVECT_F32       8
 #define UVECT_F64       9
+#define UVECT_C64       10
+#define UVECT_C128      11
 
 /*
  * 64 bits values are always represented with bignums even on 64 bits machines
- * Here are the intersting maxima for 64 bits.
+ * Here are the interesting maxima for 64 bits.
  */
 #define S64_MIN "-9223372036854775808"
 #define S64_MAX  "9223372036854775807"
@@ -1386,7 +1388,7 @@ int STk_uvector_equal(SCM u1, SCM u2);
 SCM STk_list2uvector(int type, SCM l);
 int STk_init_uniform_vector(void);
 
-  SCM STk_make_C_bytevector(int len);
+SCM STk_make_C_bytevector(int len);
 SCM STk_make_bytevector_from_C_string(char *str, long len);
 
 

--- a/src/uvector.c
+++ b/src/uvector.c
@@ -326,7 +326,7 @@ static SCM makeuvect(int type, int len, SCM init)
     case UVECT_F32:                 size = 4;           break;
     case UVECT_F64:                 size = 8;           break;
   }
-  NEWCELL_WITH_LEN(z, uvector, sizeof(struct vector_obj) + size*len - 1);
+  NEWCELL_WITH_LEN(z, uvector, sizeof(struct uvector_obj) + size*len - 1);
   UVECTOR_TYPE(z) = type;
   UVECTOR_SIZE(z) = len;
 

--- a/src/uvector.c
+++ b/src/uvector.c
@@ -355,6 +355,12 @@ static void uvector_set(SCM v, long i, SCM value)
             value, type_vector(UVECTOR_TYPE(v)));
 }
 
+
+void STk_uvector_put(SCM v, long i, SCM value) /* public version of uvector_set */
+{
+    uvector_set(v, i, value);
+}
+
 static SCM uvector_ref(SCM v, long i)
 {
   switch (UVECTOR_TYPE(v)) {

--- a/src/uvector.c
+++ b/src/uvector.c
@@ -24,6 +24,7 @@
  * Last file update: 10-Apr-2021 18:47 (eg)
  */
 
+#include <float.h>
 #include "stklos.h"
 
 int STk_uvectors_allowed = 0;
@@ -38,16 +39,18 @@ static SCM u64_max, s64_min, s64_max;
 static char *type_vector(int tip)
 {
   switch (tip) {
-    case UVECT_S8:  return "s8";
-    case UVECT_U8:  return "u8";
-    case UVECT_S16: return "s16";
-    case UVECT_U16: return "u16";
-    case UVECT_S32: return "s32";
-    case UVECT_U32: return "u32";
-    case UVECT_S64: return "s64";
-    case UVECT_U64: return "u64";
-    case UVECT_F32: return "f32";
-    case UVECT_F64: return "f64";
+    case UVECT_S8:   return "s8";
+    case UVECT_U8:   return "u8";
+    case UVECT_S16:  return "s16";
+    case UVECT_U16:  return "u16";
+    case UVECT_S32:  return "s32";
+    case UVECT_U32:  return "u32";
+    case UVECT_S64:  return "s64";
+    case UVECT_U64:  return "u64";
+    case UVECT_F32:  return "f32";
+    case UVECT_F64:  return "f64";
+    case UVECT_C64:  return "c64";
+    case UVECT_C128: return "c128";
     default:        return ""; /* never reached */
   }
 }
@@ -88,8 +91,12 @@ static void error_bad_list(SCM l)
   STk_error("bad list ~s", l);
 }
 
+SCM get_u64_max () { return u64_max; }
+SCM get_s64_min () { return s64_min; }
+SCM get_s64_max () { return s64_max; }
 
-static int vector_element_size(int type)
+
+int vector_element_size(int type)
 {
   /* compute len of one element depending on type.  We assume here
    * that characters use 8 bits and that we are at least on a 32 bits
@@ -106,6 +113,8 @@ static int vector_element_size(int type)
     case UVECT_S64: case UVECT_U64: return sizeof(SCM);
     case UVECT_F32:                 return 4;
     case UVECT_F64:                 return 8;
+    case UVECT_C64:                 return 8;
+    case UVECT_C128:                return 16;
   }
   return 0; /* never reached */
 }
@@ -170,7 +179,10 @@ static SCM control_index(int argc, SCM *argv, long *pstart, long *pend, SCM *pfi
 int STk_uniform_vector_tag(char *s)
 {
   static char *table[] =
-    {"s8", "u8", "s16", "u16", "s32", "u32", "s64", "u64", "f32", "f64", "" };
+    {"s8", "u8", "s16", "u16", "s32", "u32", "s64", "u64",
+     "f32", "f64",
+     "c64", "c128",
+     "" };
   char **p;
 
   for (p = table; **p; p++) {
@@ -186,17 +198,37 @@ int STk_uvector_equal(SCM u1, SCM u2)
       (UVECTOR_SIZE(u1) != UVECTOR_SIZE(u2)))
     return 0;
 
-  /* same length and same tyep, compare the bytes */
+  /* same length and same type, compare the bytes */
   int len = vector_element_size(UVECTOR_TYPE(u1)) * UVECTOR_SIZE(u1);
 
   return (memcmp(UVECTOR_DATA(u1), UVECTOR_DATA(u2), len) == 0);
 }
 
+
+/* Duplicated from number.c: */
+static Inline SCM Cmake_complex(SCM r, SCM i)
+{
+  SCM z;
+
+  NEWCELL(z, complex);
+  COMPLEX_REAL(z) = r;
+  COMPLEX_IMAG(z) = i;
+  return z;
+}
+
+
+/*
+ * We use exact->inexact to cast complex vectors in c64 and c128 types
+ * (possibly resultingin +inf.0 or -inf.0)
+ */
+EXTERN_PRIMITIVE("exact->inexact", ex2inex, subr1, (SCM z));
+
+
 /*
  * Basic accessors to a uniform vector
  *
  */
-static void uvector_set(int _UNUSED(type), SCM v, long i, SCM value)
+void uvector_set(int _UNUSED(type), SCM v, long i, SCM value)
 {
   long vali;
   int overflow;
@@ -272,6 +304,50 @@ static void uvector_set(int _UNUSED(type), SCM v, long i, SCM value)
         return;
       }
       break;
+
+    /*
+     Complexes are stored with the real part in the even-indexed cells, and
+     imaginary parts in odd-indexed cells:
+
+      -----+-----+-----+-----+-------
+     | r_1 | i_1 | r_2 | i_2 |  ...  |
+      -----+-----+-----+-----+-------
+     Every complex real-part and imag-part is transformed into inexact, so it would into
+     a double. Forthermore, for c64 vectors, they're downcasted to floats.
+    */
+    case UVECT_C64:
+      if (COMPLEXP(value)) {
+	/* Following what exact->inexact does, we don't signal error on
+	   overflow when converting. This is similar to what other Schemes
+	   do. */
+        SCM rea = STk_ex2inex(COMPLEX_REAL(value));
+	SCM img = STk_ex2inex(COMPLEX_IMAG(value));
+        /* We'll actually DOWNCAST the number to float + float.  */
+        ((float *) UVECTOR_DATA(v))[2*i]     = (float) REAL_VAL(rea);
+	((float *) UVECTOR_DATA(v))[2*i + 1] = (float) REAL_VAL(img);
+        return;
+      } else if (REALP(value)){
+        ((float *) UVECTOR_DATA(v))[2*i]     = (float) REAL_VAL(value);
+	((float *) UVECTOR_DATA(v))[2*i + 1] = (float) 0.0;
+	return;
+      }
+      break;
+    case UVECT_C128:
+      if (COMPLEXP(value)) {
+	/* Following what exact->inexact does, we don't signal error on
+	   overflow when converting. This is similar to what other Schemes
+	   do. */
+        SCM rea = STk_ex2inex(COMPLEX_REAL(value));
+	SCM img = STk_ex2inex(COMPLEX_IMAG(value));
+        ((double *) UVECTOR_DATA(v))[2*i]     = (double) REAL_VAL(rea);
+	((double *) UVECTOR_DATA(v))[2*i + 1] = (double) REAL_VAL(img);
+	return;
+      } else if (REALP(value)) {
+        ((double *) UVECTOR_DATA(v))[2*i]     = (double) REAL_VAL(value);
+	((double *) UVECTOR_DATA(v))[2*i + 1] = (double) 0.0;
+	return;
+      }
+      break;
   }
 
   /* If we arrive here we are sure that we have a value which is out of bounds */
@@ -279,7 +355,7 @@ static void uvector_set(int _UNUSED(type), SCM v, long i, SCM value)
             value, type_vector(UVECTOR_TYPE(v)));
 }
 
-static SCM uvector_ref(int _UNUSED(type), SCM v, long i)
+SCM uvector_ref(int _UNUSED(type), SCM v, long i)
 {
   switch (UVECTOR_TYPE(v)) {
     case UVECT_S8: return MAKE_INT(((char *) UVECTOR_DATA(v))[i]);
@@ -295,6 +371,32 @@ static SCM uvector_ref(int _UNUSED(type), SCM v, long i)
 
     case UVECT_F32: return STk_double2real(((float *) UVECTOR_DATA(v))[i]);
     case UVECT_F64: return STk_double2real(((double *) UVECTOR_DATA(v))[i]);
+
+   /*
+     Complexes are stored with the real part in the even-indexed cells, and
+     imaginary parts in odd-indexed cells:
+
+      -----+-----+-----+-----+-------
+     | r_1 | i_1 | r_2 | i_2 |  ...  |
+      -----+-----+-----+-----+-------
+     Every complex real-part and imag-part is transformed into inexact, so it would into
+     a double. Forthermore, for c64 vectors, they're downcasted to floats.
+    */
+    case UVECT_C64:
+	/* Don't return complexes with zero imaginary part! Those are reals... */
+	if ( ( (float) (((float*)UVECTOR_DATA(v))[2*i + 1]) ) == 0.0 )
+	    return STk_double2real( (float) (((float*)UVECTOR_DATA(v))[2*i]) );
+	else
+	    return Cmake_complex(STk_double2real((float) ((float *) UVECTOR_DATA(v))[2*i]),
+				 STk_double2real((float) ((float *) UVECTOR_DATA(v))[2*i + 1]));
+
+    case UVECT_C128:
+	/* Don't return complexes with zero imaginary part! Those are reals... */
+	if ( ( (double) (((double*) UVECTOR_DATA(v))[2*i + 1]) ) == 0.0 )
+	    return STk_double2real( (double) (((double*) UVECTOR_DATA(v))[2*i]) );
+	else
+	    return Cmake_complex(STk_double2real(((double *) UVECTOR_DATA(v))[2*i]),
+				 STk_double2real(((double *) UVECTOR_DATA(v))[2*i + 1]));
   }
   return STk_void; /* never reached */
 }
@@ -305,7 +407,7 @@ static SCM uvector_ref(int _UNUSED(type), SCM v, long i)
  * Uniform vector constructor
  *
  */
-static SCM makeuvect(int type, int len, SCM init)
+SCM makeuvect(int type, int len, SCM init)
 {
   long i, size = 1;
   SCM  z;
@@ -316,7 +418,7 @@ static SCM makeuvect(int type, int len, SCM init)
    * without boxing whereas S64 are represeneted by a bignum
    * (even on 64 machines where we can do better). Furthermore, we
    * suppose that C floats and doubles correspond to single and
-   * double IEEE-754 reals
+   * double IEEE-754 reals.
    */
   switch (type) {
     case UVECT_S8:  case UVECT_U8:  size = 1;           break;
@@ -325,6 +427,8 @@ static SCM makeuvect(int type, int len, SCM init)
     case UVECT_S64: case UVECT_U64: size = sizeof(SCM); break;
     case UVECT_F32:                 size = 4;           break;
     case UVECT_F64:                 size = 8;           break;
+    case UVECT_C64:                 size = 8;           break;
+    case UVECT_C128:                size = 16;          break;
   }
   NEWCELL_WITH_LEN(z, uvector, sizeof(struct uvector_obj) + size*len - 1);
   UVECTOR_TYPE(z) = type;
@@ -352,6 +456,8 @@ SCM STk_list2uvector(int type, SCM l)
   return z;
 }
 
+
+
 /*===========================================================================*\
  *
  * User primitives on uniform vectors.
@@ -364,8 +470,8 @@ DEFINE_PRIMITIVE("%make-uvector", make_uvector, subr3,(SCM type, SCM len, SCM in
   long l   = STk_integer_value(len);
   long tip = STk_integer_value(type);
 
-  if (l < 0)                             error_bad_length(len);
-  if (tip < UVECT_S8 || tip > UVECT_F64) error_bad_uniform_type(type);
+  if (l < 0)                              error_bad_length(len);
+  if (tip < UVECT_S8 || tip > UVECT_C128) error_bad_uniform_type(type);
 
   return makeuvect(tip, l, init);
 }
@@ -380,7 +486,7 @@ DEFINE_PRIMITIVE("%uvector", uvector, subr2, (SCM type, SCM values))
 {
   long tip = STk_integer_value(type);
 
-  if (tip < UVECT_S8 || tip > UVECT_F64) error_bad_uniform_type(type);
+  if (tip < UVECT_S8 || tip > UVECT_C128) error_bad_uniform_type(type);
   return STk_list2uvector(tip, values);
 }
 
@@ -388,7 +494,7 @@ DEFINE_PRIMITIVE("%uvector-length", uvector_length, subr2, (SCM type, SCM v))
 {
   long tip = STk_integer_value(type);
 
-  if (tip < UVECT_S8 || tip > UVECT_F64)        error_bad_uniform_type(type);
+  if (tip < UVECT_S8 || tip > UVECT_C128)        error_bad_uniform_type(type);
   if (!UVECTORP(v) || (UVECTOR_TYPE(v) != tip)) error_bad_uvector(v, tip);
 
   return MAKE_INT(UVECTOR_SIZE(v));
@@ -400,7 +506,7 @@ DEFINE_PRIMITIVE("%uvector-ref", uvector_ref, subr3, (SCM type, SCM v, SCM index
   long tip = STk_integer_value(type);
 
   if (!UVECTORP(v) || (UVECTOR_TYPE(v) != tip))  error_bad_vector(v);
-  if (tip < UVECT_S8 || tip > UVECT_F64)         error_bad_uniform_type(type);
+  if (tip < UVECT_S8 || tip > UVECT_C128)        error_bad_uniform_type(type);
   if (i < 0 || i >= UVECTOR_SIZE(v))             error_bad_index(index);
 
   return uvector_ref(tip, v, i);
@@ -413,7 +519,7 @@ DEFINE_PRIMITIVE("%uvector-set!", uvector_set, subr4,
   long tip = STk_integer_value(type);
 
   if (!UVECTORP(v) || (UVECTOR_TYPE(v) != tip)) error_bad_vector(v);
-  if (tip < UVECT_S8 || tip > UVECT_F64)        error_bad_uniform_type(type);
+  if (tip < UVECT_S8 || tip > UVECT_C128)       error_bad_uniform_type(type);
   if (BOXED_INFO(v) & VECTOR_CONST)             error_change_const_vector(v);
   if (i < 0 || i >= UVECTOR_SIZE(v))            error_bad_index(index);
 
@@ -427,7 +533,7 @@ DEFINE_PRIMITIVE("%uvector->list", uvector_list, subr2, (SCM type, SCM v))
   long i, len, tip = STk_integer_value(type);
   SCM z, tmp;
 
-  if (tip < UVECT_S8 || tip > UVECT_F64)        error_bad_uniform_type(type);
+  if (tip < UVECT_S8 || tip > UVECT_C128)        error_bad_uniform_type(type);
   if (!UVECTORP(v) || (UVECTOR_TYPE(v) != tip)) error_bad_vector(v);
 
   len = UVECTOR_SIZE(v);
@@ -445,9 +551,10 @@ DEFINE_PRIMITIVE("%list->uvector", list_uvector, subr2, (SCM type, SCM l))
 {
   long tip = STk_integer_value(type);
 
-  if (tip < UVECT_S8 || tip > UVECT_F64) error_bad_uniform_type(type);
+  if (tip < UVECT_S8 || tip > UVECT_C128) error_bad_uniform_type(type);
   return STk_list2uvector(tip, l);
 }
+
 
 DEFINE_PRIMITIVE("%allow-uvectors", allow_uvectors, subr0, (void))
 {

--- a/tests/srfis/160.stk
+++ b/tests/srfis/160.stk
@@ -414,3 +414,27 @@
 (test "@vector-gen 3" 4 (g))
 (test "@vector-gen 4" 5 (g))
 (test-assert "@vector-gen eof" (eof-object? (g)))
+
+
+;;;
+;;; EXTRA tests -- jpellegrini
+;;;
+
+(define v (c128vector 0.0 (sqrt 1.0) (sqrt -1.0) 2-2i))
+
+(test/error "wrong element.1" (s8vector 1000))
+(test/error "wrong element.2" (f64vector 1.0-1i))
+(test/error "wrong element.2" (s64vector 1.0))
+(test/error "wrong procedure.1" (c128vector-map 1 v))
+(test/error "wrong procedure.2" (c128vector-map (lambda (a b) (* a b)) v))
+(test/error "wrong procedure.3" (c128vector-unfold (lambda (a b) 1.0) 3 1.0))
+(test/error "wrong procedure.4" (c128vector-filter 1 v))
+(test/error "wrong seed"        (c128vector-unfold (lambda (a b) (values b 1.0)) 3 1))
+
+(test/error "wrong index.1" (c128swap! v 1 5))
+(test/error "wrong index.2" (c128swap! v -1 2))
+(test/error "wrong index.3" (c128fill! v 1 -1 2))
+(test/error "wrong index.4" (c128fill! v 1 0 5))
+(test/error "wrong value"   (c128fill! v 1 0 4))
+(test/error "wrong vector"  (c64swap! v 1 2))
+(test/error "wrong vector"  (c64fill! v 1.0))

--- a/tests/srfis/160.stk
+++ b/tests/srfis/160.stk
@@ -1,0 +1,416 @@
+;;;
+;;; Tests from the SRFI-160 reference implementation,
+;;; adapted for STklos
+;;;
+
+(import (srfi 128))
+
+
+
+
+(define-syntax test-equiv
+  (syntax-rules ()
+    ((test-equiv expect expr)
+     (test "noname" expect (s16vector->list expr)))
+    ((test-equiv name expect expr)
+     (test name expect (s16vector->list expr)))))
+
+(define-syntax test-assert
+  (syntax-rules ()
+    ((test-assert name expr)
+     (test name #t expr))))
+
+(define-syntax test-not
+  (syntax-rules ()
+    ((test-not name expr)
+     (test name #f expr))))
+
+;;; Hvector = homogeneous vector
+
+;; Test for sameness
+
+(define relerr (expt 2 -24))
+(define (inexact-real? x) (and (number? x) (inexact? x) (real? x)))
+(define (inexact-complex? x) (and (number? x) (inexact? x) (not (real? x))))
+(define (realify z) (* (real-part z) (imag-part z)))
+
+(define (same? result expected)
+  (cond
+    ((and (inexact-real? result) (inexact-real? expected))
+     (let ((abserr (abs (* expected relerr))))
+       (<= (- expected abserr) result (+ expected abserr))))
+    ((and (inexact-complex? result) (inexact-complex? expected))
+     (let ((abserr (abs (* (realify expected) relerr))))
+       (<= (- (realify expected) abserr) (realify result) (+ (realify expected) abserr))))
+    ((and (number? result) (number? expected))
+     (= result expected))
+    ((and (pair? result) (pair? expected))
+     (list-same? result expected))
+    (else
+      (equal? result expected))))
+
+ (define (list-same? result expected)
+  (cond
+    ((and (null? result) (null? expected))
+     #t)
+    ((and (pair? result) (pair? expected))
+     (and (same? (car result) (car expected)) (list-same? (cdr result) (cdr expected))))
+    (else
+     #f)))
+
+(define-syntax is-same?
+  (syntax-rules ()
+    ((is-same? result expected)
+     (test "" #t (same? result expected)))))
+
+(define (create label value)
+  value)
+
+
+(define (test% tag make-Hvector Hvector Hvector? Hvector-length
+               Hvector-ref Hvector-set! Hvector->list list->Hvector)
+  ;; (display "STARTING ")
+  ;; (display tag)
+  ;; (display "vector TESTS:")
+  ;; (newline)
+  (let* ((first 32.0)
+         (second 32.0+47.0i)
+         (third -47.0i)
+         (vec0 (make-Hvector 3))
+         (vec1 (make-Hvector 3 second))
+         (vec2 (Hvector first second third))
+         (vec3 (list->Hvector (list third second first))))
+    (is-same? (Hvector? vec0) #t)
+    (is-same? (Hvector? vec1) #t)
+    (is-same? (Hvector? vec2) #t)
+    (is-same? (Hvector? vec3) #t)
+    (is-same? (Hvector-length vec0) 3)
+    (is-same? (Hvector-length vec1) 3)
+    (is-same? (Hvector-length vec2) 3)
+    (is-same? (Hvector-length vec3) 3)
+    (Hvector-set! vec0 0 second)
+    (Hvector-set! vec0 1 third)
+    (Hvector-set! vec0 2 first)
+    (is-same? (Hvector-ref vec0 0) second)
+    (is-same? (Hvector-ref vec0 1) third)
+    (is-same? (Hvector-ref vec0 2) first)
+    (is-same? (Hvector-ref vec1 0) second)
+    (is-same? (Hvector-ref vec1 1) second)
+    (is-same? (Hvector-ref vec1 2) second)
+    (is-same? (Hvector-ref vec2 0) first)
+    (is-same? (Hvector-ref vec2 1) second)
+    (is-same? (Hvector-ref vec2 2) third)
+    (is-same? (Hvector-ref vec3 0) third)
+    (is-same? (Hvector-ref vec3 1) second)
+    (is-same? (Hvector-ref vec3 2) first)
+    (is-same? (Hvector->list vec0) (list second third first))
+    (is-same? (Hvector->list vec1) (list second second second))
+    (is-same? (Hvector->list vec2) (list first second third))
+    (is-same? (Hvector->list vec3) (list third second first))))
+
+(test% 'c64 make-c64vector c64vector c64vector? c64vector-length
+      c64vector-ref c64vector-set! c64vector->list list->c64vector)
+
+(test% 'c128 make-c128vector c128vector c128vector? c128vector-length
+      c128vector-ref c128vector-set! c128vector->list list->c128vector)
+
+(define-syntax integral-tests
+  (syntax-rules ()
+    ((integral-tests pred lo hi)
+     (begin
+       (test-not "test-int.q" (pred 1/2))
+       (test-not "test-int.r" (pred 1.0))
+       (test-not "test-int.ec" (pred 1+2i))
+       (test-not "test-int.ic" (pred 1.0+2.0i))
+       (test-assert "test-int.0" (pred 0))
+       (test-assert "test-int.hi" (pred hi))
+       (test-assert "test-int.lo" (pred lo))
+       (test-not "test-int.hi+1" (pred (+ hi 1)))
+       (test-not "test-int.lo-1" (pred (- lo 1)))))))
+
+(integral-tests u8? 0 255)
+(integral-tests s8? -128 127)
+(integral-tests u16? 0 65535)
+(integral-tests s16? -32768 32767)
+(integral-tests u32? 0 4294967295)
+(integral-tests s32? -2147483648 2147483647)
+(integral-tests u64? 0 18446744073709551615)
+(integral-tests s64? -9223372036854775808 9223372036854775807)
+
+(test-assert "f32?.1" (f32? 1.0))
+(test-not "f32?.2" (f32? 1))
+(test-not "f32?.3" (f32? 1.0+2.0i))
+
+(test-assert "f64?.1" (f64? 1.0))
+(test-not "f64?.2" (f64? 1))
+(test-not "f64?.3" (f64? 1.0+2.0i))
+
+(test-assert "c64?.1" (c64? 1.0))
+(test-not "c64?.2" (c64? 1))
+(test-assert "c64?.3" (c64? 1.0+2.0i))
+
+(test-assert "c128?.1" (c128? 1.0))
+(test-not "c128?.2" (c128? 1))
+(test-assert "c128?.3" (c128? 1.0+2.0i))
+
+
+;;;
+;;; "shared-tests.scm"
+;;;
+
+(define (times2 x) (* x 2))
+(define s5 (s16vector 1 2 3 4 5))
+(define s4 (s16vector 1 2 3 4))
+(define s5+ (s16vector 1 2 3 4 6))
+
+(define (steady i x) (values x x))
+(define (count-up i x) (values x (+ x 1)))
+(define (count-down i x) (values x (- x 1)))
+(define (odd+1 x) (if (odd? x) (+ 1 x) #f))
+(define s16vector< (comparator-ordering-predicate s16vector-comparator))
+(define s16vector-hash (comparator-hash-function s16vector-comparator))
+
+(define g (make-s16vector-generator s5))
+
+
+(test-equiv "make" '(3 3 3 3 3) (make-s16vector 5 3))
+(test-equiv "s16vector" '(-2 -1 0 1 2) (s16vector -2 -1 0 1 2))
+(test-equiv "unfold up" '(10 11 12 13 14)
+            (s16vector-unfold count-up 5 10))
+(test-equiv "unfold down" '(10 9 8 7 6)
+            (s16vector-unfold count-down 5 10))
+(test-equiv "unfold steady" '(10 10 10 10 10)
+            (s16vector-unfold steady 5 10))
+(test-equiv "unfold-right up" '(14 13 12 11 10)
+            (s16vector-unfold-right count-up 5 10))
+(test-equiv "unfold-right down" '(6 7 8 9 10)
+            (s16vector-unfold-right count-down 5 10))
+(test-equiv "unfold-right steady" '(10 10 10 10 10)
+            (s16vector-unfold-right steady 5 10))
+(test-equiv "copy" '(1 2 3 4 5) (s16vector-copy s5))
+(test-assert "copy2" (not (eqv? s5 (s16vector-copy s5))))
+(test-equiv "copy3" '(2 3) (s16vector-copy s5 1 3))
+(test-equiv "reverse-copy" '(5 4 3 2 1) (s16vector-reverse-copy s5))
+(test-equiv "append" '(1 2 3 4 5 1 2 3 4 5)
+            (s16vector-append s5 s5))
+(test-equiv "concatenate" '(1 2 3 4 5 1 2 3 4 5)
+            (s16vector-concatenate (list s5 s5)))
+(test-equiv "append-subvectors" '(2 3 2 3)
+            (s16vector-append-subvectors s5 1 3 s5 1 3))
+
+
+
+(test-assert "s16?" (s16? 5))
+(test-assert "not s16?" (not (s16? 65536)))
+(test-assert "s16vector?" (s16vector? s5))
+(test-assert "not s16vector?" (not (s16vector? #t)))
+(test-assert "empty" (s16vector-empty? (s16vector)))
+(test-assert "not empty" (not (s16vector-empty? s5)))
+(test-assert "=" (s16vector= (s16vector 1 2 3) (s16vector 1 2 3)))
+(test-assert "= multi" (s16vector= (s16vector 1 2 3)
+                                   (s16vector 1 2 3)
+                                   (s16vector 1 2 3)))
+(test-assert "not =" (not (s16vector= (s16vector 1 2 3) (s16vector 3 2 1))))
+(test-assert "not =2" (not (s16vector= (s16vector 1 2 3) (s16vector 1 2))))
+(test-assert "not = multi" (not (s16vector= (s16vector 1 2 3)
+                                            (s16vector 1 2 3)
+                                            (s16vector 3 2 1))))
+
+
+
+(test "ref" 1 (s16vector-ref (s16vector 1 2 3) 0))
+(test "length" 3 (s16vector-length (s16vector 1 2 3)))
+
+
+
+(test-equiv "take" '(1 2) (s16vector-take s5 2))
+(test-equiv "take-right" '(4 5) (s16vector-take-right s5 2))
+(test-equiv "drop" '(3 4 5) (s16vector-drop s5 2))
+(test-equiv "drop-right" '(1 2 3) (s16vector-drop-right s5 2))
+(test "segment" (list (s16vector 1 2 3) (s16vector 4 5))
+      (s16vector-segment s5 3))
+(test "fold" -6 (s16vector-fold - 0 (s16vector 1 2 3)))
+(test "fold" '(((0 1 4) 2 5) 3 6)
+      (s16vector-fold list 0 (s16vector 1 2 3) (s16vector 4 5 6)))
+(test "fold-right" -6 (s16vector-fold-right - 0 (s16vector 1 2 3)))
+(test "fold-right" '(((0 3 6) 2 5) 1 4)
+      (s16vector-fold-right list 0 (s16vector 1 2 3) (s16vector 4 5 6)))
+(test-equiv "map" '(-1 -2 -3 -4 -5) (s16vector-map - s5))
+(test-equiv "map" '(-2 -4 -6 -8 -10) (s16vector-map - s5 s5 s5 s5))
+(let ((v (s16vector 1 2 3 4 5)))
+  (s16vector-map! - v)
+  (test-equiv "map!" '(-1 -2 -3 -4 -5) v))
+(let ((v (s16vector 1 2 3 4 5))
+      (v2 (s16vector 6 7 8 9 10)))
+  (s16vector-map! + v v2)
+  (test-equiv "map!" '(7 9 11 13 15) v))
+(let ((list '()))
+  (s16vector-for-each
+   (lambda (e) (set! list (cons e list)))
+   s5)
+  ;; stupid hack to shut up test egg about testing the value of a variable
+  (test "for-each" '(5 4 3 2 1) (cons (car list) (cdr list))))
+(let ((list '()))
+  (s16vector-for-each
+   (lambda (e1 e2) (set! list (cons (cons e1 e2) list)))
+   s5
+   (s16vector 6 7 8 9 10))
+  ;; stupid hack to shut up test egg about testing the value of a variable
+  (test "for-each" '((5 . 10) (4 . 9) (3 . 8) (2 . 7) (1 . 6))
+        (cons (car list) (cdr list))))
+(test "count" 3 (s16vector-count odd? s5))
+(test "count" 2 (s16vector-count > s5 (s16vector 9 2 1 5 3)))
+(test-equiv "cumulate" '(1 3 6 10 15)
+            (s16vector-cumulate + 0 s5))
+
+
+
+(test-equiv "take-while" '(1) (s16vector-take-while odd? s5))
+(test-equiv "take-while-right" '(5) (s16vector-take-while-right odd? s5))
+(test-equiv "drop-while" '(2 3 4 5) (s16vector-drop-while odd? s5))
+(test-equiv "drop-while-right" '(1 2 3 4) (s16vector-drop-while-right odd? s5))
+(test-equiv "degenerate take-while" '() (s16vector-take-while inexact? s5))
+(test-equiv "degenerate take-while-right" '() (s16vector-take-while-right inexact? s5))
+(test-equiv "degenerate drop-while" '(1 2 3 4 5) (s16vector-drop-while inexact? s5))
+(test-equiv "degenerate drop-while-right" '(1 2 3 4 5) (s16vector-drop-while-right inexact? s5))
+(test "index" 1 (s16vector-index even? s5))
+(test "index" 2 (s16vector-index < s5 (s16vector 0 0 10 10 0)))
+(test "index-right" 3 (s16vector-index-right even? s5))
+(test "index-right" 3 (s16vector-index-right < s5 (s16vector 0 0 10 10 0)))
+(test "skip" 1 (s16vector-skip odd? s5))
+(test "skip" 2 (s16vector-skip > s5 (s16vector 0 0 10 10 0)))
+(test "skip-right" 3 (s16vector-skip-right odd? s5))
+(test "skip-right" 3 (s16vector-skip-right > s5 (s16vector 0 0 10 10 0)))
+(test "any" 4 (s16vector-any (lambda (x) (and (even? x) (* x 2))) s5))
+(test-assert "not any" (not (s16vector-any inexact? s5)))
+(test "any + 1" 2 (s16vector-any odd+1 s5))
+(test-assert "every" (s16vector-every exact? s5))
+(test-assert "not every" (not (s16vector-every odd? s5)))
+(test-assert "every + 1" (not (s16vector-every odd+1 s5)))
+(test "multi-any" 10 (s16vector-any (lambda (x y) (and (even? x) (even? y) (+ x y)))
+                                    s5 (s16vector 0 1 2 6 4)))
+(test "multi-any 2" #f (s16vector-any (lambda (x y) (and (even? x) (even? y) (+ x y)))
+                                      s5 (s16vector 0 1 2 5 4)))
+(test "multi-every" 10 (s16vector-every (lambda (x) (and (exact? x) (* x 2))) s5))
+(test "multi-every-2" 10 (s16vector-every (lambda (x y) (and (exact? x) (exact? y) (+ x y)))
+                                          s5 s5))
+(test-assert "multi-not every" (not (s16vector-every < s5 (s16vector 10 10 10 10 0))))
+(test-equiv "partition" '(1 3 5 2 4) (s16vector-partition odd? s5))
+(test-equiv "filter" '(1 3 5) (s16vector-filter odd? s5))
+(test-equiv "remove" '(2 4) (s16vector-remove odd? s5))
+
+
+(let ((v (s16vector 1 2 3)))
+  (s16vector-set! v 0 10)
+  (test-equiv "set!" '(10 2 3) v))
+(let ((v (s16vector 1 2 3)))
+  (s16vector-swap! v 0 1)
+  (test-equiv "swap!" '(2 1 3) v))
+(let ((v (s16vector 1 2 3)))
+  (s16vector-fill! v 2)
+  (test-equiv "fill!" '(2 2 2) v))
+(let ((v (s16vector 1 2 3)))
+  (s16vector-fill! v 10 0 2)
+  (test-equiv "fill2!" '(10 10 3) v))
+(let ((v (s16vector 1 2 3)))
+  (s16vector-reverse! v)
+  (test-equiv "reverse!" '(3 2 1) v))
+(let ((v (s16vector 1 2 3)))
+  (s16vector-reverse! v 1 3)
+  (test-equiv "reverse2!" '(1 3 2) v))
+(let ((v (s16vector 10 20 30 40 50)))
+  (s16vector-copy! v 1 s5 2 4)
+  (test-equiv "copy!" '(10 3 4 40 50) v))
+(let ((v (s16vector 10 20 30 40 50)))
+  (s16vector-reverse-copy! v 1 s5 2 4)
+  (test-equiv "reverse-copy!" '(10 4 3 40 50) v))
+(let ((v (s16vector 1 2 3 4 5 6 7 8)))
+  (s16vector-unfold! (lambda (_ x) (values (* x 2) (* x 2)))
+                     v 1 6 -1)
+  (test-equiv "vector-unfold!" '(1 -2 -4 -8 -16 -32 7 8) v))
+(let ((v (s16vector 1 2 3 4 5 6 7 8)))
+  (s16vector-unfold-right! (lambda (_ x) (values (* x 2) (* x 2)))
+                           v 1 6 -1)
+  (test-equiv "vector-unfold!" '(1 -32 -16 -8 -4 -2 7 8) v))
+
+
+(test "@vector->list 1" '(1 2 3 4 5)
+      (s16vector->list s5))
+(test "@vector->list 2" '(2 3 4 5)
+      (s16vector->list s5 1))
+(test "@vector->list 3" '(2 3 4)
+      (s16vector->list s5 1 4))
+(test "@vector->vector 1" #(1 2 3 4 5)
+      (s16vector->vector s5))
+(test "@vector->vector 2" #(2 3 4 5)
+      (s16vector->vector s5 1))
+(test "@vector->vector 3" #(2 3 4)
+      (s16vector->vector s5 1 4))
+(test-equiv "list->@vector" '(1 2 3 4 5)
+            (list->s16vector '(1 2 3 4 5)))
+(test-equiv "reverse-list->@vector" '(5 4 3 2 1)
+            (reverse-list->s16vector '(1 2 3 4 5)))
+(test-equiv "vector->@vector 1" '(1 2 3 4 5)
+            (vector->s16vector #(1 2 3 4 5)))
+(test-equiv "vector->@vector 2" '(2 3 4 5)
+            (vector->s16vector #(1 2 3 4 5) 1))
+(test-equiv "vector->@vector 3" '(2 3 4)
+            (vector->s16vector #(1 2 3 4 5) 1 4))
+
+
+
+(let ((port (open-output-string)))
+  (write-s16vector s5 port)
+  (test "write-@vector" "#s16(1 2 3 4 5)" (get-output-string port))
+  (close-output-port port))
+
+(test-assert "@vector< short" (s16vector< s4 s5))
+(test-assert "not @vector< short" (not (s16vector< s5 s4)))
+(test-assert "@vector< samelen" (s16vector< s5 s5+))
+(test-assert "not @vector< samelen" (not (s16vector< s5+ s5+)))
+(test-assert "@vector=" (s16vector= s5+ s5+))
+
+;; NOTE: This tests assume we're using a specific hash function.
+;;       We'll instead build two identical vectors and check if their
+;;       hash is the same.
+;;       -- jpellegrini
+;;(test "@vector-hash" 15 (s16vector-hash s5))
+
+(define new-s5 (s16vector-copy s5))
+(define new-s4 (s16vector 1 2 3 4))
+(define new-s5+ (s16vector-copy s5+))
+
+(test "@vector-hash.1" #t (= (s16vector-hash s5)
+                             (s16vector-hash new-s5)))
+(test "@vector-hash.2" #t (= (s16vector-hash s4)
+                             (s16vector-hash new-s4)))
+(test "@vector-hash.3" #t (= (s16vector-hash s5+)
+                             (s16vector-hash new-s5+)))
+
+(define c128vector-hash (comparator-hash-function c128vector-comparator))
+
+;; The -nan part is tricky. memcmp is used to compare these, and
+;; I think we get to different bit patterns representing -nan.0 there
+;; (define x1 (c128vector  0+1.0i       +inf.0      0.0    100-25.0i (/ +0.0 +0.0)))
+;; (define x2 (c128vector  (sqrt -1.0) (/ 1 0.0) (- 1.0 1) 100-25.0i -nan.0))
+
+;; (test "@vector-hash.4" #t (= (c128vector-hash x1)
+;;                              (c128vector-hash x1)))
+
+(define x3 (c128vector  0+1.0i         0.0    100-25.0i) )
+(define x4 (c128vector  (sqrt -1.0) (- 1.0 1) 100-25.0i) )
+
+(test "@vector=, c128" #t (c128vector= x3 x4))
+(test "@vector=, c128" #t (equal? x3 x4))
+
+(test "@vector-hash.5" #t (= (c128vector-hash x3)
+                             (c128vector-hash x4)))
+
+
+
+(test "@vector-gen 0" 1 (g))
+(test "@vector-gen 1" 2 (g))
+(test "@vector-gen 2" 3 (g))
+(test "@vector-gen 3" 4 (g))
+(test "@vector-gen 4" 5 (g))
+(test-assert "@vector-gen eof" (eof-object? (g)))


### PR DESCRIPTION
Hi @egallesio !

Here's R7RS Large's  SRFI-160,  Homogeneous numeric vector libraries

This one was quite an adventure...

* This SRFI has sublibraries, so for the first time we have autotools descending into a subdir of `lib/srfi`.
* Several sublibraries are almost identical, so we generate them from a template. Using `sed` (!) in the `Makefile`.
* A relatively small C core can perform a large amount of operations that are described in the SRFI.
* Exports in the convenience module `srfi/160` are done programatically, and not using `export`.

# Summary

Adds SRFI-160, which extends SRFI 4, bringing ideas from SRFIs 152 and 133.

The SRFI requires the creation of the libraries:

- `(srfi 160 base)`,  with basic procedures
- `(srfi 160 s8)`,
  `(srfi 160 u8)`,
  `(srfi 160 s16)`,
  ...,
  `(srfi 160 c128)`,
  with more specific procedures

The modules are named `srfi/160/base`, `srfi/160/s8`, `srfi/160/u8`,  and so on.

- A `srfi/160` convenience module is also provided.

Since the motivation for someone to use uniform vectors is likely to get shorter execution times, most of the procedures
are implemented in C in `160/base.c`.

The procedures in base.c are selectively exported. The C functions accept an integer as type tag, and hence work
for all uniform vectors.

# Changes in other parts of STklos

* `reader.c`: now accepts `#c64` and `#c128` syntax for uniform complex vectors

* `stklos.h`: `UVECT_C64` and `UVECT_C128` are defined

* `uvector.c`:
  - `vector_element_size` `uvector_set` `uvector_ref` `makeuvect` now handle uniform complex vectors. Complexes are stored with their real and imaginary parts together
  - `UVECT_C64` and `UVECT_C128` are used;
  - vector_element_size uvector_set uvector_ref makeuvect are not static anymore, since they're used in base.c
  - Cmake_complex was copied from number.c
  - an `EXTERN_PRIMITIVE` for exact->inexact was added
  - now includes `<float.h>` in order to use `FLT_MAX`.

* `lib/srfi/Makefile.am`, `configure.ac` were adjusted so that the Makefile in `lib/srfi/` recursively goes into `lib/srfi/160`, *and* cleans it up when we call `Make clean`.

# SRFI installation

The SRFI defines several libraries (but not "`(srfi 160)`":

```
(srfi 160 base)
(srfi 160 s8)
(srfi 160 u8)
...
(srfi 160 c128)
```

So we need a directory structure like

```
srfi/160
srfi/160/base.c
srfi/160/base.stk
srfi/160/tagvector-template.stk
srfi/160/Makefile.am
```

That automake will later install to

```
$PREFIX/lib/base.so
$PREFIX/share/base.ostk
$PREFIX/share/s8.ostk
$PREFIX/share/u8.ostk
$PREFIX/share/s16.ostk
...
$PREFIX/share/c128.ostk
```

For this to work, I changed `lib/srfi/Makefile.am` a bit, and also added `lib/srfi/160/Makefile` to `AC_CONFIG_FILES` in `configure.ac`.

The files produced are installed in their proper places.

# Convenience  SRFI-160 module

We also add a convenience `srfi/160` module, so the user can "`(import (srfi 160))`" and have all the SRFI-160
libraries loaded.

Since "`srfi/160.stk`" was not being used by the rest of the implementation, this module was implemented there.

Technically, this is interesting:

The original `TAG.stk` files are generated from the `tagvector-template.stk` file.

```
tagvector-template.stk
  |
   \_ s8.stk
   |_ u8.stk
   ...
   |_ c128.stk
```

Each one of those exports a large quantity of symbols, so having them all in exports clauses in a single file would be somewhat clumsy.

We do this: `srfi/160` will

- import `srfi/160/base` and all `srfi/160/TAG` modules
- export the same symbols as `srfi/160/base`
- from the template export list in `tagvector-template.stk`, a new list of symbols is obtained, and we programatically go through it, adding it to the module's export list.

# Tests

The tests from the reference implementation were adapted for STklos. They need the `(srfi 160)` module, which is not part of the spec, but was added for convenience.

# PENDING ISSUES

* Without PR #398 the tests will trigger two errors. Nothing serious.
* ~We use the default hash function, which is not nie for uvectors (see issue #394)~ (fixed!)
* I'm not sure about the NaNs in uniform vectors. Should `uvector=` use `memcpy`? Different schemes will treat nan's differently: see the section "Is (/ 0.0 0.0) the same as +nan.0?" here: https://github.com/jpellegrini/surveys/blob/master/surveys/non-finite-numbers.md
