### PR TITLE
Remove extraneous parenthesis

### DIFF
--- a/lib/recette.stk
+++ b/lib/recette.stk
@@ -29,7 +29,7 @@
 (define-module recette
   (import SCHEME)
   (export
-      run-tests recette-add-test! define-test))
+      run-tests recette-add-test! define-test)
 
 
 (define *tests* '())


### PR DESCRIPTION
Commit 4f41e8b55e784c4f740c7db09b3d33677a970e58 changed this file, and included an extra closing parens, actually closing 
 the module definition earlier than what it was done before. This patch reverts that.
