### PR TITLE
Fix variable name in stklos-config.in

### DIFF
--- a/utils/stklos-config.in
+++ b/utils/stklos-config.in
@@ -88,7 +88,7 @@ while test $# -gt 0; do
             echo @THREADS@
             ;;
         --libraries|-L)
-            echo "@LIB_SUMMARY@"
+            echo "@CONF_SUMMARY@"
             ;;
         --help|-h|-\?)
             usage 0 1>&2


### PR DESCRIPTION
Hi @egallesio - I'm not sure this is what you indended (was it a typo/thinko? `LIB_SUMMARY` <-> `CONF_SUMMARY`?)

Could this be a resolution to #379 ?

Seems to work now, I'm not sure it's the exact output you wanted:

```
$ stklos-config -L
(:system (libffi libpcre libgmp libgc ) :compiled () :configure ( "CC=gcc" "CFLAGS=-g -O2"))
```