### PR TITLE
autoload: delete wrapper after autoloading (this patch should not work, but... it does!?)

### DIFF
--- a/lib/load.stk
+++ b/lib/load.stk
@@ -515,13 +515,24 @@ doc>
         (old  (gensym)))
     `(begin
        ,@(map (lambda (x)
-                `(define ,x (lambda ,args
-                              (let ((,old ,x))
-                                (require ,file)
-                                (if (eq? ,old ,x)
-                                    (error 'autoload "~S has not been defined in ~S"
-                                           ',x ,file)
-                                    (apply ,x ,args))))))
+                (let ((x-found (gensym
+                                  (string-append "%%"
+                                                 (symbol->string x)
+                                                 "-found"))))
+                  (list 'begin
+                   `(define ,x-found #f)
+                   `(define ,x (lambda ,args
+                                 (let ((,old ,x))
+                                   (require ,file)
+                                   (if (eq? ,old ,x)
+                                       (error 'autoload "~S has not been defined in ~S"
+                                              ',x ,file)
+                                       (begin (set! ,x-found #t)
+                                              (apply ,x ,args))))))
+                   ;; If it was found, remove the previous definition of x
+                   ;; and bind it to its proper value in its module:
+                   `(when ,x-found
+                      (define ,x ,x-found)))))
               symbols))))
 
 ; LocalWords:  repl autoload prepended


### PR DESCRIPTION
@egallesio - this is weird.
This patch is not suppsoed to work,  but it works!

Autoload was keeping a wrapper over the procedures to be loaded, and this was slowing down the execution in some cases. This changes the autoload macro to do remember if the file was really loaded (if the binding changed) and issue a `(set! name binding)` *outside* the definition of the wrapper:

```scheme
(macro-expand '(autoload "srfi/27"      random-integer random-real))

(begin
  (begin
    (define %%random-integer-found3 #f)
    (define random-integer
      (lambda G1 (let ((G2 random-integer))
              (require "srfi/27")
              (if (eq? G2 random-integer)
                  (error 'autoload "~S has not been defined in ~S" 'random-integer "srfi/27")
                  (begin (set! %%random-integer-found3 #t)
                         (apply random-integer G1))))))
    (when %%random-integer-found3
      (define random-integer %%random-integer-found3)))
  
  (begin
    (define %%random-real-found4 #f)
    (define random-real
      (lambda G1 (let ((G2 random-real))
              (require "srfi/27")
              (if (eq? G2 random-real)
                  (error 'autoload "~S has not been defined in ~S"
                         'random-real "srfi/27")
                  (begin (set! %%random-real-found4 #t)
                         (apply random-real G1))))))
    (when %%random-real-found4
      (define random-real %%random-real-found4))))
```

However, since the `(when %%random-integer-found3 ...)` is ***outside*** the `define`, it should ***not*** be triggered when the wrapper is called.  So it should not work at all!

But it does!

```
;;;; Fresh start of STklos
stklos> (define rr random-real)
;; rr
stklos> (random-real)
0.786820954867802
stklos> (define rr2 random-real)
;; rr2
stklos> (eq? rr rr2)
#f
stklos> (eq? random-real (symbol-value 'random-real (find-module 'srfi/27)))
#t
```

Also, the slowness problem reported in #386 doesn't happen anymore:

```scheme
;;;; Fresh start of STklos
stklos> (define size 10000)
(define v (make-vector size))
(repeat 10
        (time
         (dotimes (i size)
           (vector-set! v i (random-real)))))

;; size
;; v
Elapsed time: 86.519 ms
Elapsed time: 86.45 ms
Elapsed time: 79.391 ms
Elapsed time: 100.882 ms
Elapsed time: 95.914 ms
Elapsed time: 86.347 ms
Elapsed time: 79.581 ms
Elapsed time: 97.2769999999999 ms
Elapsed time: 85.1940000000001 ms
Elapsed time: 103.131 ms
```

I'm kind of happy that it worked, but confused. *Why* does it work? My impression is that one'd need either the condition system or continuations to get this working properly (or perhaps a generic method with something to run after it's called)... (?)