### PR TITLE
Fix `disassemble-expr`

### DIFF
--- a/lib/assembler.stk
+++ b/lib/assembler.stk
@@ -508,7 +508,7 @@ doc>
 (define (disassemble-expr expr :optional (show-consts #f)
                                          (port (current-output-port)))
   (define (compile-expression e)
-    (compile e '() e #f)
+    (compile e #f e #f)
     (emit 'END-OF-CODE)
     (assemble (reverse! *code-instr*)))
 


### PR DESCRIPTION
After the changes made to the compiler to accomodate the new macros, `disassemble-expr` stopped working:

```
(disassemble-expr '(+ 2 x))
**** Error:
%fast-struct-ref: bad structure `()' in `scope-locals'
```

because the null environment is now represented by `#f`, and not `'()`, so the call to `compile` in `assembler.stk` should be adjusted.
