### PR TITLE
Add SRFI-125: Intermediate Hash Tables

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -77,6 +77,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-116: Immutable List Library
     - SRFI-117: Queues based on lists
     - SRFI-118: Simple adjustable-size strings
+    - SRFI-125: Intermediate hash tables
     - SRFI-127: Lazy Sequences
     - SRFI-128: Comparators (reduced)
     - SRFI-129: Titlecase procedures

--- a/lib/srfi/125.stk
+++ b/lib/srfi/125.stk
@@ -1,0 +1,759 @@
+;;;;
+;;;; 125.stk            -- Implementation of SRFI-125
+;;;;
+;;;; Copyright © 2022 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by John Cowan, it is copyrighted as:
+;;;;
+;;;;;;;; Copyright (C) John Cowan (2015).
+
+;;;;;;;; Permission is hereby granted, free of charge, to any person obtaining
+;;;;;;;; a copy of this software and associated documentation
+;;;;;;;; files (the "Software"), to deal in the Software without restriction,
+;;;;;;;; including without limitation the rights to use, copy, modify, merge,
+;;;;;;;; publish, distribute, sublicense, and/or sell copies of the Software,
+;;;;;;;; and to permit persons to whom the Software is furnished to do so,
+;;;;;;;; subject to the following conditions:
+
+;;;;;;;; The above copyright notice and this permission notice shall be
+;;;;;;;; included in all copies or substantial portions of the Software.
+
+;;;;;;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;;;;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;;;;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;;;;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;;;;;;;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;;;;;;;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;;;;;;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 23-Jun-2022 10:11 (jpellegrini)
+;;;; Last file update: 24-Jun-2022 08:57 (jpellegrini)
+;;;;
+
+
+
+(define deb #f)
+(define (debug . args) (when deb (apply eprintf args)))
+
+(define-module srfi/125
+  (import (srfi 128))
+
+  (export
+
+   (rename s125:make-hash-table make-hash-table)
+   (rename s125:hash-table hash-table)
+   (rename s125:hash-table-unfold hash-table-unfold)
+   (rename s125:alist->hash-table alist->hash-table)
+   
+   (rename s125:hash-table? hash-table?)
+   (rename s125:hash-table-contains? hash-table-contains?)
+   (rename s125:hash-table-empty? hash-table-empty?)
+   (rename s125:hash-table=? hash-table=?)
+   (rename s125:hash-table-mutable? hash-table-mutable?)
+
+   (rename s125:hash-table-ref hash-table-ref)
+   (rename s125:hash-table-ref/default hash-table-ref/default)
+
+   (rename s125:hash-table-set! hash-table-set!)
+   (rename s125:hash-table-delete! hash-table-delete!)
+   (rename s125:hash-table-intern! hash-table-intern!)
+   (rename s125:hash-table-update! hash-table-update!)
+   (rename s125:hash-table-update!/default hash-table-update!/default)
+   (rename s125:hash-table-pop! hash-table-pop!)
+   (rename s125:hash-table-clear! hash-table-clear!)
+
+   (rename s125:hash-table-size hash-table-size)
+   (rename s125:hash-table-keys hash-table-keys)
+   (rename s125:hash-table-values hash-table-values)
+   (rename s125:hash-table-entries hash-table-entries)
+   (rename s125:hash-table-find hash-table-find)
+   (rename s125:hash-table-count hash-table-count)
+
+   (rename s125:hash-table-map hash-table-map)
+   (rename s125:hash-table-for-each hash-table-for-each)
+   (rename s125:hash-table-map! hash-table-map!)
+   (rename s125:hash-table-map->list hash-table-map->list)
+   (rename s125:hash-table-fold hash-table-fold)
+   (rename s125:hash-table-prune! hash-table-prune!)
+
+   (rename s125:hash-table-copy hash-table-copy)
+   (rename s125:hash-table-empty-copy hash-table-empty-copy)
+   (rename s125:hash-table->alist hash-table->alist)
+
+   (rename s125:hash-table-union! hash-table-union!)
+   (rename s125:hash-table-intersection! hash-table-intersection!)
+   (rename s125:hash-table-difference! hash-table-difference!)
+   (rename s125:hash-table-xor! hash-table-xor!)
+
+   ;; The following procedures are deprecated by SRFI 125:
+
+   (rename deprecated:hash                     hash)
+   (rename deprecated:string-hash              string-hash)
+   (rename deprecated:string-ci-hash           string-ci-hash)
+   (rename deprecated:hash-by-identity         hash-by-identity)
+
+   (rename deprecated:hash-table-equivalence-function
+                                               hash-table-equivalence-function)
+   (rename deprecated:hash-table-hash-function hash-table-hash-function)
+   (rename deprecated:hash-table-exists?       hash-table-exists?)
+   (rename deprecated:hash-table-walk          hash-table-walk)
+   (rename deprecated:hash-table-merge!        hash-table-merge!)
+
+   )
+
+(define scheme (find-module 'SCHEME))
+
+(define s:make-hash-table        (symbol-value 'make-hash-table        scheme))
+(define s:hash-table?            (symbol-value 'hash-table?            scheme))
+(define s:hash-table-size        (symbol-value 'hash-table-size        scheme))
+(define s:hash-table-exists?     (symbol-value 'hash-table-exists?     scheme))
+(define s:hash-table-set!        (symbol-value 'hash-table-set!        scheme))
+(define s:hash-table-delete!     (symbol-value 'hash-table-delete!     scheme))
+(define s:hash-table-ref         (symbol-value 'hash-table-ref         scheme))
+(define s:hash-table-ref/default (symbol-value 'hash-table-ref/default scheme))
+(define s:hash-table-fold        (symbol-value 'hash-table-fold        scheme))
+(define s:hash-table-for-each    (symbol-value 'hash-table-for-each    scheme))
+(define s:hash-table-copy        (symbol-value 'hash-table-copy        scheme))
+(define s:hash-table->alist      (symbol-value 'hash-table->alist      scheme))
+(define s:hash-table-keys        (symbol-value 'hash-table-keys        scheme))
+(define s:hash-table-values      (symbol-value 'hash-table-values      scheme))
+(define s:hash-table-size        (symbol-value 'hash-table-size        scheme))
+(define s:hash-table-hash        (symbol-value 'hash-table-hash        scheme))
+
+(define s128:default-hash        (symbol-value 'default-hash    (find-module 'srfi/128)))
+(define s128:string-hash         (symbol-value 'string-hash     (find-module 'srfi/128)))
+(define s128:string-ci-hash      (symbol-value 'string-ci-hash  (find-module 'srfi/128)))
+
+(define s:hash-table-equivalence-function
+  (symbol-value 'hash-table-equivalence-function scheme))
+(define s:hash-table-hash-function
+  (symbol-value 'hash-table-hash-function scheme))
+
+(define (issue-deprecated-warnings?) #f)
+
+(define (issue-warning-deprecated name-of-deprecated-misfeature)
+  (if (not (memq name-of-deprecated-misfeature already-warned))
+      (begin
+       (set! already-warned
+             (cons name-of-deprecated-misfeature already-warned))
+       (if (issue-deprecated-warnings?)
+           (let ((out (current-error-port)))
+             (display "WARNING: " out)
+             (display name-of-deprecated-misfeature out)
+             (newline out)
+             (display "    is deprecated by SRFI 125.  See" out)
+             (newline out)
+             (display "    " out)
+             (display url:deprecated out)
+             (newline out))))))
+
+(define url:deprecated
+  "http://srfi.schemers.org/srfi-125/srfi-125.html")
+
+; List of deprecated features for which a warning has already
+; been issued.
+
+(define already-warned '())
+
+;;; Comparators contain a type test predicate, which implementations
+;;; of the hash-table-set! procedure can use to reject invalid keys.
+;;; That's hard to do without sacrificing interoperability with R6RS
+;;; and/or SRFI 69 and/or SRFI 126 hash tables.
+;;;
+;;; Full interoperability means the hash tables implemented here are
+;;; interchangeable with the SRFI 126 hashtables used to implement them.
+;;; SRFI 69 and R6RS and SRFI 126 hashtables don't contain comparators,
+;;; so any association between a hash table and its comparator would have
+;;; to be maintained outside the representation of hash tables themselves,
+;;; which is problematic unless weak pointers are available.
+;;;
+;;; Not all of the hash tables implemented here will have comparators
+;;; associated with them anyway, because an equivalence procedure
+;;; and hash function can be used to create a hash table instead of
+;;; a comparator (although that usage is deprecated by SRFI 125).
+;;;
+;;; One way to preserve interoperability while enforcing a comparator's
+;;; type test is to incorporate that test into a hash table's hash
+;;; function.  The advantage of doing that should be weighed against
+;;; these disadvantages:
+;;;
+;;;     If the type test is slow, then hashing would also be slower.
+;;;
+;;;     The R6RS, SRFI 69, and SRFI 126 APIs allow extraction of
+;;;     a hash function from some hash tables.
+;;;     Some programmers might expect that hash function to be the
+;;;     hash function encapsulated by the comparator (in the sense
+;;;     of eq?, perhaps) even though this API makes no such guarantee
+;;;     (and extraction of that hash function from an existing hash
+;;;     table can only be done by calling a deprecated procedure).
+
+;;; If %enforce-comparator-type-tests is true, then make-hash-table,
+;;; when passed a comparator, will use a hash function that enforces
+;;; the comparator's type test.
+
+(define %enforce-comparator-type-tests #t)
+
+;;; Given a comparator, return its hash function, possibly augmented
+;;; by the comparator's type test.
+
+(define (%comparator-hash-function comparator)
+  (let ((okay? (comparator-type-test-predicate comparator))
+        (hash-function (comparator-hash-function comparator)))
+    (if %enforce-comparator-type-tests
+        (lambda (x . rest)
+          (cond ((not (okay? x))
+                 (error "key rejected by hash-table comparator"
+                        x
+                        comparator))
+                ((null? rest)
+                 (hash-function x))
+                (else
+                 (apply hash-function x rest))))
+        hash-function)))
+
+;;; A unique (in the sense of eq?) value that will never be found
+;;; within a hash-table.
+
+(define %not-found (gensym "srfi-125:not-found"))
+
+;;; A unique (in the sense of eq?) value that escapes only as an irritant
+;;; when a hash-table key is not found.
+
+(define %not-found-irritant (list 'not-found))
+
+;;; The error message used when a hash-table key is not found.
+
+(define %not-found-message "hash-table key not found")
+
+;;; FIXME: thread-safe, weak-keys, ephemeral-keys, weak-values,
+;;; and ephemeral-values are not supported by this portable
+;;; reference implementation.
+
+(define (%check-optional-arguments procname args)
+  (if (or (memq 'thread-safe args)
+          (memq 'weak-keys args)
+          (memq 'weak-values args)
+          (memq 'ephemeral-keys args)
+          (memq 'ephemeral-values args))
+      (error (string-append (symbol->string procname)
+                            ": unsupported optional argument(s)")
+             args)))
+
+;;; This was exported by an earlier draft of SRFI 125,
+;;; and is still used by hash-table=?
+
+(define (s125:hash-table-every proc ht)
+  (call-with-values
+   (lambda () (s125:hash-table-entries ht))
+   (lambda (keys vals)
+     (let loop ((keys keys)
+                (vals vals))
+       (if (null? keys)
+           #t
+           (let* ((key (car keys))
+                  (val (car vals))
+                  (x   (proc key val)))
+             (and x
+                  (loop (cdr keys)
+                        (cdr vals)))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Exported procedures
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Constructors.
+
+;;; The first argument can be a comparator or an equality predicate.
+;;;
+;;; If the first argument is a comparator, any remaining arguments
+;;; are implementation-dependent, but a non-negative exact integer
+;;; should be interpreted as an initial capacity and the symbols
+;;; thread-safe, weak-keys, ephemeral-keys, weak-values, and
+;;; emphemeral-values should be interpreted specially.  (These
+;;; special symbols are distinct from the analogous special symbols
+;;; in SRFI 126.)
+;;;
+;;; If the first argument is not a comparator, then it had better
+;;; be an equality predicate (which is deprecated by SRFI 125).
+;;; If a second argument is present and is a procedure, then it's
+;;; a hash function (which is allowed only for the deprecated case
+;;; in which the first argument is an equality predicate).  If a
+;;; second argument is not a procedure, then it's some kind of
+;;; implementation-dependent optional argument, as are all arguments
+;;; beyond the second.
+;;;
+;;; SRFI 128 defines make-eq-comparator, make-eqv-comparator, and
+;;; make-equal-comparator procedures whose hash function is the
+;;; default-hash procedure of SRFI 128, which is inappropriate
+;;; for use with eq? and eqv? unless the object being hashed is
+;;; never mutated.  Neither SRFI 125 nor 128 provide any way to
+;;; define a comparator whose hash function is truly compatible
+;;; with the use of eq? or eqv? as an equality predicate.
+;;;
+;;; That would make SRFI 125 almost as bad as SRFI 69 if not for
+;;; the following paragraph of SRFI 125:
+;;;
+;;;     Implementations are permitted to ignore user-specified
+;;;     hash functions in certain circumstances. Specifically,
+;;;     if the equality predicate, whether passed as part of a
+;;;     comparator or explicitly, is more fine-grained (in the
+;;;     sense of R7RS-small section 6.1) than equal?, the
+;;;     implementation is free — indeed, is encouraged — to
+;;;     ignore the user-specified hash function and use something
+;;;     implementation-dependent. This allows the use of addresses
+;;;     as hashes, in which case the keys must be rehashed if
+;;;     they are moved by the garbage collector. Such a hash
+;;;     function is unsafe to use outside the context of
+;;;     implementation-provided hash tables. It can of course be
+;;;     exposed by an implementation as an extension, with
+;;;     suitable warnings against inappropriate uses.
+;;;
+;;; That gives implementations permission to do something more
+;;; useful, but when should implementations take advantage of
+;;; that permission?  This implementation uses the superior
+;;; solution provided by SRFI 126 whenever:
+;;;
+;;;     A comparator is passed as first argument and its equality
+;;;     predicate is eq? or eqv?.
+;;;
+;;;     The eq? or eqv? procedure is passed as first argument
+;;;     (which is a deprecated usage).
+
+(define (s125:make-hash-table comparator/equiv . rest)
+  (debug "enter s125:make-hash-table, rest = ~a~%" rest)
+  (if (comparator? comparator/equiv)
+      (let ((equiv (comparator-equality-predicate comparator/equiv))
+            (hash-function (%comparator-hash-function comparator/equiv)))
+        (debug "s125:make-hash-table CASE 1~%")
+        (let ((x
+               (%%make-hash-table equiv hash-function rest))
+              )
+          (debug "s125:make-hash-table END~%") x))
+      (let* ((equiv comparator/equiv)
+             (hash-function (if (and (not (null? rest))
+                                     (procedure? (car rest)))
+                                (car rest)
+                                #f))
+             (rest (if hash-function (cdr rest) rest)))
+        (issue-warning-deprecated 'srfi-69-style:make-hash-table)
+        (debug "s125:make-hash-table CASE 2~%")
+        (%%make-hash-table equiv hash-function rest))))
+
+;; We'll trust STklos' hash-table-hash to do the right thing, and define
+;; equal-hash and symbol-hash as synonyms to it.
+;;
+;; Maybe string-hash and string-ci-hash should also be treated the same way?
+(define equal-hash  s:hash-table-hash)
+(define symbol-hash s:hash-table-hash)
+
+;; there's already a primitive called %make-hash-table, so we include
+;; an extra '%' here...
+(define (%%make-hash-table equiv hash-function opts)
+  (%check-optional-arguments 'make-hash-table opts)
+  (debug "enter %make-hash-table, opts = ~a~%" opts)
+  (cond ((eq? equiv eq?)
+         (s:make-hash-table eq?))
+        ((eq? equiv eqv?)
+         (s:make-hash-table eqv?))
+        (hash-function
+         (s:make-hash-table equiv hash-function))
+        ((eq? equiv equal?)
+         (s:make-hash-table equiv equal-hash))
+        ((eq? equiv string=?)
+         (s:make-hash-table equiv s128:string-hash))
+        ((eq? equiv string-ci=?)
+         (s:make-hash-table equiv s128:string-ci-hash))
+        ((eq? equiv symbol=?)
+         (s:make-hash-table equiv symbol-hash))
+        (else
+         (error "make-hash-table: unable to infer hash function"
+                equiv))))
+
+(define (s125:hash-table comparator . rest)
+  (let ((ht (apply s125:make-hash-table comparator rest)))
+    (let loop ((kvs rest))
+      (cond
+       ((null? kvs) #f)
+       ((null? (cdr kvs)) (error "hash-table: wrong number of arguments"))
+       ((s:hash-table-exists? ht (car kvs))
+        (error "hash-table: two equivalent keys were provided"
+               (car kvs)))
+       (else (s:hash-table-set! ht (car kvs) (cadr kvs))
+             (loop (cddr kvs)))))
+    (s:hash-table-copy ht)))
+
+(define (s125:hash-table-unfold stop? mapper successor seed comparator . rest)
+  (let ((ht (apply s125:make-hash-table comparator rest)))
+    (let loop ((seed seed))
+      (if (stop? seed)
+          ht
+          (call-with-values
+           (lambda () (mapper seed))
+           (lambda (key val)
+             (s:hash-table-set! ht key val)
+             (loop (successor seed))))))))
+
+(define (s125:alist->hash-table alist comparator/equiv . rest)
+  (if (and (not (null? rest))
+           (procedure? (car rest)))
+      (issue-warning-deprecated 'srfi-69-style:alist->hash-table))
+  (let ((ht (apply s125:make-hash-table comparator/equiv rest))
+        (entries (reverse alist)))
+    (for-each (lambda (entry)
+                (s:hash-table-set! ht (car entry) (cdr entry)))
+              entries)
+    ht))
+
+;;; Predicates.
+
+(define s125:hash-table?  s:hash-table?)
+
+(define s125:hash-table-contains? s:hash-table-exists?)
+
+(define (s125:hash-table-empty? ht)
+  (= 0 (s:hash-table-size ht)))
+
+;;; FIXME: walks both hash tables because their key comparators
+;;; might be different
+
+(define (s125:hash-table=? value-comparator ht1 ht2)
+  (let ((val=? (comparator-equality-predicate value-comparator))
+        (n1 (s125:hash-table-size ht1))
+        (n2 (s125:hash-table-size ht2)))
+    (and (= n1 n2)
+         (s125:hash-table-every (lambda (key val1)
+                                  (and (s:hash-table-exists? ht2 key)
+                                       (val=? val1
+                                              (s:hash-table-ref ht2 key 'ignored))))
+                                ht1)
+         (s125:hash-table-every (lambda (key val2)
+                                  (and (s:hash-table-exists? ht1 key)
+                                       (val=? val2
+                                              (s:hash-table-ref ht1 key 'ignored))))
+                                ht2))))
+
+;;; FIXME: pending implementation of immutable hashtables
+;;;
+(define (s125:hash-table-mutable? ht) #t)
+;;  (hashtable-mutable? ht))
+
+;;; Accessors.
+
+(define (s125:hash-table-ref ht key . rest)
+  (let ((failure (if (null? rest) #f (car rest)))
+        (success (if (or (null? rest) (null? (cdr rest))) #f (cadr rest)))
+        (val (s:hash-table-ref ht key (lambda () %not-found))))
+    (cond ((eq? val %not-found)
+           (if (and failure (procedure? failure))
+               (failure)
+               (error %not-found-message ht key %not-found-irritant)))
+          (success
+           (success val))
+          (else
+           val))))
+
+(define (s125:hash-table-ref/default ht key default)
+  (s:hash-table-ref/default ht key default))
+
+;;; Mutators.
+
+(define (s125:hash-table-set! ht . rest)
+  (if (= 2 (length rest))
+      (s:hash-table-set! ht (car rest) (cadr rest))
+      (let loop ((kvs rest))
+        (cond ((and (not (null? kvs))
+                    (not (null? (cdr kvs))))
+               (s:hash-table-set! ht (car kvs) (cadr kvs))
+               (loop (cddr kvs)))
+              ((not (null? kvs))
+               (error "hash-table-set!: wrong number of arguments"
+                      (cons ht rest)))))))
+
+(define (s125:hash-table-delete! ht . keys)
+  (let loop ((keys keys) (cnt 0))
+    (cond ((null? keys) cnt)
+	  ((s:hash-table-exists? ht (car keys))
+	   (s:hash-table-delete! ht (car keys))
+	   (loop (cdr keys) (+ cnt 1)))
+	  (else
+	   (loop (cdr keys) cnt)))))
+
+(define (s125:hash-table-intern! ht key failure)
+  (if (s:hash-table-exists? ht key)
+      (s125:hash-table-ref ht key)
+      (let ((val (failure)))
+        (s125:hash-table-set! ht key val)
+        val)))
+
+(define (s125:hash-table-update! ht key updater . rest)
+  (s125:hash-table-set! ht
+                   key
+                   (updater (apply s125:hash-table-ref ht key rest))))
+
+(define (s125:hash-table-update!/default ht key updater default)
+  (s125:hash-table-set! ht key (updater (s:hash-table-ref/default ht key default))))
+
+(define (s125:hash-table-pop! ht)
+  (call/cc
+    (lambda (return)
+      (s125:hash-table-for-each
+        (lambda (key value)
+          (s125:hash-table-delete! ht key)
+          (return key value))
+        ht)
+      (error "hash-table-pop!: hash table is empty" ht))))
+
+;; FIXME: maybe a primitive would be better, so we could just
+;;        deallocate the table's internal vector and not have to
+;;        iterate over the keys?
+(define (s125:hash-table-clear! ht)
+  (let ((keys (s:hash-table-keys ht)))
+    (for-each (lambda (k) (s:hash-table-delete! ht k))
+              keys)))
+
+;;; The whole hash table.
+
+(define s125:hash-table-size s:hash-table-size)
+
+(define s125:hash-table-keys s:hash-table-keys)
+
+(define s125:hash-table-values s:hash-table-values)
+
+(define (s125:hash-table-entries ht)
+    (values (s:hash-table-keys ht)
+            (s:hash-table-values ht)))
+
+(define (s125:hash-table-find proc ht failure)
+  (call-with-values
+   (lambda () (s125:hash-table-entries ht))
+   (lambda (keys vals)
+     (let loop ((keys keys)
+                (vals vals))
+       (if (null? keys)
+           (failure)
+           (let* ((key (car keys))
+                  (val (car vals))
+                  (x   (proc key val)))
+             (or x
+                 (loop (cdr keys)
+                       (cdr vals)))))))))
+
+(define (s125:hash-table-count pred ht)
+  (call-with-values
+      (lambda () (s125:hash-table-entries ht))
+    (lambda (keys vals)
+      (let loop ((keys keys)
+                 (vals vals)
+                 (n 0))
+        (if (null? keys)
+            n
+            (let* ((key (car keys))
+                   (val (car vals))
+                   (x   (pred key val)))
+              (loop (cdr keys)
+                    (cdr vals)
+                    (if x (+ n 1) n))))))))
+
+;;; Mapping and folding.
+
+(define (s125:hash-table-map proc comparator ht)
+  (let ((result (s125:make-hash-table comparator)))
+    (s125:hash-table-for-each
+     (lambda (key val)
+       (s125:hash-table-set! result key (proc val)))
+     ht)
+    result))
+
+(define (s125:hash-table-map->list proc ht)
+  (call-with-values
+      (lambda () (s125:hash-table-entries ht))
+    (lambda (keys vals)
+      (map proc keys vals))))
+
+;;; With this particular implementation, the proc can safely mutate ht.
+;;; That property is not guaranteed by the specification, but can be
+;;; relied upon by procedures defined in this file.
+
+
+(define (s125:hash-table-for-each proc h)
+  (debug "enter s125:hash-table-for-each~%") ;; DEBUG
+  ;;(%display-backtrace (%vm-backtrace) 3)   ;; DEBUG
+  (s:hash-table-for-each h proc))
+
+;; Original code, from reference implementation:
+;; (define (hash-table-for-each proc ht)
+;;   (call-with-values
+;;    (lambda () (hashtable-entries ht))
+;;    (lambda (keys vals)
+;;      (vector-for-each proc keys vals))))
+
+(define (s125:hash-table-map! proc ht)
+  (s125:hash-table-for-each (lambda (key val)
+                              (s:hash-table-set! ht key (proc key val)))
+                            ht))
+
+(define (s125:hash-table-fold proc init ht)
+  (if (s:hash-table? proc)
+      (deprecated:hash-table-fold proc init ht)
+      (s:hash-table-fold ht proc init)))
+
+      ;; Original code, from reference implementation:
+      ;; (call-with-values
+      ;;  (lambda () (hash-table-entries ht))
+      ;;  (lambda (keys vals)
+      ;;    (let loop ((keys keys)
+      ;;               (vals vals)
+      ;;               (x    init))
+      ;;      (if (null? keys)
+      ;;          x
+      ;;          (loop (cdr keys)
+      ;;                (cdr vals)
+      ;;                (proc (car keys) (car vals) x))))))))
+
+(define (s125:hash-table-prune! proc ht)
+  (s125:hash-table-for-each (lambda (key val)
+                              (if (proc key val)
+                                  (s:hash-table-delete! ht key)))
+                            ht))
+
+;;; Copying and conversion.
+
+(define (s125:hash-table-copy ht . rest)
+  ;; FIXME: we do not support immutable hash tables. This should be easy
+  ;; to add.
+  (s:hash-table-copy ht))
+
+;; FIXME: This copies the entire hashtable! It'd be better to create a
+;; primitive for this
+(define (s125:hash-table-empty-copy ht)
+  (let* ((ht2 (s:hash-table-copy ht)) ;; FIXME: should not be immutable?
+         (ignored (s125:hash-table-clear! ht2)))
+    ht2))
+
+(define s125:hash-table->alist s:hash-table->alist)
+
+;; Original code, from reference implementation:
+;; (define (hash-table->alist ht)
+;;   (call-with-values
+;;    (lambda () (hash-table-entries ht))
+;;    (lambda (keys vals)
+;;      (map cons keys vals))))
+
+;;; Hash tables as sets.
+
+(define (s125:hash-table-union! ht1 ht2)
+  (s125:hash-table-for-each
+   (lambda (key2 val2)
+     (if (not (s:hash-table-exists? ht1 key2))
+         (s:hash-table-set! ht1 key2 val2)))
+   ht2)
+  ht1)
+
+(define (s125:hash-table-intersection! ht1 ht2)
+  (s125:hash-table-for-each
+   (lambda (key1 val1)
+     (if (not (s:hash-table-exists? ht2 key1))
+         (s:hash-table-delete! ht1 key1)))
+   ht1)
+  ht1)
+
+(define (s125:hash-table-difference! ht1 ht2)
+  (s125:hash-table-for-each
+   (lambda (key1 val1)
+     (if (s:hash-table-exists? ht2 key1)
+         (s:hash-table-delete! ht1 key1)))
+   ht1)
+  ht1)
+
+(define (s125:hash-table-xor! ht1 ht2)
+  (s125:hash-table-for-each
+   (lambda (key2 val2)
+     (if (s:hash-table-exists? ht1 key2)
+         (s:hash-table-delete! ht1 key2)
+         (s:hash-table-set! ht1 key2 val2)))
+   ht2)
+  ht1)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; The following procedures are deprecated by SRFI 125, but must
+;;; be exported nonetheless.
+;;;
+;;; Programs that import the (srfi 125) library must rename the
+;;; deprecated string-hash and string-ci-hash procedures to avoid
+;;; conflict with the string-hash and string-ci-hash procedures
+;;; exported by SRFI 126 and SRFI 128.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; We use STklos' default hash instead of the one available in
+;; SRFI 128 reference implementation, except for the string-ci-hash,
+;; which must be different.
+
+(define (deprecated:hash obj . rest)
+  (issue-warning-deprecated 'hash)
+  (s:hash-table-hash obj))
+  ;;(s128:default-hash obj))
+
+(define (deprecated:string-hash obj . rest)
+  (issue-warning-deprecated 'srfi-125:string-hash)
+  (s:hash-table-hash obj))
+  ;;(s128:string-hash obj))
+
+(define (deprecated:string-ci-hash obj . rest)
+  (issue-warning-deprecated 'srfi-125:string-ci-hash)
+  (s128:string-ci-hash obj))
+
+(define (deprecated:hash-by-identity obj . rest)
+  (issue-warning-deprecated 'hash-by-identity)
+  (s:hash-table-hash obj))
+  ;;(s128:default-hash obj))
+
+(define (deprecated:hash-table-equivalence-function ht)
+  (issue-warning-deprecated 'hash-table-equivalence-function)
+  (s:hash-table-equivalence-function ht))
+
+(define (deprecated:hash-table-hash-function ht)
+  (issue-warning-deprecated 'hash-table-hash-function)
+  (s:hash-table-hash-function ht))
+
+(define (deprecated:hash-table-exists? ht key)
+  (issue-warning-deprecated 'hash-table-exists?)
+  (s:hash-table-exists? ht key))
+
+(define (deprecated:hash-table-walk ht proc)
+  (issue-warning-deprecated 'hash-table-walk)
+  (s125:hash-table-for-each proc ht))
+
+(define (deprecated:hash-table-fold ht proc seed)
+  (issue-warning-deprecated 'srfi-69-style:hash-table-fold)
+  (s125:hash-table-fold proc seed ht))
+
+(define (deprecated:hash-table-merge! ht1 ht2)
+  (issue-warning-deprecated 'hash-table-merge!)
+  (s125:hash-table-union! ht1 ht2))
+
+) ;; END of module srfi/125
+
+
+(provide "srfi/125")

--- a/lib/srfi/125.stk
+++ b/lib/srfi/125.stk
@@ -147,32 +147,6 @@
 (define s:hash-table-hash-function
   (symbol-value 'hash-table-hash-function scheme))
 
-(define (issue-deprecated-warnings?) #f)
-
-(define (issue-warning-deprecated name-of-deprecated-misfeature)
-  (if (not (memq name-of-deprecated-misfeature already-warned))
-      (begin
-       (set! already-warned
-             (cons name-of-deprecated-misfeature already-warned))
-       (if (issue-deprecated-warnings?)
-           (let ((out (current-error-port)))
-             (display "WARNING: " out)
-             (display name-of-deprecated-misfeature out)
-             (newline out)
-             (display "    is deprecated by SRFI 125.  See" out)
-             (newline out)
-             (display "    " out)
-             (display url:deprecated out)
-             (newline out))))))
-
-(define url:deprecated
-  "http://srfi.schemers.org/srfi-125/srfi-125.html")
-
-; List of deprecated features for which a warning has already
-; been issued.
-
-(define already-warned '())
-
 ;;; Comparators contain a type test predicate, which implementations
 ;;; of the hash-table-set! procedure can use to reject invalid keys.
 ;;; That's hard to do without sacrificing interoperability with R6RS
@@ -355,7 +329,6 @@
                                 (car rest)
                                 #f))
              (rest (if hash-function (cdr rest) rest)))
-        (issue-warning-deprecated 'srfi-69-style:make-hash-table)
         (debug "s125:make-hash-table CASE 2~%")
         (%%make-hash-table equiv hash-function rest))))
 
@@ -414,9 +387,6 @@
              (loop (successor seed))))))))
 
 (define (s125:alist->hash-table alist comparator/equiv . rest)
-  (if (and (not (null? rest))
-           (procedure? (car rest)))
-      (issue-warning-deprecated 'srfi-69-style:alist->hash-table))
   (let ((ht (apply s125:make-hash-table comparator/equiv rest))
         (entries (reverse alist)))
     (for-each (lambda (entry)
@@ -711,47 +681,33 @@
 ;; which must be different.
 
 (define (deprecated:hash obj . rest)
-  (issue-warning-deprecated 'hash)
   (s:hash-table-hash obj))
   ;;(s128:default-hash obj))
 
 (define (deprecated:string-hash obj . rest)
-  (issue-warning-deprecated 'srfi-125:string-hash)
   (s:hash-table-hash obj))
   ;;(s128:string-hash obj))
 
 (define (deprecated:string-ci-hash obj . rest)
-  (issue-warning-deprecated 'srfi-125:string-ci-hash)
   (s128:string-ci-hash obj))
 
 (define (deprecated:hash-by-identity obj . rest)
-  (issue-warning-deprecated 'hash-by-identity)
   (s:hash-table-hash obj))
   ;;(s128:default-hash obj))
 
-(define (deprecated:hash-table-equivalence-function ht)
-  (issue-warning-deprecated 'hash-table-equivalence-function)
-  (s:hash-table-equivalence-function ht))
+(define deprecated:hash-table-equivalence-function s:hash-table-equivalence-function)
+(define deprecated:hash-table-hash-function s:hash-table-hash-function)
+(define deprecated:hash-table-exists? s:hash-table-exists?)
 
-(define (deprecated:hash-table-hash-function ht)
-  (issue-warning-deprecated 'hash-table-hash-function)
-  (s:hash-table-hash-function ht))
-
-(define (deprecated:hash-table-exists? ht key)
-  (issue-warning-deprecated 'hash-table-exists?)
-  (s:hash-table-exists? ht key))
-
+;; must change argument order!
 (define (deprecated:hash-table-walk ht proc)
-  (issue-warning-deprecated 'hash-table-walk)
   (s125:hash-table-for-each proc ht))
 
+;; must change argument order!
 (define (deprecated:hash-table-fold ht proc seed)
-  (issue-warning-deprecated 'srfi-69-style:hash-table-fold)
   (s125:hash-table-fold proc seed ht))
 
-(define (deprecated:hash-table-merge! ht1 ht2)
-  (issue-warning-deprecated 'hash-table-merge!)
-  (s125:hash-table-union! ht1 ht2))
+(define deprecated:hash-table-merge! s125:hash-table-union!)
 
 ) ;; END of module srfi/125
 

--- a/lib/srfi/125.stk
+++ b/lib/srfi/125.stk
@@ -50,9 +50,6 @@
 
 
 
-(define deb #f)
-(define (debug . args) (when deb (apply eprintf args)))
-
 (define-module srfi/125
   (import (srfi 128))
 
@@ -127,6 +124,7 @@
 (define s:hash-table-exists?     (symbol-value 'hash-table-exists?     scheme))
 (define s:hash-table-set!        (symbol-value 'hash-table-set!        scheme))
 (define s:hash-table-delete!     (symbol-value 'hash-table-delete!     scheme))
+(define s:hash-table-clear!      (symbol-value 'hash-table-clear!      scheme))
 (define s:hash-table-ref         (symbol-value 'hash-table-ref         scheme))
 (define s:hash-table-ref/default (symbol-value 'hash-table-ref/default scheme))
 (define s:hash-table-fold        (symbol-value 'hash-table-fold        scheme))
@@ -137,6 +135,8 @@
 (define s:hash-table-values      (symbol-value 'hash-table-values      scheme))
 (define s:hash-table-size        (symbol-value 'hash-table-size        scheme))
 (define s:hash-table-hash        (symbol-value 'hash-table-hash        scheme))
+
+(define s125:hash-table-mutable? (symbol-value 'hash-table-mutable?    scheme))
 
 (define s128:default-hash        (symbol-value 'default-hash    (find-module 'srfi/128)))
 (define s128:string-hash         (symbol-value 'string-hash     (find-module 'srfi/128)))
@@ -314,22 +314,16 @@
 ;;;     (which is a deprecated usage).
 
 (define (s125:make-hash-table comparator/equiv . rest)
-  (debug "enter s125:make-hash-table, rest = ~a~%" rest)
   (if (comparator? comparator/equiv)
       (let ((equiv (comparator-equality-predicate comparator/equiv))
             (hash-function (%comparator-hash-function comparator/equiv)))
-        (debug "s125:make-hash-table CASE 1~%")
-        (let ((x
-               (%%make-hash-table equiv hash-function rest))
-              )
-          (debug "s125:make-hash-table END~%") x))
+        (%%make-hash-table equiv hash-function rest))
       (let* ((equiv comparator/equiv)
              (hash-function (if (and (not (null? rest))
                                      (procedure? (car rest)))
                                 (car rest)
                                 #f))
              (rest (if hash-function (cdr rest) rest)))
-        (debug "s125:make-hash-table CASE 2~%")
         (%%make-hash-table equiv hash-function rest))))
 
 ;; We'll trust STklos' hash-table-hash to do the right thing, and define
@@ -343,7 +337,6 @@
 ;; an extra '%' here...
 (define (%%make-hash-table equiv hash-function opts)
   (%check-optional-arguments 'make-hash-table opts)
-  (debug "enter %make-hash-table, opts = ~a~%" opts)
   (cond ((eq? equiv eq?)
          (s:make-hash-table eq?))
         ((eq? equiv eqv?)
@@ -373,7 +366,8 @@
                (car kvs)))
        (else (s:hash-table-set! ht (car kvs) (cadr kvs))
              (loop (cddr kvs)))))
-    (s:hash-table-copy ht)))
+    (hash-table-immutable! ht)
+    ht))
 
 (define (s125:hash-table-unfold stop? mapper successor seed comparator . rest)
   (let ((ht (apply s125:make-hash-table comparator rest)))
@@ -422,10 +416,6 @@
                                               (s:hash-table-ref ht1 key 'ignored))))
                                 ht2))))
 
-;;; FIXME: pending implementation of immutable hashtables
-;;;
-(define (s125:hash-table-mutable? ht) #t)
-;;  (hashtable-mutable? ht))
 
 ;;; Accessors.
 
@@ -446,6 +436,8 @@
   (s:hash-table-ref/default ht key default))
 
 ;;; Mutators.
+
+(define s125:hash-table-clear!  s:hash-table-clear!)
 
 (define (s125:hash-table-set! ht . rest)
   (if (= 2 (length rest))
@@ -492,14 +484,6 @@
           (return key value))
         ht)
       (error "hash-table-pop!: hash table is empty" ht))))
-
-;; FIXME: maybe a primitive would be better, so we could just
-;;        deallocate the table's internal vector and not have to
-;;        iterate over the keys?
-(define (s125:hash-table-clear! ht)
-  (let ((keys (s:hash-table-keys ht)))
-    (for-each (lambda (k) (s:hash-table-delete! ht k))
-              keys)))
 
 ;;; The whole hash table.
 
@@ -566,16 +550,7 @@
 
 
 (define (s125:hash-table-for-each proc h)
-  (debug "enter s125:hash-table-for-each~%") ;; DEBUG
-  ;;(%display-backtrace (%vm-backtrace) 3)   ;; DEBUG
   (s:hash-table-for-each h proc))
-
-;; Original code, from reference implementation:
-;; (define (hash-table-for-each proc ht)
-;;   (call-with-values
-;;    (lambda () (hashtable-entries ht))
-;;    (lambda (keys vals)
-;;      (vector-for-each proc keys vals))))
 
 (define (s125:hash-table-map! proc ht)
   (s125:hash-table-for-each (lambda (key val)
@@ -587,18 +562,6 @@
       (deprecated:hash-table-fold proc init ht)
       (s:hash-table-fold ht proc init)))
 
-      ;; Original code, from reference implementation:
-      ;; (call-with-values
-      ;;  (lambda () (hash-table-entries ht))
-      ;;  (lambda (keys vals)
-      ;;    (let loop ((keys keys)
-      ;;               (vals vals)
-      ;;               (x    init))
-      ;;      (if (null? keys)
-      ;;          x
-      ;;          (loop (cdr keys)
-      ;;                (cdr vals)
-      ;;                (proc (car keys) (car vals) x))))))))
 
 (define (s125:hash-table-prune! proc ht)
   (s125:hash-table-for-each (lambda (key val)
@@ -608,26 +571,20 @@
 
 ;;; Copying and conversion.
 
-(define (s125:hash-table-copy ht . rest)
-  ;; FIXME: we do not support immutable hash tables. This should be easy
-  ;; to add.
-  (s:hash-table-copy ht))
+(define (s125:hash-table-copy ht :optional (mutable? #f))
+  (let ((ht (s:hash-table-copy ht)))
+    (unless mutable?
+      (hash-table-immutable! ht))
+    ht))
 
 ;; FIXME: This copies the entire hashtable! It'd be better to create a
 ;; primitive for this
 (define (s125:hash-table-empty-copy ht)
-  (let* ((ht2 (s:hash-table-copy ht)) ;; FIXME: should not be immutable?
-         (ignored (s125:hash-table-clear! ht2)))
+  (let* ((ht2 (s:hash-table-copy ht)))
+    (s:hash-table-clear! ht2)
     ht2))
 
 (define s125:hash-table->alist s:hash-table->alist)
-
-;; Original code, from reference implementation:
-;; (define (hash-table->alist ht)
-;;   (call-with-values
-;;    (lambda () (hash-table-entries ht))
-;;    (lambda (keys vals)
-;;      (map cons keys vals))))
 
 ;;; Hash tables as sets.
 

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -270,6 +270,7 @@ $(DEPEND_9): 9.ostk
 94.ostk: 60.ostk
 95.ostk:  132.ostk 132.$(SO)
 113.ostk: 128.ostk
+125.ostk: 128.ostk
 130.ostk: 13.ostk
 133.ostk: ../stklos/itrie.so
 134.ostk: 158.ostk

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -85,6 +85,7 @@ SRC_STK   = 1.stk   \
             113.stk \
             117.stk \
             118.stk \
+            125.stk \
             127.stk \
             128.stk \
             129.stk \
@@ -179,6 +180,7 @@ SRC_OSTK =  1.ostk   \
             117.ostk \
             118.ostk \
             113.ostk \
+            125.ostk \
             127.ostk \
             128.ostk \
             129.ostk \

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -399,6 +399,7 @@ SRC_STK = 1.stk   \
             113.stk \
             117.stk \
             118.stk \
+            125.stk \
             127.stk \
             128.stk \
             129.stk \
@@ -493,6 +494,7 @@ SRC_OSTK = 1.ostk   \
             117.ostk \
             118.ostk \
             113.ostk \
+            125.ostk \
             127.ostk \
             128.ostk \
             129.ostk \

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -163,7 +163,7 @@
     ;; 122  Nonempty Intervals and Generalized Arrays
     ;; 123  Generic accessor and modifier operators
     ;; 124  Ephemerons
-    ;; 125  Intermediate hash tables
+    (125 "Intermediate hash tables" (hash-table) "srfi-125")
     ;; 126  R6RS-based hashtables
     (127 "Lazy Sequences" (lazy-sequences) "srfi-127")
     (128 "Comparators (reduced)" (comparators-reduced) "srfi-128")

--- a/src/hash.c
+++ b/src/hash.c
@@ -826,6 +826,26 @@ DEFINE_PRIMITIVE("hash-table-delete!", hash_delete, subr2, (SCM ht, SCM key))
   return STk_void;
 }
 
+DEFINE_PRIMITIVE("hash-table-clear!", hash_clear, subr1, (SCM ht))
+{
+  if (!HASHP(ht)) error_bad_hash_table(ht);
+
+  /* We could either clear the fields that are not to be kept from the
+     hashtable, one at a time, or select the fields to be kept,
+     re-initialize and restore what needs to be restored. We chose
+     the second approach. */
+  hash_type type = HASH_TYPE(ht);
+  SCM comparison = HASH_COMPAR(ht);
+  SCM hash_fct   = HASH_HASH(ht);
+
+  STk_hashtable_init ((struct hash_table_obj *)ht, BOXED_INFO(ht));
+
+  HASH_TYPE(ht)   = type;
+  HASH_COMPAR(ht) = comparison;
+  HASH_HASH(ht)   = hash_fct;
+
+  return STk_void;
+}
 
 
 /*
@@ -981,6 +1001,7 @@ int STk_init_hash(void)
   ADD_PRIMITIVE(hash_existp);
 
   ADD_PRIMITIVE(hash_delete);
+  ADD_PRIMITIVE(hash_clear);
 
   ADD_PRIMITIVE(hash_for_each);
   ADD_PRIMITIVE(hash_map);

--- a/tests/srfis/125.stk
+++ b/tests/srfis/125.stk
@@ -512,14 +512,17 @@
                   '(169 144 121 0 1 4 9 16 25 36 49 64 75 81)))
       '(13 12 11 0 1 2 3 4 5 -1 -1 8 -1 -1))
 
-(let ((ht-eg (hash-table number-comparator 1 1 4 2 9 3 16 4 25 5 64 8)))
+(let* ((ht-eg* (hash-table number-comparator 1 1 4 2 9 3 16 4 25 5 64 8))
+       (ht-eg (hash-table-copy ht-eg* #t))) ;; mutable
   (test* "srfi-125.36" (hash-table-delete! ht-eg)
         0)
   (test* "srfi-125.37" (hash-table-delete! ht-eg 2 7 2000)
         0)
   (test* "srfi-125.38" (hash-table-delete! ht-eg 1 2 4 7 64 2000)
         3)
-  (test-assert (= 3 (length (hash-table-keys ht-eg)))))
+  (test* "srfi-125.38.5"
+         (length (hash-table-keys ht-eg))
+         3))
 
 (test* "srfi-125.39" (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
            '(169 144 121 0 1 4 9 16 25 36 49 64 81))

--- a/tests/srfis/125.stk
+++ b/tests/srfis/125.stk
@@ -1,0 +1,982 @@
+;;;;
+;;;; Tests for SRFI-125
+;;;;
+;;;; Copyright © 2022 Jeronimo Pellegrini - <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;; This file is a derivative work from the  implementation of
+;;;; this SRFI by Will Clinger, it is copyrighted as:
+
+;;; Copyright (C) William D Clinger 2015. All Rights Reserved.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without restriction,
+;;; including without limitation the rights to use, copy, modify, merge,
+;;; publish, distribute, sublicense, and/or sell copies of the Software,
+;;; and to permit persons to whom the Software is furnished to do so,
+;;; subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+;;; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+;;; CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+;;; This is a very shallow sanity test for hash tables.
+;;;
+;;; Tests marked by a "FIXME: glass-box" comment test behavior of the
+;;; reference implementation that is not required by the specification.
+
+
+
+;;; We will run the tests in a module, so as to not interfere
+;;; with other tests.
+;;; HOWEVER -- this is a workaround. The real problem is that
+;;; SRFI 125 changes the parameter order of some procedures, and
+;;; STklos uses those internally.
+;;; When one imports SRFI 125, it should not change the internal
+;;; bindings used by STklos.
+
+(define-module test/srfi/125
+  
+(import ;SCHEME
+        ;scheme base)
+        ;(scheme char)
+        ;(scheme write)
+        ;(only (scheme process-context) exit)
+        
+        ;;(scheme comparator)            ; was (srfi 128)
+        (srfi 128)
+        ;;(only (scheme sort) list-sort) ; was (r6rs sorting)
+        (only (srfi 132) list-sort)
+        (rename (srfi 125)
+                (string-hash    deprecated:string-hash)
+                (string-ci-hash deprecated:string-ci-hash)))
+(export do-tests)
+
+
+(define (writeln . xs)
+  (for-each write xs)
+  (newline))
+
+(define (displayln . xs)
+  (for-each display xs)
+  (newline))
+
+(define ultimate-exit-status 0)
+
+(define (fail token . more)
+  (set! ultimate-exit-status 1)
+  (displayln "Error: test failed: ")
+  (writeln token)
+  (if (not (null? more))
+      (for-each writeln more))
+  (newline)
+  #f)
+
+;;; FIXME: when debugging catastrophic failures, printing every expression
+;;; before it's executed may help.
+
+;; (define-syntax test
+;;   (syntax-rules ()
+;;    ((_ expr expected)
+;;     (let ()
+;; ;     (write 'expr) (newline)
+;;       (let ((actual expr))
+;;         (or (equal? actual expected)
+;;             (fail 'expr actual expected)))))))
+
+(define-syntax test*
+  (syntax-rules ()
+    ((_ name expr res)
+     (test name res expr))))
+
+;; (define-syntax test-assert
+;;   (syntax-rules ()
+;;    ((_ expr)
+;;     (or expr (fail 'expr)))))
+
+(define-syntax test-assert
+  (syntax-rules ()
+   ((_ expr)
+    (test "--" #f (not expr)))))
+
+;; (define-syntax test-deny
+;;   (syntax-rules ()
+;;    ((_ expr)
+;;     (or (not expr) (fail 'expr)))))
+
+(define-syntax test-deny
+  (syntax-rules ()
+   ((_ expr)
+    (test "--" #t (not expr)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Transition from SRFI 114 to SRFI 128.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define default-comparator (make-default-comparator))
+
+;;; SRFI 128 says the following definition will work, but that's
+;;; an error in SRFI 128; the hash function produce non-integers.
+
+#;
+(define number-comparator
+  (make-comparator real? = < (lambda (x) (exact (abs x)))))
+
+(define number-comparator
+  (make-comparator real? = < (lambda (x) (exact (abs (round x))))))
+
+(define string-comparator
+  (make-comparator string? string=? string<? string-hash))
+
+(define string-ci-comparator
+  (make-comparator string? string-ci=? string-ci<? string-ci-hash))
+
+(define eq-comparator (make-eq-comparator))
+
+(define eqv-comparator (make-eqv-comparator))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Transition from earlier draft of SRFI 125 to this draft.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Returns an immutable hash table.
+
+(define (hash-table-tabulate comparator n proc)
+  (let ((ht (make-hash-table comparator)))
+    (do ((i 0 (+ i 1)))
+        ((= i n)
+         (hash-table-copy ht))
+      (call-with-values
+       (lambda ()
+         (proc i))
+       (lambda (key val)
+         (hash-table-set! ht key val))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Constructors.
+
+(define ht-default (make-hash-table default-comparator))
+
+(define ht-eq (make-hash-table eq-comparator 'random-argument "another"))
+
+(define ht-eqv (make-hash-table eqv-comparator))
+
+(define ht-eq2 (make-hash-table eq?))
+
+(define ht-eqv2 (make-hash-table eqv?))
+
+(define ht-equal (make-hash-table equal?))
+
+(define ht-string (make-hash-table string=?))
+
+(define ht-string-ci (make-hash-table string-ci=?))
+
+(define ht-symbol (make-hash-table symbol=?))    ; FIXME: glass-box
+
+(define ht-fixnum (make-hash-table = abs))
+
+(define ht-default2
+  (hash-table default-comparator 'foo 'bar 101.3 "fever" '(x y z) '#()))
+
+(define ht-fixnum2
+  (hash-table-tabulate number-comparator
+                       10
+                       (lambda (i) (values (* i i) i))))
+
+(define ht-string2
+  (hash-table-unfold (lambda (s) (= 0 (string-length s)))
+                     (lambda (s) (values s (string-length s)))
+                     (lambda (s) (substring s 0 (- (string-length s) 1)))
+                     "prefixes"
+                     string-comparator
+                     'ignored1 'ignored2 "ignored3" '#(ignored 4 5)))
+
+(define ht-string-ci2
+  (alist->hash-table '(("" . 0) ("Mary" . 4) ("Paul" . 4) ("Peter" . 5))
+                     string-ci-comparator
+                     "ignored1" 'ignored2))
+
+(define ht-symbol2
+  (alist->hash-table '((mary . travers) (noel . stookey) (peter .yarrow))
+                     eq?))
+
+(define ht-equal2
+  (alist->hash-table '(((edward) . abbey)
+                       ((dashiell) . hammett)
+                       ((edward) . teach)
+                       ((mark) . twain))
+                     equal?
+                     (comparator-hash-function default-comparator)))
+
+(define test-tables
+  (list ht-default   ht-default2   ; initial keys: foo, 101.3, (x y z)
+        ht-eq        ht-eq2        ; initially empty
+        ht-eqv       ht-eqv2       ; initially empty
+        ht-equal     ht-equal2     ; initial keys: (edward), (dashiell), (mark)
+        ht-string    ht-string2    ; initial keys: "p, "pr", ..., "prefixes"
+        ht-string-ci ht-string-ci2 ; initial keys: "", "Mary", "Paul", "Peter"
+        ht-symbol    ht-symbol2    ; initial keys: mary, noel, peter
+        ht-fixnum    ht-fixnum2))  ; initial keys: 0, 1, 4, 9, ..., 81
+
+
+(define (do-tests)
+
+;;; Predicates
+
+(test* "srfi-125.1" (map hash-table?
+                         (cons '#()
+                               (cons default-comparator
+                                     test-tables)))
+       (append '(#f #f) (map (lambda (x) #t) test-tables)))
+
+(test* "srfi-125.2" (map hash-table-contains?
+           test-tables
+           '(foo 101.3
+             x "y"
+             (14 15) #\newline
+             (edward) (mark)
+             "p" "pref"
+             "mike" "PAUL"
+             jane noel
+             0 4))
+      '(#f #t #f #f #f #f #f #t #f #t #f #t #f #t #f #t))
+
+(test* "srfi-125.3" (map hash-table-contains?
+           test-tables
+           '(#u8() 47.9
+             '#() '()
+             foo bar
+             19 (henry)
+             "p" "perp"
+             "mike" "Noel"
+             jane paul
+             0 5))
+      (map (lambda (x) #f) test-tables))
+
+(test* "srfi-125.4" (map hash-table-empty? test-tables)
+      '(#t #f #t #t #t #t #t #f #t #f #t #f #t #f #t #f))
+
+(test* "srfi-125.5" (map (lambda (ht1 ht2) (hash-table=? default-comparator ht1 ht2))
+           test-tables
+           test-tables)
+      (map (lambda (x) #t) test-tables))
+
+(test* "srfi-125.6" (map (lambda (ht1 ht2) (hash-table=? default-comparator ht1 ht2))
+           test-tables
+           (do ((tables (reverse test-tables) (cddr tables))
+                (rev '() (cons (car tables) (cons (cadr tables) rev))))
+               ((null? tables)
+                rev)))
+      '(#f #f #t #t #t #t #f #f #f #f #f #f #f #f #f #f))
+
+(test* "srfi-125.7" (map hash-table-mutable? test-tables)
+      '(#t #f #t #t #t #t #t #t #t #t #t #t #t #t #t #f))
+
+;;; FIXME: glass-box
+
+(test* "srfi-125.8" (map hash-table-mutable? (map hash-table-copy test-tables))
+      (map (lambda (x) #f) test-tables))
+
+(test* "srfi-125.9" (hash-table-mutable? (hash-table-copy ht-fixnum2 #t))
+      #t)
+
+;;; Accessors.
+
+;;; FIXME: glass-box (implementations not required to raise an exception here)
+
+(test* "srfi-125.10" (map (lambda (ht)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref ht 'not-a-key)))
+           test-tables)
+      (map (lambda (ht) 'err) test-tables))
+
+;;; FIXME: glass-box (implementations not required to raise an exception here)
+
+(test* "srfi-125.11" (map (lambda (ht)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref ht 'not-a-key (lambda () 'err))))
+           test-tables)
+      (map (lambda (ht) 'err) test-tables))
+
+;;; FIXME: glass-box (implementations not required to raise an exception here)
+
+(test* "srfi-125.12" (map (lambda (ht)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref ht 'not-a-key (lambda () 'err) values)))
+           test-tables)
+      (map (lambda (ht) 'err) test-tables))
+
+(test* "srfi-125.13" (map (lambda (ht key)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref ht key)))
+           test-tables
+           '(foo 101.3
+             x "y"
+             (14 15) #\newline
+             (edward) (mark)
+             "p" "pref"
+             "mike" "PAUL"
+             jane noel
+             0 4))
+      '(err "fever" err err err err err twain err 4 err 4 err stookey err 2))
+
+(test* "srfi-125.14"
+       (map (lambda (ht key)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref ht key (lambda () 'eh))))
+           test-tables
+           '(foo 101.3
+             x "y"
+             (14 15) #\newline
+             (edward) (mark)
+             "p" "pref"
+             "mike" "PAUL"
+             jane noel
+             0 4))
+      '(eh "fever" eh eh eh eh eh twain eh 4 eh 4 eh stookey eh 2))
+
+(test* "srfi-125.15" (map (lambda (ht key)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref ht key (lambda () 'eh) list)))
+           test-tables
+           '(foo 101.3
+             x "y"
+             (14 15) #\newline
+             (edward) (mark)
+             "p" "pref"
+             "mike" "PAUL"
+             jane noel
+             0 4))
+      '(eh ("fever") eh eh eh eh eh (twain) eh (4) eh (4) eh (stookey) eh (2)))
+
+;;; FIXME: glass-box (implementations not required to raise an exception here)
+
+(test* "srfi-125.16" (map (lambda (ht)
+             (guard (exn
+                     (else 'eh))
+              (hash-table-ref/default ht 'not-a-key 'eh)))
+           test-tables)
+      (map (lambda (ht) 'eh) test-tables))
+
+(test* "srfi-125.17" (map (lambda (ht key)
+             (guard (exn
+                     (else 'err))
+              (hash-table-ref/default ht key 'eh)))
+           test-tables
+           '(foo 101.3
+             x "y"
+             (14 15) #\newline
+             (edward) (mark)
+             "p" "pref"
+             "mike" "PAUL"
+             jane noel
+             0 4))
+      '(eh "fever" eh eh eh eh eh twain eh 4 eh 4 eh stookey eh 2))
+
+(test* "srfi-125.18" (begin (hash-table-set! ht-fixnum)
+              (list-sort < (hash-table-keys ht-fixnum)))
+      '())
+
+(test* "srfi-125.19" (begin (hash-table-set! ht-fixnum 121 11 144 12 169 13)
+             (list-sort < (hash-table-keys ht-fixnum)))
+      '(121 144 169))
+
+(test* "srfi-125.20" (begin (hash-table-set! ht-fixnum
+                              0 0 1 1 4 2 9 3 16 4 25 5 36 6 49 7 64 8 81 9)
+             (list-sort < (hash-table-keys ht-fixnum)))
+      '(0 1 4 9 16 25 36 49 64 81 121 144 169))
+
+(test* "srfi-125.21"
+       (map (lambda (i) (hash-table-ref/default ht-fixnum i 'error))
+            '(169 144 121 0 1 4 9 16 25 36 49 64 81))
+      '(13 12 11 0 1 2 3 4 5 6 7 8 9))
+
+(test* "srfi-125.22"
+       (begin (hash-table-delete! ht-fixnum)
+              (map (lambda (i) (hash-table-ref/default ht-fixnum i 'error))
+                   '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 3 4 5 6 7 8 9))
+
+(test* "srfi-125.23"
+       (begin (hash-table-delete! ht-fixnum 1 9 25 49 81 200 121 169 81 1)
+                            (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                                 '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+       '(-1 12 -1 0 -1 2 -1 4 -1 6 -1 8 -1))
+
+(test* "srfi-125.24" (begin (hash-table-delete! ht-fixnum 200 100 0 81 36)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(-1 12 -1 -1 -1 2 -1 4 -1 -1 -1 8 -1))
+
+(test* "srfi-125.25" (begin (hash-table-intern! ht-fixnum 169 (lambda () 13))
+             (hash-table-intern! ht-fixnum 121 (lambda () 11))
+             (hash-table-intern! ht-fixnum   0 (lambda ()  0))
+             (hash-table-intern! ht-fixnum   1 (lambda ()  1))
+             (hash-table-intern! ht-fixnum   1 (lambda () 99))
+             (hash-table-intern! ht-fixnum 121 (lambda () 66))
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 -1 4 -1 -1 -1 8 -1))
+
+(test* "srfi-125.26" (list-sort (lambda (v1 v2) (< (vector-ref v1 0) (vector-ref v2 0)))
+                 (hash-table-map->list vector ht-fixnum))
+      '(#(0 0) #(1 1) #(4 2) #(16 4) #(64 8) #(121 11) #(144 12) #(169 13)))
+
+(test* "srfi-125.27" (begin (hash-table-prune! (lambda (key val)
+                                  (and (odd? key) (> val 10)))
+                                ht-fixnum)
+             (list-sort (lambda (l1 l2)
+                          (< (car l1) (car l2)))
+                        (hash-table-map->list list ht-fixnum)))
+      '((0 0) (1 1) (4 2) (16 4) (64 8) #;(121 11) (144 12) #;(169 13)))
+
+(test* "srfi-125.28" (begin (hash-table-intern! ht-fixnum 169 (lambda () 13))
+             (hash-table-intern! ht-fixnum 144 (lambda () 9999))
+             (hash-table-intern! ht-fixnum 121 (lambda () 11))
+             (list-sort (lambda (l1 l2)
+                          (< (car l1) (car l2)))
+                        (hash-table-map->list list ht-fixnum)))
+      '((0 0) (1 1) (4 2) (16 4) (64 8) (121 11) (144 12) (169 13)))
+
+(test* "srfi-125.29" (begin (hash-table-update! ht-fixnum 9 length (lambda () '(a b c)))
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 3 4 -1 -1 -1 8 -1))
+
+(test* "srfi-125.30" (begin (hash-table-update! ht-fixnum 16 -)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 3 -4 -1 -1 -1 8 -1))
+
+(test* "srfi-125.31" (begin (hash-table-update! ht-fixnum 16 - abs)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 3 4 -1 -1 -1 8 -1))
+
+(test* "srfi-125.32"
+       (begin (hash-table-update!/default ht-fixnum 25 - 5)
+              (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                   '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+       '(13 12 11 0 1 2 3 4 -5 -1 -1 8 -1))
+
+(test* "srfi-125.33" (begin (hash-table-update!/default ht-fixnum 25 - 999)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 3 4 5 -1 -1 8 -1))
+
+(test* "srfi-125.34" (let* ((n0 (hash-table-size ht-fixnum))
+             (ht (hash-table-copy ht-fixnum #t)))
+        (call-with-values
+         (lambda () (hash-table-pop! ht))
+         (lambda (key val)
+           (list (= key (* val val))
+                 (= (- n0 1) (hash-table-size ht))))))
+      '(#t #t))
+
+(test* "srfi-125.35" (begin (hash-table-delete! ht-fixnum 75)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 75 81)))
+      '(13 12 11 0 1 2 3 4 5 -1 -1 8 -1 -1))
+
+(let ((ht-eg (hash-table number-comparator 1 1 4 2 9 3 16 4 25 5 64 8)))
+  (test* "srfi-125.36" (hash-table-delete! ht-eg)
+        0)
+  (test* "srfi-125.37" (hash-table-delete! ht-eg 2 7 2000)
+        0)
+  (test* "srfi-125.38" (hash-table-delete! ht-eg 1 2 4 7 64 2000)
+        3)
+  (test-assert (= 3 (length (hash-table-keys ht-eg)))))
+
+(test* "srfi-125.39" (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+           '(169 144 121 0 1 4 9 16 25 36 49 64 81))
+      '(13 12 11 0 1 2 3 4 5 -1 -1 8 -1))
+
+(test* "srfi-125.40" (begin (hash-table-set! ht-fixnum 36 6)
+             (hash-table-set! ht-fixnum 81 9)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(169 144 121 0 1 4 9 16 25 36 49 64 81)))
+      '(13 12 11 0 1 2 3 4 5 6 -1 8 9))
+
+(test* "srfi-125.41"
+       (begin (hash-table-clear! ht-eq)
+             (hash-table-size ht-eq))
+      0)
+
+;;; The whole hash table.
+
+(test* "srfi-125.42" (begin (hash-table-set! ht-eq 'foo 13 'bar 14 'baz 18)
+             (hash-table-size ht-eq))
+      3)
+
+(test* "srfi-125.43"
+       (let* ((ht (hash-table-empty-copy ht-eq))
+             (n0 (hash-table-size ht))
+             (ignored (hash-table-set! ht 'foo 13 'bar 14 'baz 18))
+             (n1 (hash-table-size ht)))
+        (list n0 n1 (hash-table=? default-comparator ht ht-eq)))
+      '(0 3 #t))
+
+(test* "srfi-125.44" (begin (hash-table-clear! ht-eq)
+             (hash-table-size ht-eq))
+      0)
+
+(test* "srfi-125.45" (hash-table-find (lambda (key val)
+                         (if (= 144 key (* val val))
+                             (list key val)
+                             #f))
+                       ht-fixnum
+                       (lambda () 99))
+      '(144 12))
+
+(test* "srfi-125.46" (hash-table-find (lambda (key val)
+                         (if (= 144 key val)
+                             (list key val)
+                             #f))
+                       ht-fixnum
+                       (lambda () 99))
+      99)
+
+(test* "srfi-125.47" (hash-table-count <= ht-fixnum)
+      2)
+
+;;; Mapping and folding.
+
+(test* "srfi-125.48" (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+           '(0 1 4 9 16 25 36 49 64 81 100 121 144 169 196))
+      '(0 1 2 3 4 5 6 -1 8 9 -1 11 12 13 -1))
+
+(test* "srfi-125.49" (let ((ht (hash-table-map (lambda (val) (* val val))
+                                eqv-comparator
+                                ht-fixnum)))
+        (map (lambda (i) (hash-table-ref/default ht i -1))
+             '(0 1 4 9 16 25 36 49 64 81 100 121 144 169 196)))
+      '(0 1 4 9 16 25 36 -1 64 81 -1 121 144 169 -1))
+
+(test* "srfi-125.50" (let ((keys (make-vector 15 -1))
+            (vals (make-vector 15 -1)))
+        (hash-table-for-each (lambda (key val)
+                               (vector-set! keys val key)
+                               (vector-set! vals val val))
+                             ht-fixnum)
+        (list keys vals))
+      '(#(0 1 4 9 16 25 36 -1 64 81 -1 121 144 169 -1)
+        #(0 1 2 3  4  5  6 -1  8  9 -1  11  12  13 -1)))
+
+(test* "srfi-125.51" (begin (hash-table-map! (lambda (key val)
+                                (if (<= 10 key)
+                                    (- val)
+                                    val))
+                              ht-fixnum)
+             (map (lambda (i) (hash-table-ref/default ht-fixnum i -1))
+                  '(0 1 4 9 16 25 36 49 64 81 100 121 144 169 196)))
+      '(0 1 2 3 -4 -5 -6 -1 -8 -9 -1 -11 -12 -13 -1))
+
+(test* "srfi-125.52" (hash-table-fold (lambda (key val acc)
+                         (+ val acc))
+                       0
+                       ht-string-ci2)
+      13)
+
+(test* "srfi-125.53" (list-sort < (hash-table-fold (lambda (key val acc)
+                                      (cons key acc))
+                                    '()
+                                    ht-fixnum))
+      '(0 1 4 9 16 25 36 64 81 121 144 169))
+
+;;; Copying and conversion.
+
+(test* "srfi-125.54" (hash-table=? number-comparator ht-fixnum (hash-table-copy ht-fixnum))
+      #t)
+
+(test* "srfi-125.55" (hash-table=? number-comparator ht-fixnum (hash-table-copy ht-fixnum #f))
+      #t)
+
+(test* "srfi-125.56" (hash-table=? number-comparator ht-fixnum (hash-table-copy ht-fixnum #t))
+      #t)
+
+(test* "srfi-125.57" (hash-table-mutable? (hash-table-copy ht-fixnum))
+      #f)
+
+(test* "srfi-125.58" (hash-table-mutable? (hash-table-copy ht-fixnum #f))
+      #f)
+
+(test* "srfi-125.59" (hash-table-mutable? (hash-table-copy ht-fixnum #t))
+      #t)
+
+(test* "srfi-125.60" (hash-table->alist ht-eq)
+      '())
+
+(test* "srfi-125.61" (list-sort (lambda (x y) (< (car x) (car y)))
+                 (hash-table->alist ht-fixnum))
+      '((0 . 0)
+        (1 . 1)
+        (4 . 2)
+        (9 . 3)
+        (16 . -4)
+        (25 . -5)
+        (36 . -6)
+        (64 . -8)
+        (81 . -9)
+        (121 . -11)
+        (144 . -12)
+        (169 . -13)))
+
+;;; Hash tables as sets.
+
+(test* "srfi-125.62" (begin (hash-table-union! ht-fixnum ht-fixnum2)
+             (list-sort (lambda (x y) (< (car x) (car y)))
+                        (hash-table->alist ht-fixnum)))
+      '((0 . 0)
+        (1 . 1)
+        (4 . 2)
+        (9 . 3)
+        (16 . -4)
+        (25 . -5)
+        (36 . -6)
+        (49 . 7)
+        (64 . -8)
+        (81 . -9)
+        (121 . -11)
+        (144 . -12)
+        (169 . -13)))
+
+(test* "srfi-125.63" (let ((ht (hash-table-copy ht-fixnum2 #t)))
+        (hash-table-union! ht ht-fixnum)
+        (list-sort (lambda (x y) (< (car x) (car y)))
+                   (hash-table->alist ht)))
+      '((0 . 0)
+        (1 . 1)
+        (4 . 2)
+        (9 . 3)
+        (16 . 4)
+        (25 . 5)
+        (36 . 6)
+        (49 . 7)
+        (64 . 8)
+        (81 . 9)
+        (121 . -11)
+        (144 . -12)
+        (169 . -13)))
+
+(test* "srfi-125.64" (begin (hash-table-union! ht-eqv2 ht-fixnum)
+             (hash-table=? default-comparator ht-eqv2 ht-fixnum))
+      #t)
+
+(test* "srfi-125.65" (begin (hash-table-intersection! ht-eqv2 ht-fixnum)
+             (hash-table=? default-comparator ht-eqv2 ht-fixnum))
+      #t)
+
+(test* "srfi-125.66" (begin (hash-table-intersection! ht-eqv2 ht-eqv)
+             (hash-table-empty? ht-eqv2))
+      #t)
+
+(test* "srfi-125.67" (begin (hash-table-intersection! ht-fixnum ht-fixnum2)
+             (list-sort (lambda (x y) (< (car x) (car y)))
+                        (hash-table->alist ht-fixnum)))
+      '((0 . 0)
+        (1 . 1)
+        (4 . 2)
+        (9 . 3)
+        (16 . -4)
+        (25 . -5)
+        (36 . -6)
+        (49 . 7)
+        (64 . -8)
+        (81 . -9)))
+
+(test* "srfi-125.68" (begin (hash-table-intersection!
+              ht-fixnum
+              (alist->hash-table '((-1 . -1) (4 . 202) (25 . 205) (100 . 10))
+                                 number-comparator))
+             (list-sort (lambda (x y) (< (car x) (car y)))
+                        (hash-table->alist ht-fixnum)))
+      '((4 . 2)
+        (25 . -5)))
+
+(test* "srfi-125.69" (let ((ht (hash-table-copy ht-fixnum2 #t)))
+        (hash-table-difference!
+         ht
+         (alist->hash-table '((-1 . -1) (4 . 202) (25 . 205) (100 . 10))
+                            number-comparator))
+        (list-sort (lambda (x y) (< (car x) (car y)))
+                   (hash-table->alist ht)))
+      '((0 . 0)
+        (1 . 1)
+        (9 . 3)
+        (16 . 4)
+        (36 . 6)
+        (49 . 7)
+        (64 . 8)
+        (81 . 9)))
+
+(test* "srfi-125.70"(let ((ht (hash-table-copy ht-fixnum2 #t)))
+        (hash-table-xor!
+         ht
+         (alist->hash-table '((-1 . -1) (4 . 202) (25 . 205) (100 . 10))
+                            number-comparator))
+        (list-sort (lambda (x y) (< (car x) (car y)))
+                   (hash-table->alist ht)))
+      '((-1 . -1)
+        (0 . 0)
+        (1 . 1)
+        (9 . 3)
+        (16 . 4)
+        (36 . 6)
+        (49 . 7)
+        (64 . 8)
+        (81 . 9)
+        (100 . 10)))
+
+(test* "srfi-125.71" (guard (exn
+              (else 'key-not-found))
+       (hash-table-ref ht-default "this key won't be present"))
+      'key-not-found)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Desultory tests of deprecated procedures and usages.
+;;; Deprecated usage of make-hash-table and alist->hash-table
+;;; has already been tested above.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(test* "srfi-125.72" (let* ((x (list 1 2 3))
+             (y (cons 1 (cdr x)))
+             (h1 (hash x))
+             (h2 (hash y)))
+        (list (exact-integer? h1)
+              (exact-integer? h2)
+              (= h1 h2)))
+      '(#t #t #t))
+
+(test* "srfi-125.73" (let* ((x "abcd")
+             (y (string-append "ab" "cd"))
+             (h1 (deprecated:string-hash x))
+             (h2 (deprecated:string-hash y)))
+        (list (exact-integer? h1)
+              (exact-integer? h2)
+              (= h1 h2)))
+      '(#t #t #t))
+
+(test* "srfi-125.74" (let* ((x "Hello There!")
+             (y "hello THERE!")
+             (h1 (deprecated:string-ci-hash x))
+             (h2 (deprecated:string-ci-hash y)))
+        (list (exact-integer? h1)
+              (exact-integer? h2)
+              (= h1 h2)))
+      '(#t #t #t))
+
+(test* "srfi-125.75"
+       (let* ((x '#(a "bcD" #\c (d 2.718) -42 #u8() #() #u8(19 20)))
+              (y x)
+              (h1 (hash-by-identity x))
+              (h2 (hash-by-identity y)))
+         (list (exact-integer? h1)
+               (exact-integer? h2)
+               (= h1 h2)))
+       '(#t #t #t))
+
+(test* "srfi-125.76" (let* ((x (list 1 2 3))
+             (y (cons 1 (cdr x)))
+             (h1 (hash x 60))
+             (h2 (hash y 60)))
+        (list (exact-integer? h1)
+              (exact-integer? h2)
+              (= h1 h2)))
+      '(#t #t #t))
+
+(test* "srfi-125.77" (let* ((x "abcd")
+             (y (string-append "ab" "cd"))
+             (h1 (deprecated:string-hash x 97))
+             (h2 (deprecated:string-hash y 97)))
+        (list (exact-integer? h1)
+              (exact-integer? h2)
+              (= h1 h2)))
+      '(#t #t #t))
+
+(test* "srfi-125.78"
+       (let* ((x "Hello There!")
+             (y "hello THERE!")
+             (h1 (deprecated:string-ci-hash x 101))
+             (h2 (deprecated:string-ci-hash y 101)))
+        (list (exact-integer? h1)
+              (exact-integer? h2)
+              (= h1 h2)))
+      '(#t #t #t))
+
+(test* "srfi-125.79"
+       (let* ((x '#(a "bcD" #\c (d 2.718) -42 #u8() #() #u8(19 20)))
+              (y x)
+              (h1 (hash-by-identity x 102))
+              (h2 (hash-by-identity y 102)))
+         (list (exact-integer? h1)
+               (exact-integer? h2)
+               (= h1 h2)))
+       '(#t #t #t))
+
+(test* "srfi-125.80" (let ((f (hash-table-equivalence-function ht-fixnum)))
+        (if (procedure? f)
+            (f 34 34)
+            #t))
+      #t)
+
+(test* "srfi-125.81" (let ((f (hash-table-hash-function ht-fixnum)))
+        (if (procedure? f)
+            (= (f 34) (f 34))
+            #t))
+      #t)
+
+(test* "srfi-125.82"
+       (map (lambda (key) (hash-table-exists? ht-fixnum2 key))
+           '(0 1 2 3 4 5 6 7 8 9 10))
+      '(#t #t #f #f #t #f #f #f #f #t #f))
+
+(test* "srfi-125.83" (let ((n 0))
+        (hash-table-walk ht-fixnum2
+                         (lambda (key val) (set! n (+ n key))))
+        n)
+      (apply +
+             (map (lambda (x) (* x x))
+                  '(0 1 2 3 4 5 6 7 8 9))))
+
+(test* "srfi-125.84" (list-sort < (hash-table-fold ht-fixnum2
+                                    (lambda (key val acc)
+                                      (cons key acc))
+                                    '()))
+      '(0 1 4 9 16 25 36 49 64 81))
+
+(test* "srfi-125.85" (let ((ht (hash-table-copy ht-fixnum2 #t))
+            (ht2 (hash-table number-comparator
+                             .25 .5 64 9999 81 9998 121 -11 144 -12)))
+        (hash-table-merge! ht ht2)
+        (list-sort (lambda (x y) (< (car x) (car y)))
+                   (hash-table->alist ht)))
+      '((0 . 0)
+        (.25 . .5)
+        (1 . 1)
+        (4 . 2)
+        (9 . 3)
+        (16 . 4)
+        (25 . 5)
+        (36 . 6)
+        (49 . 7)
+        (64 . 8)
+        (81 . 9)
+        (121 . -11)
+        (144 . -12)))
+
+;;; Bugs reported on 5 January 2019 by Jéssica Milaré
+;;; ( https://srfi-email.schemers.org/srfi-125/msg/10177551 )
+
+;;; Spec says hash-table returns an immutable hash table (if that
+;;; is supported) and signal an error if there are duplicate keys,
+;;; but standard implementation returns a mutable hash table and
+;;; signals no error with duplicate keys.
+;;;
+;;; Comment by Will Clinger: the spec says specifying a duplicate
+;;; key "is an error", so hash-table is not required to signal an
+;;; error when there are duplicate keys.  That part of the spec
+;;; was added on 8 May 2016, which is why it was not implemented
+;;; by the sample implementation of 2 May 2016.  Because a duplicate
+;;; key "is an error" rather than "signals an error", testing for
+;;; that situation is glass-box, as is testing for immutability.
+
+;;; FIXME: glass-box
+
+(test* "srfi-125.86" (hash-table-mutable?
+       (hash-table number-comparator
+                   .25 .5 64 9999 81 9998 121 -11 144 -12))
+      #f)
+
+;;; FIXME: glass-box (implementations not required to raise an exception here)
+
+(test* "srfi-125.87" (guard (exn
+              (else 'eh))
+       (hash-table number-comparator .25 .5 .25 -.5))
+      'eh)
+
+;;; Spec says hash-table-set! must go left to right, but in
+;;; standard implementation it goes right to left.
+;;;
+;;; Comment by Will Clinger: the left-to-right requirement was
+;;; added to the spec on 8 May 2016, which is why it was not
+;;; implemented by the sample implementation of 2 May 2016.
+
+(test* "srfi-125.88" (let* ((ht (hash-table-empty-copy ht-eq))
+             (ignored (hash-table-set! ht 'foo 13 'bar 14 'foo 18)))
+        (hash-table-ref ht 'foo))
+      18)
+
+;;; Spec says hash-table-empty-copy returns a mutable hash table,
+;;; but in standard implementation it returns an immutable hash
+;;; table if the given hash table is immutable.
+
+;;; FIXME: glass-box (immutable tables need not be supported)
+
+(test* "srfi-125.89" (hash-table-mutable?
+       (hash-table number-comparator))
+      #f)
+
+(test* "srfi-125.90" (hash-table-mutable?
+       (hash-table-empty-copy
+        (hash-table-copy (hash-table number-comparator) #f)))
+      #t)
+
+;;; hash-table-delete! seems to loop infinitely once it finds a key.
+;;;
+;;; Comment by Will Clinger: that bug was added by
+;;; commit e17c15203a934ab741300e59619f880f363c2b2f
+;;; on 26 September 2018.  I do not understand the purpose of that
+;;; commit, as its one change appears to have had no substantive
+;;; effect apart from inserting this bug.
+
+(test* "srfi-125.91" (let* ((ht
+              (hash-table default-comparator 'foo 1 'bar 2 'baz 3))
+             (ht (hash-table-copy ht #t)))
+        (hash-table-delete! ht 'foo)
+        (hash-table-size ht))
+      2)
+
+))
+
+(select-module test/srfi/125)
+(do-tests)
+(select-module STklos)
+;;(displayln "Done.")
+
+;;(exit ultimate-exit-status)


### PR DESCRIPTION
Hi @egallesio !

Here's R7RS large hashtables... There are still some issues, and it actually needs immutable hashtables (PR #383 ).


- This implmentation directly uses STklos' hashtable API (and doesn't even load SRFI 69)

- In srfis.stk, the alias given is the one defined for it in R7RS/Large Tangerine Edition ("hash-table"). But this doesn't (yet) make it possible to do (import (scheme hash-table)). Maybe later.

Not perfect yet:

- ~SRFI 125 requires immutable hashtbles, which STklos doesn't yet have;~ we have those now :)

- Maybe ~`hash-table-clear!`~ and `hash-table-empty-copy` could be implemented as primitives? They do excessive work because there's no way to remove all data in a hash table. But would it be OK to implement them in core, or d owe create a C sublibrary just for them? UPDATE: I added a patch for `hash-table-clear!`. I'm not sure if having a primitive for `hash-table-empty-copy` is that interesting...

- ~The implementation has some deprecation warning code. Maybe it'd be better to remove it~ ok, already did...

- For some reason, when we define `make-hash-table` in the module, then STklos internal code starts using it and gets confused because the procedure signature changed. The solution I found was to rename all symbols inernally, prepending `s125:` to them, and then renaming on export -- but this is a workaround...
