### PR TITLE
Fix small glitch in `STk_utf8_grab_char`

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -68,8 +68,8 @@ char *STk_utf8_grab_char(char *str, uint32_t *c) /* result = pos. after current 
     return str + 3;
   }
 
-  *c = ((buff[0] & 0x0f) << 16) +
-       ((buff[1] & 0x3f) <<  6) +
+  *c = ((buff[0] & 0x07) << 18) +
+       ((buff[1] & 0x3f) << 12) +
        ((buff[2] & 0x3f) <<  6) +
         (buff[3] & 0x3f);
   return str + 4;

--- a/tests/test-utf8.stk
+++ b/tests/test-utf8.stk
@@ -304,6 +304,26 @@
         '(1 2 3)
         ( (λ λ λ) 1 2 3)))
 
+(test-subsection "Integer <-> character UTF-8 conversion")
+
+;; #xD800 = start of surrogate range
+(dotimes (i #xD800)
+  (test "list->string / string->list unicode range (low)"
+        #t
+        (equal? (string->list
+                 (list->string
+                  (list (integer->char i))))
+                (list (integer->char i)))))
+
+;; #xE000   = min unicoode after surrogates
+;; #x10FFFD = max unicode range
+(dotimes (i (- #x10FFFD #xE000))
+  (test "list->string / string->list unicode range (high)"
+        #t
+        (equal? (string->list
+                 (list->string
+                  (list (integer->char (fx+ i #xE000)))))
+                (list (integer->char (fx+ i #xE000))))))
 
 ;;------------------------------------------------------------------
 (test-section-end)


### PR DESCRIPTION
When the first byte is $>=$ `0xf0`, the algorithm was decoding incorrectly:

```scheme
(list->string (list (integer->char 65537)))
 => "𐀁"        ;; Ok

(string->list (list->string (list (integer->char 65537))))
 => (#\Ё)      ;; Oops! list->string and string->list
               ;; do not work as inverses, because the
               ;; character is decoded incorrectly in
               ;; string->list (and string-ref too)
```

This fixes the problem. Also included some tests: the full Unicode range (excluding surrogates) is verified to encode and decode correctly, as per

```scheme
(equal? (string->list (list->string (list (integer->char i))))
                                    (list (integer->char i)))
```