### PR TITLE
Add R7RS-Large bytevectors

### DIFF
--- a/lib/scheme/Makefile.am
+++ b/lib/scheme/Makefile.am
@@ -102,9 +102,9 @@ LARGE_OBJS = list.ostk       \
              division.ostk   \
              bitwise.ostk
 
-LARGE_C     = ilist.c     flonum.c     sort.c     vector.c
-LARGE_C_STK = ilist.stk   flonum.stk   sort.stk   vector.stk
-LARGE_SHOBJ = ilist.$(SO) flonum.$(SO) sort.$(SO) vector.$(SO)
+LARGE_C     = ilist.c     flonum.c     sort.c     vector.c     bytevector.c
+LARGE_C_STK = ilist.stk   flonum.stk   sort.stk   vector.stk   bytevector.stk
+LARGE_SHOBJ = ilist.$(SO) flonum.$(SO) sort.$(SO) vector.$(SO) bytevector.$(SO)
 
 
 #----------------------------------------------------------------------
@@ -163,6 +163,7 @@ set.ostk: ../srfi/9.ostk ../srfi/69.ostk comparator.ostk
 ../srfi/60.ostk:
 	(cd ../srfi; $(MAKE) 60.ostk)
 
+bytevector.$(SO): bytevector-incl.c bytevector.c
 
 ilist.$(SO): ilist-incl.c
 ilist-incl.c: comparator.ostk

--- a/lib/scheme/Makefile.in
+++ b/lib/scheme/Makefile.in
@@ -417,9 +417,9 @@ LARGE_OBJS = list.ostk       \
              division.ostk   \
              bitwise.ostk
 
-LARGE_C = ilist.c     flonum.c     sort.c     vector.c
-LARGE_C_STK = ilist.stk   flonum.stk   sort.stk   vector.stk
-LARGE_SHOBJ = ilist.$(SO) flonum.$(SO) sort.$(SO) vector.$(SO)
+LARGE_C = ilist.c     flonum.c     sort.c     vector.c     bytevector.c
+LARGE_C_STK = ilist.stk   flonum.stk   sort.stk   vector.stk   bytevector.stk
+LARGE_SHOBJ = ilist.$(SO) flonum.$(SO) sort.$(SO) vector.$(SO) bytevector.$(SO)
 
 #----------------------------------------------------------------------
 SRC_STK = $(R7_STK) $(LARGE_STK)   $(LARGE_C_STK)
@@ -753,6 +753,8 @@ set.ostk: ../srfi/9.ostk ../srfi/69.ostk comparator.ostk
 	(cd ../srfi; $(MAKE) 129.ostk)
 ../srfi/60.ostk:
 	(cd ../srfi; $(MAKE) 60.ostk)
+
+bytevector.$(SO): bytevector-incl.c bytevector.c
 
 ilist.$(SO): ilist-incl.c
 ilist-incl.c: comparator.ostk

--- a/lib/scheme/bytevector.c
+++ b/lib/scheme/bytevector.c
@@ -1,0 +1,1594 @@
+/*
+ * bytevector.c   -- Implementation of R7RS-Large bytevectors
+ *
+ * Copyright © 2022 Jerônimo Pellegrini <j_p@aleph0.info>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ *
+ *           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+ *    Creation date: 07-Jul-2022 22:40
+ * Last file update: 08-Jul-2022 14:15 (jpellegrini)
+ */
+
+#include <gmp.h>
+#include <sys/param.h>
+#include <endian.h>
+#include <stklos.h>
+#include "bytevector-incl.c"
+
+/* We define a type for endianness, just for convenience. */
+typedef enum { end_little=0, end_big } endianness_t;
+static endianness_t  native_endianness;
+
+/* We'll need to handle bignums at some point. */
+struct bignum_obj {
+  stk_header header;
+  mpz_t val;
+};
+
+#define BIGNUM_VAL(p)   (((struct bignum_obj *) (p))->val)
+
+#define LONG_FITS_INTEGER(_l)    (INT_MIN_VAL <= (_l) && (_l) <= INT_MAX_VAL)
+
+/* Reals... */
+static inline SCM double2real(double x)
+{
+  SCM z;
+
+  NEWCELL(z, real);
+  REAL_VAL(z) = x;
+  return z;
+}
+
+/* Some utilities */
+
+static inline void
+check_integer(SCM x) {
+  if (!INTP(x)) STk_error("bad integer ~S", x);
+}
+static inline void
+check_list(SCM x) {
+    if (! ( CONSP(x) || NULLP(x) ) ) STk_error("bad list ~S", x);
+}
+static inline void
+check_string(SCM x) {
+  if (!STRINGP(x)) STk_error("bad string ~S", x);
+}
+static inline void
+check_bytevector(SCM v)
+{
+  if (!BYTEVECTORP(v))
+    STk_error("bad bytevector ~s", v);
+}
+
+
+static inline void
+bad_arguments(int low, int hi, int given) {
+    STk_error ("expected between %d and %d arguments, but got %d", low, hi, given);
+}
+
+static inline void
+bytevector_init_native_endianness() {
+  unsigned int i = 1;
+  char *c = (char*) &i;
+
+  if ( (int) *c )
+      native_endianness = end_little;
+  else
+      native_endianness = end_big;
+}
+
+static inline endianness_t
+get_endianness(SCM endianness) {
+  if (!endianness) return end_big;
+  if (!SYMBOLP(endianness)) STk_error ("bad symbol ~S", endianness);
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      return end_little;
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      return end_big;
+  else STk_error("bad endianness symbol ~S", endianness);
+  return end_little; /* Never reached */
+}
+
+
+
+/*
+<doc EXT native-endianness
+ * (native-endianness)
+ *
+ * Returns the endianness symbol of the underlying machine.
+doc>
+*/
+DEFINE_PRIMITIVE("native-endianness", native_endianness, subr0, ())
+{
+    if (native_endianness == end_little)
+        return STk_intern("little");
+    else
+        return STk_intern("big");
+}
+
+
+/*
+<doc EXT bytevector=?
+ * (bytevector=? bytevector1 bytevector2 )
+ *
+ * Returns true if |bytevector1| and |bytevector2| are equal—that
+ * is, if they have the same length and equal bytes at all valid
+ * indices. It returns false otherwise.
+doc>
+*/
+DEFINE_PRIMITIVE("bytevector=?", bytevector_equal, subr2,
+                 (SCM a, SCM b))
+{
+  check_bytevector(a);
+  check_bytevector(b);
+  return MAKE_BOOLEAN(STk_uvector_equal(a,b));
+}
+
+/*
+<doc EXT bytevector-fill!
+ * (bytevector-fill! bytevector fill )
+ *
+ * The |fill| argument is as in the description of the make-bytevector
+ * procedure. The |bytevector-fill!|  procedure stores |fill| in every
+ * element of bytevector and returns unspecified values. Analogous to
+ * |vector-fill!|.
+doc>
+*/
+DEFINE_PRIMITIVE("bytevector-fill!", bytevector_fill, subr2,
+                 (SCM b, SCM x))
+{
+  check_bytevector(b);
+  check_integer(x);
+  
+  long vali = INT_VAL(x);
+  
+  if (vali >= 256 || vali < -128)
+      STk_error("value ~S is out of bounds or incorrect for a bytevector", x);
+  
+  if (vali < 0)
+      for (long i=0; i<UVECTOR_SIZE(b); i++)
+          ((char *) UVECTOR_DATA(b))[i] = (char) vali;
+  else
+      for (long i=0; i<UVECTOR_SIZE(b); i++)
+          ((uint8_t *) UVECTOR_DATA(b))[i] = (uint8_t) vali;;
+
+  return STk_void;
+}
+
+/*
+<doc EXT bytevector-u8-ref bytevector-s8-ref
+ * (bytevector-u8-ref bytevector k)
+ * (bytevector-s8-ref bytevector k)
+ *
+ * The |bytevector-u8-ref| procedure returns the byte at index |k| of
+ * |bytevector|, as an octet.
+ * The |bytevector-s8-ref| procedure returns the byte at index |k| of
+ * |bytevector|, as a signed byte.
+ *
+ * @lisp
+ * (let ((b1 (make-bytevector 16 -127))
+ *       (b2 (make-bytevector 16 255)))
+ *   (list
+ *     (bytevector-s8-ref b1 0)
+ *     (bytevector-u8-ref b1 0)
+ *     (bytevector-s8-ref b2 0)
+ *     (bytevector-u8-ref b2 0)))
+ * => (-127 129 -1 255)
+ * @end lisp
+doc>
+*/
+DEFINE_PRIMITIVE("bytevector-s8-ref", bytevector_s8_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);  
+  check_integer(i);
+
+  return MAKE_INT(((char *) UVECTOR_DATA(b))[INT_VAL(i)]);
+}
+
+/*
+<doc EXT bytevector-u8-set! bytevector-s8-set!
+ * (bytevector-u8-set! bytevector k octet)
+ * (bytevector-s8-set! bytevector k byte)
+ *
+ * |K| must be a valid index of bytevector.
+ * The |bytevector-u8-set!| procedure stores octet in element
+ * |k| of |bytevector|.
+ * The |bytevector-s8-set!| procedure stores the two’s-complement
+ * representation of |byte| in element |k| of |bytevector|.
+ * Both procedures return unspecified values.
+ *
+ * @lisp
+ * (let ((b (make-bytevector 16 -127)))
+ *   (bytevector-s8-set! b 0 -126)
+ *   (bytevector-u8-set! b 1 246)
+ *   (list
+ *     (bytevector-s8-ref b 0)
+ *     (bytevector-u8-ref b 0)
+ *     (bytevector-s8-ref b 1)
+ *     (bytevector-u8-ref b 1)))
+ *   => (-126 130 -10 246)
+ * @end lisp
+doc>
+*/
+DEFINE_PRIMITIVE("bytevector-s8-set!", bytevector_s8_set, subr3,
+                 (SCM b, SCM i, SCM byte))
+{
+  check_integer(i);
+  long  vali = STk_integer_value(byte);
+  if (-128 <= vali && vali < +128)
+      ((char *) UVECTOR_DATA(b))[INT_VAL(i)] = (char) vali;
+  else STk_error("value ~S is out of bounds or incorrect for a bytevector", byte);
+  return STk_void;
+}
+
+/******
+       INT
+*******/
+
+SCM
+bytevector_uint_ref_aux(SCM b, endianness_t end, size_t idx, size_t size, int sig) {
+  if (size <= sizeof(long)) {
+
+    char *ptr; /* points into the bytevector */
+
+    /* Only one of these will be used, one for signed and one for unsigned result.
+       We'll make an uint8_t point to the right one, and build the number. */
+    long          res  = 0L;
+    unsigned long ures = 0L;
+
+    uint8_t *tmp; /* points into the *result long integer!*  */
+    if (sig)  tmp = (uint8_t*) &res;
+    else      tmp = (uint8_t*) &ures;
+    
+    if (end == end_little) ptr = &(((char *) UVECTOR_DATA(b))[idx]);
+    else                   ptr = &(((char *) UVECTOR_DATA(b))[idx]) + size - 1;
+    for (int i=0; i < size; i++) {
+      *tmp = *ptr;
+      tmp++;
+      if (end == end_little) ptr++;
+      else                   ptr--;
+    }
+
+    /* If the requested 'size' was less than sizeof(long), then
+       we filled part of the number. If we also have a negative number,
+       we need to finish filling the most significative part with ones. */
+    if (sig && (*(tmp-1) >= 128)) {
+	memset(tmp, 0xff, sizeof(long)-size);
+    }
+
+    /* We have built the long integer result as if the machine was little endian.
+       If it is big endian, we swap everything: */
+    switch (sizeof(long)) {
+    case 4:
+	res  = le32toh(res);
+	ures = le32toh(ures);
+	break;
+    case 8:
+	res  = le64toh(res);
+	ures = le64toh(ures);
+	break;
+    default: STk_error("STklos does not support long integers with %d bytes", sizeof(long));
+    }
+
+    return sig
+	? STk_long2integer(res)
+	: STk_ulong2integer(ures);
+    
+  } else {
+      /*** BIGNUMS ***/
+      
+      if (sig &&
+	  ( (  (end == end_big) &&
+	       (((char *) UVECTOR_DATA(b))[idx]) < 0)
+	    ||
+	    (  (end == end_little) &&
+	       (((char *) UVECTOR_DATA(b))[idx+size-1]) < 0))) {
+	  /***
+	      Negtive case: we do this:
+	      - copy the bits to tmp
+	      - invert all bits
+	      - import into GMP
+	      - add one
+	      I have tried to not use the tmp buffer, and inverting the bits
+	      after they were in a GMP number, but that didn't work for some
+	      reason.
+	  ***/
+
+	  char *tmp = STk_must_malloc(size);
+	  memcpy(tmp,&(((char *) UVECTOR_DATA(b))[idx]),size);
+
+	  /* Negate the bits */
+	  for (int i=0; i<size; i++)
+	      tmp[i] = ~tmp[i];
+
+	  /* import into a GMP number: */
+	  SCM z;
+	  mpz_t num, num2;
+	  mpz_init(num);
+	  mpz_init(num2);
+	  int e = (end == end_little) ? -1 : +1;
+	  mpz_import (num,                                 /* destination             */
+		      size,                                /* word count              */
+		      e,                                   /* order (endianness)      */
+		      1,                                   /* word size               */
+		      e,                                   /* endianness within words */
+		      0,                                   /* nails (skipped bits)    */
+		      tmp);                                /* from                    */
+
+	  /* Add one, to finish the conversion from 2's complement: */
+	  mpz_add_ui(num2,num,1);
+	  mpz_neg(num,num2);
+
+	  NEWCELL(z, bignum);
+	  mpz_set(BIGNUM_VAL(z), num);
+	  return z;
+	
+      } else {
+	  /***
+	      Positive case: the GMP already has a function for that!
+	  ***/
+	  SCM z;
+	  mpz_t num;
+	  mpz_init(num);
+	  int e = (end == end_little) ? -1 : +1;
+	  mpz_import (num,                                 /* destination             */
+		      size,                                /* word count              */
+		      e,                                   /* order (endianness)      */
+		      1,                                   /* word size               */
+		      e,                                   /* endianness within words */
+		      0,                                   /* nails (skipped bits)    */
+		      &(((char *) UVECTOR_DATA(b))[idx])); /* from                    */
+	
+	  NEWCELL(z, bignum);
+	  mpz_set(BIGNUM_VAL(z), num);
+	  return z;
+      }
+  }
+}
+
+/*
+<doc EXT bytevector-uint-ref bytevector-sint-ref bytevector-uint-set! bytevector-sint-set!
+ * (bytevector-uint-ref bytevector k endianness size)
+ * (bytevector-sint-ref bytevector k endianness size)
+ * (bytevector-uint-set! bytevector k n endianness size)
+ * (bytevector-sint-set! bytevector k n endianness size)
+ *
+ * The |bytevector-uint-ref| procedure retrieves the exact
+ * integer object corresponding to the unsigned representation
+ * of size |size| and specified by |endianness| at indices
+ * |k , ... , k + size − 1|.
+ *
+ * The |bytevector-sint-ref| procedure retrieves the exact
+ * integer object corresponding to the two’s-complement
+ * representation of size |size| and specified by |endianness|
+ * at indices |k , ... , k + size − 1|.
+ *
+ * For |bytevector-uint-set!|, |n| must be an exact integer
+ * object in the interval |{0, ... , 256^size − 1}|.
+ *
+ * The |bytevector-uint-set!| procedure stores the unsigned
+ * representation of size |size| and specified by |endianness|
+ * into |bytevector| at indices |k , ... , k + size − 1|.
+ *
+ * For bytevector-sint-set!, n must be an exact integer
+ * object in the interval |{−256^size /2, ... , 256^size /2 − 1}|.
+ * |Bytevector-sint-set!| stores the two’s-complement 
+ * representation of size |size| and specified by |endianness|
+ * into |bytevector| at indices |k , ... , k + size − 1|.
+ *
+ * The |...-set!| procedures return unspecified values.
+ *
+ * @lisp
+ * (define b (make-bytevector 16 -127))
+ *
+ * (bytevector-uint-set! b 0 (- (expt 2 128) 3)
+ *                       (endianness little) 16)
+ * (bytevector-uint-ref b 0 (endianness little) 16)
+ *  => #xfffffffffffffffffffffffffffffffd
+ *
+ * (bytevector-sint-ref b 0 (endianness little) 16)
+ *  => -3
+ *
+ * (bytevector->u8-list b)
+ *  => (253 255 255 255 255 255 255 255
+ *      255 255 255 255 255 255 255 255)
+ *
+ * (bytevector-uint-set! b 0 (- (expt 2 128) 3)
+ *                       (endianness big) 16)
+ * (bytevector-uint-ref b 0 (endianness big) 16)
+ *  => #xfffffffffffffffffffffffffffffffd
+ *
+ * (bytevector-sint-ref b 0 (endianness big) 16)
+ *  =>-3
+ *
+ * (bytevector->u8-list b)
+ *  => (255 255 255 255 255 255 255 255
+ *      255 255 255 255 255 255 255 253))
+ * @end lisp
+doc>
+*/
+DEFINE_PRIMITIVE("bytevector-uint-ref", bytevector_uint_ref, subr4,
+                 (SCM b, SCM i, SCM endianness, SCM s))
+{
+  check_bytevector(b);
+  check_integer(i);
+  check_integer(s);
+
+  unsigned long idx = INT_VAL(i);
+  unsigned long size = INT_VAL(s);
+
+  if (idx < 0)
+      STk_error("negative index %d", idx);
+  if (size < 0)
+      STk_error("negative size %d", size);
+  if (idx + size > UVECTOR_SIZE(b))
+      STk_error("index %d plus size %d out of bounds for bytevector of length %d",
+                idx, size, UVECTOR_SIZE(b));
+  
+  endianness_t end = get_endianness(endianness);
+   
+  return bytevector_uint_ref_aux(b, end, idx, size, 0);
+}
+
+
+DEFINE_PRIMITIVE("bytevector-sint-ref", bytevector_sint_ref, subr4,
+                 (SCM b, SCM i, SCM endianness, SCM s))
+{
+  check_bytevector(b);
+  check_integer(i);
+  check_integer(s);
+
+  unsigned long idx = INT_VAL(i);
+  unsigned long size = INT_VAL(s);
+
+  if (idx < 0)
+      STk_error("negative index %d", idx);
+  if (size < 0)
+      STk_error("negative size %d", size);
+  if (idx + size > UVECTOR_SIZE(b))
+      STk_error("index %d plus size %d out of bounds for bytevector of length %d",
+                idx, size, UVECTOR_SIZE(b));
+  
+  endianness_t end = get_endianness(endianness);
+   
+  return bytevector_uint_ref_aux(b, end, idx, size, 1);
+}
+
+
+
+DEFINE_PRIMITIVE("bytevector-uint-set!", bytevector_uint_set, subr5,
+                 (SCM b, SCM i, SCM n, SCM endianness, SCM s))
+{
+  check_bytevector(b);
+  check_integer(i);
+  check_integer(s);
+  if (!(INTP(n)||BIGNUMP(n))) STk_error("bad integer ~S", n);
+
+  unsigned long idx  = INT_VAL(i);
+  unsigned long size = INT_VAL(s);
+
+  endianness_t end = get_endianness(endianness);
+
+  if (idx < 0)
+      STk_error("negative index %d", idx);
+  if (size < 0)
+      STk_error("negative size %d", size);
+  if (idx + size > UVECTOR_SIZE(b))
+      STk_error("index %d plus size %d out of bounds for bytevector of length %d",
+                idx, size, UVECTOR_SIZE(b));
+
+  if (INTP(n)) {
+      int j;
+      long val  = INT_VAL(n);
+
+      /* This is the uint version, so no negatives: */
+      if (val < 0)
+          STk_error("value ~S is not unsigned", n);
+
+      /* The value must fit the 'size' bytes, which means it should
+         be less than (256)^size.  The bounds are explicit in the
+         spec. */
+      if (val >= ((unsigned long) 1 << (size * 8)))
+          STk_error("value %d does not fit in %d bytes", val, size);
+
+      char *ptr;
+      if (end == end_little) ptr = &(((char *) UVECTOR_DATA(b))[idx]);
+      else                   ptr = &(((char *) UVECTOR_DATA(b))[idx]) + size - 1;
+      for (j=0; j < size; j++) {
+          *ptr = (char) (val & 0xff);
+          val = val >> 8;
+          if (end == end_little) ptr++;
+          else                   ptr--;
+      }
+  } else {
+      /* n is a BIGNUM */
+      int e = (end == end_little) ? -1 : +1;
+      size_t count;
+      void *ptr = mpz_export (NULL,               /* destination             */
+                              &count,             /* bytes written           */
+                              e,                  /* endianness              */
+                              1,                  /* word size               */
+                              e,                  /* endianness within words */
+                              0,                  /* nails                   */
+                              BIGNUM_VAL(n));     /* from */
+      if (count > size)
+          STk_error("bignum ~S does not fit in ~S bytes", n, size);
+          
+      if (end == end_little) {
+          memcpy(&(((char *) UVECTOR_DATA(b))[idx]),
+                 ptr,
+                 count);
+          memset(&(((char *) UVECTOR_DATA(b))[idx+count]),
+                 0,
+                 size - count);
+          /* do not free ptr, GMP is using libgc already */
+      } else {
+          memcpy(&(((char *) UVECTOR_DATA(b))[idx+size-count]),
+                 ptr,
+                 count);
+          memset(&(((char *) UVECTOR_DATA(b))[idx]),
+                 0,
+                 size - count);
+          /* do not free ptr, GMP is using libgc already */
+      }
+  }
+  return STk_void;
+}
+
+ 
+
+/******
+       INT16
+*******/
+
+DEFINE_PRIMITIVE("bytevector-u16-ref", bytevector_u16_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);
+  check_integer(i);
+
+  unsigned long idx = INT_VAL(i);
+
+  uint16_t *z = (uint16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      return MAKE_INT(le16toh (*z));
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      return MAKE_INT(be16toh (*z));
+  else STk_error("bad endianness symbol ~S", endianness);
+  return STk_void; /* Never reached */
+}
+
+
+
+DEFINE_PRIMITIVE("bytevector-s16-ref", bytevector_s16_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  
+  unsigned long idx = INT_VAL(i);
+
+  uint16_t *z = (uint16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      return MAKE_INT((int16_t)le16toh (*z));
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      return MAKE_INT((int16_t)be16toh (*z));
+  else STk_error("bad endianness symbol ~S", endianness);
+  return STk_void; /* Never reached */
+}
+
+
+
+
+DEFINE_PRIMITIVE("bytevector-u16-set!", bytevector_u16_set, subr4,
+                 (SCM b, SCM i, SCM val, SCM endianness))
+{
+  check_bytevector(b);
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+
+  if (vali < +65536) {
+      uint16_t *z = (uint16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      
+      if (STk_eq(endianness,STk_intern("little"))==STk_true) {
+          *z = htole16(vali);
+      } else if (STk_eq(endianness,STk_intern("big"))==STk_true) {
+          *z = htobe16(vali);
+      } else STk_error("bad endianness symbol ~S", endianness);
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", val);
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-s16-set!", bytevector_s16_set, subr4,
+                 (SCM b, SCM i, SCM byte, SCM endianness))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  long vali = STk_integer_value(byte);
+  
+  if (vali < +32768 && vali >= -32768) {
+      int16_t *z = (int16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      
+      if (STk_eq(endianness,STk_intern("little"))==STk_true) {
+          *z = (int16_t) htole16((uint16_t) vali);
+      } else if (STk_eq(endianness,STk_intern("big"))==STk_true) {
+          *z = (int16_t) htobe16((uint16_t) vali);
+      } else STk_error("bad endianness symbol ~S", endianness);
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", byte);
+  return STk_void;
+}
+
+
+
+
+DEFINE_PRIMITIVE("bytevector-u16-native-ref", bytevector_u16_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);
+  check_integer(i);
+    
+  unsigned long idx = INT_VAL(i);
+    
+  uint16_t *z = (uint16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+  return MAKE_INT(*z);
+}
+                 
+
+DEFINE_PRIMITIVE("bytevector-s16-native-ref", bytevector_s16_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);
+  check_integer(i);
+
+  long idx = INT_VAL(i);
+
+  int16_t *z = (int16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+  return MAKE_INT(*z);
+}
+
+
+DEFINE_PRIMITIVE("bytevector-u16-native-set!", bytevector_u16_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+
+  if (vali < +65536) {
+    uint16_t *z = (uint16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+    *z = vali;
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", val);
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-s16-native-set!", bytevector_s16_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  long vali = STk_integer_value(val);
+
+  if (vali > -32768 && vali < +32767) {
+    int16_t *z = (int16_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+    *z = (int16_t)  vali;
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", val);
+  return STk_void;
+}
+
+/******
+       INT32
+*******/
+
+DEFINE_PRIMITIVE("bytevector-u32-ref", bytevector_u32_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint32_t z = *((uint32_t *) &(((char *) UVECTOR_DATA(b))[idx++]));
+  
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      z = (uint32_t) le32toh (z);
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      z = (uint32_t) be32toh (z);
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  return MAKE_INT((unsigned long)z);
+}
+
+
+
+DEFINE_PRIMITIVE("bytevector-s32-ref", bytevector_s32_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint32_t z = *( (uint32_t *) &(((char *) UVECTOR_DATA(b))[idx++]) );
+  
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      return MAKE_INT((int32_t)le32toh (z));
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      return MAKE_INT((int32_t)be32toh (z));
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  return STk_void; /* Never reached */
+}
+
+
+
+
+DEFINE_PRIMITIVE("bytevector-u32-set!", bytevector_u32_set, subr4,
+                 (SCM b, SCM i, SCM val, SCM endianness))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+
+  if (vali < +4294967296) {
+      uint32_t *z = (uint32_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      
+      if (STk_eq(endianness,STk_intern("little"))==STk_true) {
+          *z = htole32(vali);
+      } else if (STk_eq(endianness,STk_intern("big"))==STk_true) {
+          *z = htobe32(vali);
+      } else STk_error("bad endianness symbol ~S", endianness);
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", val);
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-s32-set!", bytevector_s32_set, subr4,
+                 (SCM b, SCM i, SCM byte, SCM endianness))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  long vali = STk_integer_value(byte);
+  
+  if (vali <= +2147483647 && vali >= -2147483648) {
+      int32_t *z = (int32_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      
+      if (STk_eq(endianness,STk_intern("little"))==STk_true) {
+          *z = (int32_t) htole32((uint32_t) vali);
+      } else if (STk_eq(endianness,STk_intern("big"))==STk_true) {
+          *z = (int32_t) htobe32((uint32_t) vali);
+      } else STk_error("bad endianness symbol ~S", endianness);
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", byte);
+  return STk_void;
+}
+
+
+
+
+
+DEFINE_PRIMITIVE("bytevector-u32-native-ref", bytevector_u32_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint32_t z = *((uint32_t *) &(((char *) UVECTOR_DATA(b))[idx]));
+  
+  return MAKE_INT((unsigned long) z);
+}
+
+DEFINE_PRIMITIVE("bytevector-s32-native-ref", bytevector_s32_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  int32_t z = *((int32_t *) &(((char *) UVECTOR_DATA(b))[idx]) );
+  
+  return MAKE_INT((int32_t) z);
+}
+
+DEFINE_PRIMITIVE("bytevector-u32-native-set!", bytevector_u32_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+
+  if (vali < +4294967296) {
+      uint32_t *z = (uint32_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      *z = vali;
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", val);
+
+  return STk_void;
+}
+
+      
+DEFINE_PRIMITIVE("bytevector-s32-native-set!", bytevector_s32_native_set, subr3,
+                 (SCM b, SCM i, SCM byte))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  long vali = STk_integer_value(byte);
+  
+  if (vali <= +2147483647 && vali >= -2147483648) {
+      int32_t *z = (int32_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      *z = (int32_t) vali;
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", byte);
+
+  return STk_void;
+}
+
+
+/******
+       INT64
+*******/
+
+DEFINE_PRIMITIVE("bytevector-u64-ref", bytevector_u64_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint64_t z = * ((uint64_t *) &(((char *) UVECTOR_DATA(b))[idx++]) );
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      z = le64toh (z);
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      z = be64toh (z);
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  return (LONG_FITS_INTEGER(z))
+      ? MAKE_INT(z)
+      : STk_ulong2integer(z);
+}
+
+
+
+DEFINE_PRIMITIVE("bytevector-s64-ref", bytevector_s64_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint64_t z = * ((uint64_t *) &(((char *) UVECTOR_DATA(b))[idx++]) );
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      z = (int64_t) le64toh (z);
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      z = (int64_t) be64toh (z);
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  return (LONG_FITS_INTEGER(z))
+      ? MAKE_INT((long) z)
+      : STk_long2integer((long) z);
+}
+
+
+
+
+DEFINE_PRIMITIVE("bytevector-u64-set!", bytevector_u64_set, subr4,
+                 (SCM b, SCM i, SCM val, SCM endianness))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+
+  if (vali < +65536) {
+      uint64_t *z = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      
+      if (STk_eq(endianness,STk_intern("little"))==STk_true) {
+          *z = htole64(vali);
+      } else if (STk_eq(endianness,STk_intern("big"))==STk_true) {
+          *z = htobe64(vali);
+      } else STk_error("bad endianness symbol ~S", endianness);
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", val);
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-s64-set!", bytevector_s64_set, subr4,
+                 (SCM b, SCM i, SCM byte, SCM endianness))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(byte);
+  
+  if (vali < +64768 && vali >= -64768) {
+      int64_t *z = (int64_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+      
+      if (STk_eq(endianness,STk_intern("little"))==STk_true) {
+          *z = (int64_t) htole64((uint64_t) vali);
+      } else if (STk_eq(endianness,STk_intern("big"))==STk_true) {
+          *z = (int64_t) htobe64((uint64_t) vali);
+      } else STk_error("bad endianness symbol ~S", endianness);
+  } else STk_error("value ~S is out of bounds or incorrect for a bytevector", byte);
+  return STk_void;
+}
+
+
+DEFINE_PRIMITIVE("bytevector-u64-native-ref", bytevector_u64_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint64_t z = * ((uint64_t *) &(((char *) UVECTOR_DATA(b))[idx++]) );
+
+  return (LONG_FITS_INTEGER(z))
+      ? MAKE_INT(z)
+      : STk_ulong2integer(z);
+}
+
+DEFINE_PRIMITIVE("bytevector-s64-native-ref", bytevector_s64_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);  
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  uint64_t z = * ((uint64_t *) &(((char *) UVECTOR_DATA(b))[idx++]) );
+  z = (int64_t) z;
+
+  return (LONG_FITS_INTEGER(z))
+      ? MAKE_INT((long) z)
+      : STk_long2integer((long) z);
+}
+
+
+DEFINE_PRIMITIVE("bytevector-u64-native-set!", bytevector_u64_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+
+  uint64_t *z = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+  *z = vali;
+
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-s64-native-set!", bytevector_s64_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  unsigned long vali = STk_integer_value(val);
+  
+  int64_t *z = (int64_t *) &(((char *) UVECTOR_DATA(b))[idx++]);
+  *z = (int64_t) vali;
+
+  return STk_void;
+}
+
+
+/******
+       IEEE-754
+*******/
+
+uint32_t
+ieee_4_ref(SCM b, unsigned int idx, endianness_t end) {
+  uint32_t *z = (uint32_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+  uint32_t w;
+  if (end == end_little)
+      w = le32toh (*z);
+  else if (end == end_big)
+      w = be32toh (*z);
+  return w;
+}
+
+uint64_t
+ieee_8_ref(SCM b, unsigned int idx, endianness_t end) {
+  uint64_t *z = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+  uint64_t w;
+  if (end == end_little)
+      w = le64toh (*z);
+  else if (end == end_big)
+      w = be64toh (*z);
+  return w;
+}
+
+void
+ieee_4_set(uint32_t *place, unsigned int idx, endianness_t end,  void *val) {
+  if (end == end_little)
+      *place = htole32( *((uint32_t*) val));
+  else if (end == end_big)
+      *place = htobe32( *((uint32_t*) val));
+}
+
+void
+ieee_8_set(uint64_t *place, unsigned int idx, endianness_t end,  void *val) {
+  if (end == end_little)
+      *place = htole64( *((uint64_t*) val));
+  else if (end == end_big)
+      *place = htobe64( *((uint64_t*) val));
+}
+
+
+DEFINE_PRIMITIVE("bytevector-ieee-single-ref", bytevector_ieee_single_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);
+  endianness_t end;
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      end = end_little;
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      end = end_big;
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  
+  switch (sizeof(float)) {
+  case 4:
+      uint32_t  w4 = ieee_4_ref(b, idx, end);
+      return double2real(*((float*) (&w4)));
+  case 8:
+      uint64_t  w8 = ieee_8_ref(b, idx, end);
+      return double2real(*((float*) (&w8)));
+  default:
+      STk_error("floats of %d bytes are not supported in STklos", sizeof(float));
+  }
+  return STk_false; /* Never reached */
+}
+
+DEFINE_PRIMITIVE("bytevector-ieee-single-native-ref", bytevector_ieee_single_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+  
+  switch (sizeof(float)) {
+  case 4:
+      uint32_t  w4 = ieee_4_ref(b, idx, native_endianness);
+      return double2real(*((float*) (&w4)));
+  case 8:
+      uint64_t  w8 = ieee_8_ref(b, idx, native_endianness);
+      return double2real(*((float*) (&w8)));
+  default:
+      STk_error("floats of %d bytes are not supported in STklos", sizeof(float));
+  }
+  return STk_false; /* Never reached */
+}
+
+
+DEFINE_PRIMITIVE("bytevector-ieee-double-ref", bytevector_ieee_double_ref, subr3,
+                 (SCM b, SCM i, SCM endianness))
+{
+  check_bytevector(b);
+  endianness_t end;
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      end = end_little;
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      end = end_big;
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  switch (sizeof(double)) {
+  case 8:
+      uint64_t  w8 = ieee_8_ref(b, idx, end);
+      return double2real(*((double*) (&w8)));
+  default:
+      STk_error("doubles of %d bytes are not supported in STklos", sizeof(double));
+  }
+  return STk_false; /* Never reached */
+}
+
+DEFINE_PRIMITIVE("bytevector-ieee-double-native-ref", bytevector_ieee_double_native_ref, subr2,
+                 (SCM b, SCM i))
+{
+  check_bytevector(b);
+  check_integer(i);
+  unsigned long idx = INT_VAL(i);
+
+  switch (sizeof(double)) {
+  case 8:
+      uint64_t  w8 = ieee_8_ref(b, idx, native_endianness);
+      return double2real(*((double*) (&w8)));
+  default:
+      STk_error("doubles of %d bytes are not supported in STklos", sizeof(double));
+  }
+  return STk_false; /* Never reached */
+}
+
+
+
+DEFINE_PRIMITIVE("bytevector-ieee-single-set!", bytevector_ieee_single_set, subr4,
+                 (SCM b, SCM i, SCM val, SCM endianness))
+{
+  check_integer(i);
+
+  endianness_t end;
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      end = end_little;
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      end = end_big;
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  unsigned long idx = INT_VAL(i);
+  float valf = REAL_VAL(val);
+
+  switch (sizeof(float)) {
+  case 4:
+      uint32_t *z4 = (uint32_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+      ieee_4_set(z4, idx, end, &valf);
+      break;
+  case 8:
+      uint64_t *z8 = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+      ieee_8_set(z8, idx, end, &valf);
+      break;
+  default:
+      STk_error("floats of %d bytes are not supported in STklos", sizeof(float));
+  }
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-ieee-single-native-set!", bytevector_ieee_single_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_integer(i);
+
+  unsigned long idx = INT_VAL(i);
+  float valf = REAL_VAL(val);
+
+  switch (sizeof(float)) {
+  case 4:
+      uint32_t *z4 = (uint32_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+      ieee_4_set(z4, idx, native_endianness, &valf);
+      break;
+  case 8:
+      uint64_t *z8 = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+      ieee_8_set(z8, idx, native_endianness, &valf);
+      break;
+  default:
+      STk_error("floats of %d bytes are not supported in STklos", sizeof(float));
+  }
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-ieee-double-set!", bytevector_ieee_double_set, subr4,
+                 (SCM b, SCM i, SCM val, SCM endianness))
+{
+  check_integer(i);
+
+  endianness_t end;
+  if (STk_eq(endianness,STk_intern("little"))==STk_true)
+      end = end_little;
+  else if (STk_eq(endianness,STk_intern("big"))==STk_true)
+      end = end_big;
+  else STk_error("bad endianness symbol ~S", endianness);
+
+  unsigned long   idx  = INT_VAL(i);
+  double valf = REAL_VAL(val);
+
+  switch (sizeof(double)) {
+  case 8:
+      uint64_t *z = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+      ieee_8_set(z, idx, end, &valf);
+      break;
+  default:
+      STk_error("doubles of %d bytes are not supported in STklos", sizeof(double));
+  }
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("bytevector-ieee-double-native-set!", bytevector_ieee_double_native_set, subr3,
+                 (SCM b, SCM i, SCM val))
+{
+  check_integer(i);
+
+  unsigned long   idx  = INT_VAL(i);
+  double valf = REAL_VAL(val);
+
+  switch (sizeof(double)) {
+  case 8:
+      uint64_t *z = (uint64_t *) &(((char *) UVECTOR_DATA(b))[idx]);
+      ieee_8_set(z, idx, native_endianness, &valf);
+      break;
+  default:
+      STk_error("doubles of %d bytes are not supported in STklos", sizeof(double));
+  }
+  return STk_void;
+}
+
+/******
+       STRINGS
+*******/
+
+endianness_t
+get_bom_16(SCM vec, endianness_t default_end, int *bom_bytes) {
+    *bom_bytes = 0;
+    
+    if (UVECTOR_SIZE(vec) < 2) return default_end;
+    
+    uint8_t a = ((uint8_t *)UVECTOR_DATA(vec))[0];
+    uint8_t b = ((uint8_t *)UVECTOR_DATA(vec))[1];
+    
+    if (a == 0xff && b == 0xfe) {
+        *bom_bytes = 2;
+        return end_little;
+    }
+    if (a == 0xfe && b == 0xff) {
+        *bom_bytes = 2;
+        return end_big;
+    }
+
+    return default_end;
+}
+
+
+
+DEFINE_PRIMITIVE("utf16->string", utf162string, subr23, (SCM vec, SCM end, SCM bbom))
+{
+    if (bbom != NULL && !BOOLEANP(bbom)) STk_error ("bad boolean ~S", bbom);
+    
+    int bom = (bbom == STk_true)? 0 : 1;
+    int bom_bytes = 0;
+    
+    check_bytevector(vec);
+    unsigned long len = UVECTOR_SIZE(vec);
+    
+
+    endianness_t endianness = get_endianness(end);
+    if (bom) endianness = get_bom_16(vec, endianness, &bom_bytes);
+
+    uint16_t w1, w2;
+
+    /* compute number of characters */
+    unsigned long size = 0;
+    for (unsigned long i=bom_bytes; i<len;) {
+        if (endianness == end_little) {
+            w1  = ((uint8_t *) UVECTOR_DATA(vec))[i++];
+            w1 |= ((uint8_t *) UVECTOR_DATA(vec))[i++] << 8;
+        } else {
+            w1  = ((uint8_t *) UVECTOR_DATA(vec))[i++] << 8;
+            w1 |= ((uint8_t *) UVECTOR_DATA(vec))[i++];
+        }
+
+	if (w1 > 0x10FFFF) STk_error("character with value ~S outside of Unicode range",
+				     MAKE_INT(w1));
+
+	if (w1 >= 0xd800 &&
+	    w1 <= 0xdfff) {
+	    if (i == len-1)
+		STk_error("bad UTF16 encoding (bytevector ~S ends in half byte pair)", vec);
+	    size++;
+            i+=2; /* w2 */
+	} else
+	    size++;
+    }
+    SCM s = STk_makestring(size,NULL);
+
+    uint32_t u;
+    unsigned long idx_v = bom_bytes;
+    for(unsigned long idx_s=0; idx_s < size; idx_s++) {
+        if (endianness == end_little) {
+            w1  = ((uint8_t *) UVECTOR_DATA(vec))[idx_v++];
+            w1 |= ((uint8_t *) UVECTOR_DATA(vec))[idx_v++] << 8;
+        } else {
+            w1  = ((uint8_t *) UVECTOR_DATA(vec))[idx_v++] << 8;
+            w1 |= ((uint8_t *) UVECTOR_DATA(vec))[idx_v++];
+        }
+        
+	if (w1 < 0xd800 || w1 > 0xdfff)
+	    STk_string_set(s, MAKE_INT(idx_s), MAKE_CHARACTER(w1));
+        else {
+         if (endianness == end_little) {
+            w2  = ((uint8_t *) UVECTOR_DATA(vec))[idx_v++];
+            w2 |= (uint16_t) (((uint8_t *) UVECTOR_DATA(vec))[idx_v++]) << 8;
+         } else {
+             w2  = (uint16_t) (((uint8_t *) UVECTOR_DATA(vec))[idx_v++]) << 8;
+             w2 |= ((uint8_t *) UVECTOR_DATA(vec))[idx_v++];
+         }
+
+            u = (((uint32_t) (w2 & 0x3ff)) |
+                 ((uint32_t) ((w1 & 0x3ff)<< 10)));
+
+	    u += 0x10000;
+	    STk_string_set(s, MAKE_INT(idx_s), MAKE_CHARACTER(u));
+	}
+    }
+    return s;
+}
+
+
+DEFINE_PRIMITIVE("string->utf16", string2utf16, vsubr, (int argc, SCM *argv))
+{
+    if (argc < 1 || argc > 3) bad_arguments(2, 3, argc);
+    SCM str = *argv--;
+    SCM end  = (argc > 1) ? *argv-- : NULL;
+    SCM bbom = (argc > 2) ? *argv-- : NULL;
+
+    check_string(str);
+    if (bbom != NULL && !BOOLEANP(bbom)) STk_error ("bad boolean ~S", bbom);
+    
+    int bom = (bbom == STk_true)? 1 : 0;
+
+    if (STRING_LENGTH(str) == 0) return STk_make_C_bytevector(0);
+    
+    endianness_t endianness = get_endianness(end);
+
+    unsigned long len = STRING_LENGTH(str);
+    SCM ch;
+    long val;
+    unsigned long dst_len = 0;
+
+    for (unsigned long i=0; i<len; i++) {
+        ch = STk_string_ref(str,MAKE_INT(i));
+        val = CHARACTER_VAL(ch);
+        dst_len += 2;
+	if (val > 0x10FFFF) STk_error("character with value ~S outside of Unicode range",
+                                      MAKE_INT(val));
+        if (val >= 0x10000) dst_len += 2;
+    }
+        
+    SCM dest = STk_make_C_bytevector(dst_len + 2 * bom);
+
+    unsigned long dest_idx = 0;
+
+    if (bom) {
+	if (endianness == end_little) {
+	    ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = 0xff;
+	    ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = 0xfe;
+	} else {
+	    ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = 0xfe;
+	    ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = 0xff;
+	}
+    }
+    
+    for (unsigned long i=0; i<len; i++) {
+
+        SCM ch = STk_string_ref(str,MAKE_INT(i));
+        unsigned long val = CHARACTER_VAL(ch);
+
+        if (val < 0x10000) {
+            uint16_t e = (endianness == end_big)
+                ? htobe16 ((uint16_t) val)
+                : htole16 ((uint16_t) val);
+
+            uint8_t* c = (uint8_t* ) &e;
+            ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = *c++;
+            ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = *c;
+
+        } else {
+
+            val -= 0x10000;
+            
+            uint16_t w1;
+            uint16_t w2;
+
+            w1 = 0xd800 | (uint16_t) ((val >> 10) & 0x3ff);   /*  select 10 higher-order bits */
+            w2 = 0xdc00 | (uint16_t) (val & 0x3ff);           /*  0b1111111111,
+                                                                  select 10 lower-order bits  */
+            if (endianness == end_little) {
+                w1 = htole16(w1);
+                w2 = htole16(w2);
+            } else {
+                /* big */
+                w1 = htobe16(w1);
+                w2 = htobe16(w2);
+            }
+
+            uint8_t *c = (uint8_t *) &w1;
+            ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = *c++;
+            ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = *c++;
+            c = (uint8_t *) &w2;
+            ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = *c++;
+            ((uint8_t *) UVECTOR_DATA(dest))[dest_idx++] = *c;
+        }
+    }
+    return dest;
+}
+
+
+
+
+
+/* UTF32 */
+
+
+/**/
+endianness_t
+get_bom_32(SCM vec, endianness_t default_end, int *bom_bytes) {
+  *bom_bytes = 0;
+
+  if (UVECTOR_SIZE(vec) < 4) return default_end;
+
+  uint8_t a = ((uint8_t *)UVECTOR_DATA(vec))[0];
+  uint8_t b = ((uint8_t *)UVECTOR_DATA(vec))[1];
+  uint8_t c = ((uint8_t *)UVECTOR_DATA(vec))[2];
+  uint8_t d = ((uint8_t *)UVECTOR_DATA(vec))[3];
+  
+  if (a == 0xff && b == 0xfe &&
+      c == 0x00 && d == 0x00) {
+      *bom_bytes = 4;
+      return end_little;
+  }
+  if (a == 0x00 && b == 0x00 &&
+      c == 0xfe && d == 0xff) {
+      *bom_bytes = 4;
+      return end_big;
+  }
+
+  return default_end;
+}
+
+DEFINE_PRIMITIVE("utf32->string", utf322string, subr23, (SCM vec, SCM end, SCM bbom))
+{
+    if (bbom != NULL && !BOOLEANP(bbom)) STk_error ("bad boolean ~S", bbom);
+    
+    int bom = (bbom == STk_true)? 0 : 1;
+    int bom_bytes = 0;
+    
+    check_bytevector(vec);
+    unsigned long len = UVECTOR_SIZE(vec);
+
+    endianness_t endianness = get_endianness(end);
+    if (bom) endianness = get_bom_32(vec, endianness, &bom_bytes);
+    
+    if (len%4) STk_error("bad bytevector length %d for UTF32 string", len);
+
+    SCM str = STk_makestring((len - bom_bytes)/4, NULL);
+
+    uint32_t *p;
+    uint32_t z;
+    unsigned long j = 0;
+    for (unsigned long i = bom_bytes; i < len; i += 4, j++) {
+        p = (uint32_t *)  &(((uint8_t *) UVECTOR_DATA(vec))[i]);
+        z = *p;
+        if (endianness == end_big)
+            z = be32toh(z);
+        else
+            z = le32toh(z);
+        /* Now z is the exact integer reprsenting the character we want */
+        STk_string_set(str, MAKE_INT(j), MAKE_CHARACTER(z));
+    }
+    return str;
+}
+
+DEFINE_PRIMITIVE("string->utf32", string2utf32, vsubr, (int argc, SCM *argv))
+{
+    if (argc < 1 || argc > 3) bad_arguments(2, 3, argc);
+    SCM str = *argv--;
+    SCM end  = (argc > 1) ? *argv-- : NULL;
+    SCM bbom = (argc > 2) ? *argv-- : NULL;
+    
+    check_string(str);
+
+    if (bbom != NULL && !BOOLEANP(bbom)) STk_error ("bad boolean ~S", bbom);
+    int bom = (bbom == STk_true)? 1 : 0;
+
+    endianness_t endianness = get_endianness(end);
+
+    unsigned long len = STRING_LENGTH(str);
+    SCM dest = STk_make_C_bytevector((len+bom)*4); /* 4 bytes = one uint32_t */
+
+    uint32_t z;
+
+    unsigned long j=0; /* index for the destination uvector */
+
+    if (bom) {
+	if (endianness == end_little) {
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0xff;
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0xfe;
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0x00;
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0x00;
+	} else {
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0x00;
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0x00;
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0xfe;
+	    ((uint8_t *) UVECTOR_DATA(dest))[j++] = 0xff;
+	}
+    }
+
+    for (unsigned long i=0; i<len; i++) {
+        z = CHARACTER_VAL(STk_string_ref(str,MAKE_INT(i)));
+        if (endianness == end_big)
+            z = htobe32(z);
+        else
+            z = htole32(z);
+        uint8_t *c = (uint8_t *) &z;
+        ((uint8_t *) UVECTOR_DATA(dest))[j++] = *c++;
+        ((uint8_t *) UVECTOR_DATA(dest))[j++] = *c++;
+        ((uint8_t *) UVECTOR_DATA(dest))[j++] = *c++;
+        ((uint8_t *) UVECTOR_DATA(dest))[j++] = *c++;
+    }
+    return dest;
+}
+
+
+
+MODULE_ENTRY_START("scheme/bytevector")
+{
+    SCM module =  STk_create_module(STk_intern("scheme/bytevector"));
+
+    bytevector_init_native_endianness();
+
+    ADD_PRIMITIVE_IN_MODULE(native_endianness,   module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_equal,    module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_fill,     module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_uint_ref, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_sint_ref, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_uint_set, module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s8_ref,   module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s8_set,   module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u16_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s16_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u16_set,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s16_set,  module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u16_native_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s16_native_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u16_native_set,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s16_native_set,  module);
+    
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u32_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s32_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u32_set,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s32_set,  module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u32_native_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s32_native_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u32_native_set,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s32_native_set,  module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u64_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s64_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u64_set,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s64_set,  module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u64_native_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s64_native_ref,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_u64_native_set,  module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_s64_native_set,  module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_single_ref, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_single_set, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_double_ref, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_double_set, module);
+
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_single_native_ref, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_single_native_set, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_double_native_ref, module);
+    ADD_PRIMITIVE_IN_MODULE(bytevector_ieee_double_native_set, module);
+
+    ADD_PRIMITIVE_IN_MODULE(string2utf16, module);
+    ADD_PRIMITIVE_IN_MODULE(utf162string, module);
+
+    ADD_PRIMITIVE_IN_MODULE(string2utf32, module);
+    ADD_PRIMITIVE_IN_MODULE(utf322string, module);
+
+   /* Export all the symbols we have just defined */
+    STk_export_all_symbols(module);
+
+
+    /* Execute Scheme code */
+    STk_execute_C_bytecode(__module_consts, __module_code);
+}
+MODULE_ENTRY_END
+
+DEFINE_MODULE_INFO

--- a/lib/scheme/bytevector.stk
+++ b/lib/scheme/bytevector.stk
@@ -1,0 +1,205 @@
+;;;;
+;;;; bytevector.stk       -- Implementation of R7RS-Large bytevectors
+;;;;
+;;;; Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 07-Jul-2022 21:02
+;;;; Last file update: 08-Jul-2022 14:12 (jpellegrini)
+
+(select-module scheme/bytevector)
+
+
+;; Some of the procedures are mandatory in R7RS, so they are
+;; already present in the SCHEME module
+(import (only SCHEME
+              make-bytevector
+              bytevector?
+              bytevector-length
+              bytevector-copy!
+              bytevector-copy
+              bytevector-u8-ref
+              bytevector-u8-set!
+              utf8->string
+              string->utf8))
+
+
+(export endianness
+        ;; native-endianness   -> in C
+        bytevector?         ;; -> already in STklos
+        make-bytevector     ;; -> already in STklos, DIFFERENT SEMANTICS!
+        bytevector-length   ;; -> already in STklos
+        ;; bytevector=?     ;; -> in C
+        ;; bytevector-fill!    -> in C
+        bytevector-copy!    ;; -> already in STklos, DIFFERENT ARGUMENT ORDER!
+        bytevector-copy     ;; -> already in STklos
+        ;; bytevector-s8-ref   -> in C
+        ;; bytevector-s8-set!  -> in C
+        bytevector-u8-ref   ;; -> already in STklos
+        bytevector-u8-set!  ;; -> already in STklos
+        utf8->string        ;; -> already in STklos
+        string->utf8        ;; -> already in STklos
+        bytevector->u8-list
+        u8-list->bytevector
+        bytevector->uint-list
+        bytevector->sint-list
+        uint-list->bytevector
+        sint-list->bytevector
+        ;; utf16->string       -> in C
+        ;; string->utf16       -> in C
+        ;; utf32->string       -> in C
+        ;; string->utf32       -> in C
+        )
+
+(define s:make-bytevector  (symbol-value 'make-bytevector  (find-module 'SCHEME)))
+(define s:bytevector-copy! (symbol-value 'bytevector-copy! (find-module 'SCHEME)))
+
+#|
+<doc endianness
+ * (endianness endianness-symbol)
+ *
+ * The name of |endianness-symbol| must be a symbol describing an 
+ * endianness.  An implementation must support at least the symbols big
+ * and little, but may support other endianness symbols.
+ * |(endianness endianness-symbol)| evaluates to the symbol named
+ * |endianness-symbol|. Whenever one of the procedures operating on
+ * bytevectors accepts an endianness as an argument, that argument must
+ * be one of these symbols. It is a syntax violation for |endianness-symbol|
+ * to be anything other than |little| or |big|.
+doc>
+|#
+(define-macro (endianness x)
+  (if (memq x '(little big))
+      `(quote ,x)
+      `(syntax-error "bad endianness symbol ~S" (quote ,x))))
+
+;; Wrapper to create an R6RS-like version of make-bytevector.
+;; R7RS-Large is incompatible with R7RS-Small in this aspect.
+(define (make-bytevector k :optional (fill 0))
+  (s:make-bytevector k (if (negative? fill)
+                           (fx+ fill 256)
+                           fill)))
+
+;; Wrapper to create an R6RS-like version of bytevector-copy!.
+;; Quite weird, but it's what R7RS-large does: it overrides
+;; R7RS-small!
+(define (bytevector-copy! source
+                          source-start
+                          target
+                          target-start
+                          k)
+  (s:bytevector-copy! target target-start
+                      source source-start
+                      (fx+ source-start k)))
+
+(define (bytevector->u8-list b)
+  (unless (bytevector? b) (error "bad bytevector ~S" b))
+  (let ((len (bytevector-length b)))
+    (let loop ((lst ()) (i 0))
+      (if (>= i len)
+          lst
+          (cons (bytevector-u8-ref b i) (loop lst (fx+ i 1)))))))
+
+(define (u8-list->bytevector lst)
+  (unless (list? lst) (error "bad list ~S" lst))
+  (let ((b (make-bytevector (length lst))))
+    (let loop ((lst lst) (i 0))
+      (unless (null? lst)
+        (bytevector-u8-set! b i (car lst))
+        (loop (cdr lst) (fx+ i 1)))
+      b)))
+
+(define (bytevector->uint-list b end size)
+  (when (not (bytevector? b))
+    (error "bad bytevector ~S" b))
+  (when (not (memq end '(little big)))
+    (error "bad endianness ~S" end))
+  (when (not (and (integer? size)
+                  (>= size 0)))
+    (error "bad integer ~S" size))
+  (when (positive? (remainder (bytevector-length b) size))
+    (error "bytevector length ~S is not multiple if chunk size ~S"
+           (bytevector-length b) size))
+
+  (let loop ((i (- (bytevector-length b) size))
+             (lst '()))
+    (if (>= i 0)
+        (loop (- i size)
+              (cons (bytevector-uint-ref b i end size) lst))
+        lst)))
+
+(define (bytevector->sint-list b end size)
+  (when (not (bytevector? b))
+    (error "bad bytevector ~S" b))
+  (when (not (memq end '(little big)))
+    (error "bad endianness ~S" end))
+  (when (not (and (integer? size)
+                  (>= size 0)))
+    (error "bad integer ~S" size))
+  (when (positive? (remainder (bytevector-length b) size))
+    (error "bytevector length ~S is not multiple if chunk size ~S"
+           (bytevector-length b) size))
+
+  (let loop ((i (- (bytevector-length b) size))
+             (lst '()))
+    (if (>= i 0)
+        (loop (- i size)
+              (cons (bytevector-sint-ref b i end size) lst))
+        lst)))
+
+(define (uint-list->bytevector lst end size)
+  (when (not (list? lst))
+    (error "bad bytevector ~S" b))
+  (when (not (memq end '(little big)))
+    (error "bad endianness ~S" end))
+  (when (not (and (integer? size)
+                  (>= size 0)))
+    (error "bad integer ~S" size))
+  (let ((l-len (length lst)))
+    (let ((b-len (* l-len size)))
+      (let ((b (make-bytevector b-len)))
+        (let loop ((i 0)
+                   (ptr lst))
+          (if (>= i b-len)
+              b
+              (begin
+                (bytevector-uint-set! b i (car ptr) end size)
+                (loop (fx+ i size) (cdr ptr)))))))))
+
+
+
+(define (sint-list->bytevector lst end size)
+  (when (not (list? lst))
+    (error "bad bytevector ~S" b))
+  (when (not (memq end '(little big)))
+    (error "bad endianness ~S" end))
+  (when (not (and (integer? size)
+                  (>= size 0)))
+    (error "bad integer ~S" size))
+  (let ((l-len (length lst)))
+    (let ((b-len (* l-len size)))
+      (let ((b (make-bytevector b-len)))
+        (let loop ((i 0)
+                   (ptr lst))
+          (if (>= i b-len)
+              b
+              (begin
+                (bytevector-sint-set! b i (car ptr) end size)
+                (loop (fx+ i size) (cdr ptr)))))))))
+
+(provide "scheme-bytevector")

--- a/tests/do-test.stk
+++ b/tests/do-test.stk
@@ -38,6 +38,7 @@
   (load "test-threads.stk")
   (load "test-hash.stk")
   (load "test-srfi.stk")
+  (load "test-libs.stk")
   (load "test-json.stk")
   (load "test-md5.stk")
   (load "test-base64.stk")

--- a/tests/lib/scheme/bytevector.stk
+++ b/tests/lib/scheme/bytevector.stk
@@ -1,0 +1,475 @@
+
+;;; TESTS for (scheme bytevector).
+;;; The tests are performed inside a module, because the library
+;;; overrides a standard R7RS procedure, changing its signature.
+
+(define-module test-scheme/bytevector
+  (import (scheme bytevector))
+  (export run)
+
+(define epsilon 0.00001)
+
+(define-syntax test/approx
+  (syntax-rules ()
+    ((_ name ex1 ex2)
+     (let* ((e1 ex1)
+            (e2 ex2)
+            (dif (if (finite? e1)
+                     (abs (- e1 e2))
+                     (if (= e1 e2) 0 +nan.0))))
+       (test name #t (< dif epsilon))))))
+
+
+(define (run)
+
+(test "native-endianness"
+      #t
+      (not (not (memq (native-endianness) '(little big)))))
+
+(test "bytevector=?.1"
+      #t
+      (bytevector=? #u8(1 2 3) #u8(1 2 3)))
+
+(test "bytevector=?.2"
+      #f
+      (bytevector=? #u8(1 2 3 4) #u8(1 2 3)))
+
+(test "bytevector=?.3"
+      #f
+      (bytevector=? #u8(1 2 1) #u8(1 2 3)))
+
+(test "bytevector=?.4"
+      #t
+      (bytevector=? (bytevector 1 2 1) #u8(1 2 1)))
+
+(test "bytevector-copy!.1"
+      '(1 2 3 1 2 3 4 8)
+      (let ((b (u8-list->bytevector '(1 2 3 4 5 6 7 8))))
+        (bytevector-copy! b 0 b 3 4)
+        (bytevector->u8-list b)))
+
+(test "bytevector-fill!"
+      #u8(5 5 5 5)
+      (let ((b (bytevector 1 2 3 4)))
+        (bytevector-fill! b 5)
+        b))
+
+(test "bytevector-{u,s}8-ref"
+      '(-127 129 -1 255)
+      (let ((b1 (make-bytevector 16 -127))
+            (b2 (make-bytevector 16 255)))
+        (list
+         (bytevector-s8-ref b1 0)
+         (bytevector-u8-ref b1 0)
+         (bytevector-s8-ref b2 0)
+         (bytevector-u8-ref b2 0))))
+
+(test "bytevector-s8-ref"
+      '(-1 -2 0 1)
+      (let ((b (bytevector 255 254 0 1)))
+        (list (bytevector-s8-ref b 0)
+              (bytevector-s8-ref b 1)
+              (bytevector-s8-ref b 2)
+              (bytevector-s8-ref b 3))))
+
+(test "bytevector-u8-ref"
+      '(255 254 0 1)
+      (let ((b (bytevector 255 254 0 1)))
+        (list (bytevector-u8-ref b 0)
+              (bytevector-u8-ref b 1)
+              (bytevector-u8-ref b 2)
+              (bytevector-u8-ref b 3))))
+
+(test "bytevector-s8-set!"
+      #u8(10 20 246 236) 
+      (let ((b (bytevector 1 1 1 1)))
+        (bytevector-s8-set! b 0  10)
+        (bytevector-s8-set! b 1  20)
+        (bytevector-s8-set! b 2 -10)
+        (bytevector-s8-set! b 3 -20)
+        b))
+
+(test "bytevector-u8-set!"
+      #u8(10 20 30 40)
+      (let ((b (bytevector 1 1 1 1)))
+        (bytevector-u8-set! b 0  10)
+        (bytevector-u8-set! b 1  20)
+        (bytevector-u8-set! b 2  30)
+        (bytevector-u8-set! b 3  40)
+        b))
+
+
+(test/error "bytevector-s8-set!.error"
+            (let ((b (bytevector 1 1 1 1)))
+              (bytevector-u8-set! b 0 -10)))
+
+
+(test "bytevector-uint-ref.fixnum.2-bytes.LE"
+      769
+      (let ((b #u8(1 1 3 4)))
+        (bytevector-uint-ref b 1 'little 2)))
+
+(test "bytevector-uint-ref.fixnum.2-bytes.BE"
+      259
+      (let ((b #u8(1 1 3 4)))
+        (bytevector-uint-ref b 1 'big 2)))
+
+
+(test "bytevector-uint-ref.fixnum.3-bytes.LE"
+      196865
+      (let ((b #u8(1 1 3 4)))
+        (bytevector-uint-ref b 0 'little 3)))
+
+(test "bytevector-uint-ref.fixnum.3-bytes.BE"
+      65795
+      (let ((b #u8(1 1 3 4)))
+        (bytevector-uint-ref b 0 'big 3)))
+
+(test "bytevector-uint-ref.bignum.10-bytes.LE"
+      9444805024432857023233
+      (let ((b #u8(1 1 3 4 1 0 1 0 1 0 2 3)))
+        (bytevector-uint-ref b 1 'little 10)))
+
+(test "bytevector-uint-ref.bignum.10-bytes.BE"
+      4741030526724903796992      
+      (let ((b #u8(1 1 3 4 1 0 1 0 1 0 2 3)))
+        (bytevector-uint-ref b 0 'big 10)))
+
+(let ((v (make-bytevector 16)))
+  (test "bytevector-ieee-double-set!"
+        #u8(11 42 170 126 165 64 95 64 0 0 0 0 0 0 0 0)
+        (begin (bytevector-ieee-double-set! v 0 125.010101 'little)
+               v))
+  (test "bytevector-ieee-double-ref"
+        125.010101
+        (bytevector-ieee-double-ref v 0 'little)))
+
+;;;
+;;;
+
+
+(test "string->utf16.basic.little"
+      #u8(97 0 98 0 99 0)
+      (string->utf16 "abc" 'little))
+
+(test "string->utf16.basic.big"
+      #u8(0 97 0 98 0 99)
+      (string->utf16 "abc" 'big))
+
+(let ((s (string-copy "abcd")))
+  (string-set! s 2 (integer->char 65599))
+
+  (test "string->utf16.large.little"
+        #u8(97 0 98 0 0 216 63 220 100 0)
+        (string->utf16 s 'little))
+  
+  (test "string->utf16.large.big"
+        #u8(0 97 0 98 216 0 220 63 0 100)
+        (string->utf16 s 'big)))
+
+(let ((s (string-copy "axbd")))
+  (string-set! s 1 (integer->char 65599))
+
+  (test "utf16->string.1.little"
+        s
+        (utf16->string #u8(97 0 0 216 63 220 98 0 100 0) 'little))
+
+  (test "utf16->string.1.big"
+        s
+        (utf16->string #u8(0 97 216 0 220 63 0 98 0 100) 'big)))
+
+
+
+;;;
+;;;
+
+(test "string->utf32.basic.little"
+      #u8(97 0 0 0 98 0 0 0 99 0 0 0)
+      (string->utf32 "abc" 'little))
+
+(test "string->utf32.basic.big"
+      #u8(0 0 0 97 0 0 0 98 0 0 0 99)
+      (string->utf32 "abc" 'big))
+
+
+
+
+;;;
+;;; From Sagittarius
+;;;
+
+    (test "1" (endianness little) 'little)
+    (test "2" (endianness big) 'big)
+    (test "3" (symbol? (native-endianness)) #t)
+
+    (test "4" (bytevector? #u8(1 2 3)) #t)
+    (test "5" (bytevector? "123") #f)
+
+    (test "6" (bytevector-length #u8(1 2 3)) 3)
+    (test "7" (bytevector-length (make-bytevector 10)) 10)
+    (test "8" (bytevector-length (make-bytevector 10 3)) 10)
+    (test "9" (bytevector-u8-ref (make-bytevector 10 3) 0) 3)
+    (test "10" (bytevector-u8-ref (make-bytevector 10 3) 5) 3)
+    (test "11" (bytevector-u8-ref (make-bytevector 10 3) 9) 3)
+    (test "12" (bytevector-u8-ref (make-bytevector 10 255) 9) 255)
+    (test "13" (bytevector-u8-ref (make-bytevector 10 -1) 9) 255)
+    (test "14" (bytevector-u8-ref (make-bytevector 10 -128) 9) 128)
+    (let ([v (make-bytevector 5 2)])
+      (test "15" (void) (bytevector-fill! v -1))
+      (test "16" v #u8(255 255 255 255 255))
+      (test "17" (void) (bytevector-fill! v 17))
+      (test "18" v #u8(17 17 17 17 17))
+      (test "19" (void) (bytevector-fill! v 255))
+      (test "20" v #u8(255 255 255 255 255)))
+
+    (test "21" (let ((b (u8-list->bytevector '(1 2 3 4 5 6 7 8))))
+            (bytevector-copy! b 0 b 3 4)
+            (bytevector->u8-list b))
+          '(1 2 3 1 2 3 4 8))
+
+    (test "22" (bytevector-copy #u8(1 2 3)) #u8(1 2 3))
+
+    (test "23" (let ((b1 (make-bytevector 16 -127))
+                     (b2 (make-bytevector 16 255)))
+                 (list
+                  (bytevector-s8-ref b1 0)
+                  (bytevector-u8-ref b1 0)
+                  (bytevector-s8-ref b2 0)
+                  (bytevector-u8-ref b2 0)))
+          '(-127 129 -1 255))
+
+    (test "24" (let ((b (make-bytevector 16 -127)))
+                 (bytevector-s8-set! b 0 -126)
+                 (bytevector-u8-set! b 1 246)
+                 
+            (list
+             (bytevector-s8-ref b 0)
+             (bytevector-u8-ref b 0)
+             (bytevector-s8-ref b 1)
+             (bytevector-u8-ref b 1)))
+          '(-126 130 -10 246))
+
+    (test "25" (bytevector->u8-list #u8(1 2 3)) '(1 2 3))
+    (test "26" (bytevector->u8-list #u8(255 255 255)) '(255 255 255))
+    (test "27" (u8-list->bytevector '(1 2 3)) #u8(1 2 3))
+    (test "28" (u8-list->bytevector '()) #u8())
+
+    (let ([b (make-bytevector 16 -127)])
+      (test "29"
+            (void)
+            (bytevector-uint-set! b 0 (- (expt 2 128) 3)
+                                  (endianness little) 16))
+
+      (test "30" (bytevector-uint-ref b 0 (endianness little) 16)
+            #xfffffffffffffffffffffffffffffffd)
+
+      (test "31" (bytevector-sint-ref b 0 (endianness little) 16)
+            -3)
+      (test "32" (bytevector->u8-list b)
+            '(253 255 255 255 255 255 255 255
+                  255 255 255 255 255 255 255 255))
+      
+      (test "33"
+            (void)
+            (bytevector-uint-set! b 0 (- (expt 2 128) 3)
+                                  (endianness big) 16))
+      (test "34" (bytevector-uint-ref b 0 (endianness big) 16)
+            #xfffffffffffffffffffffffffffffffd)
+      
+      (test "35" (bytevector-sint-ref b 0 (endianness big) 16) -3)
+      
+      (test "36" (bytevector->u8-list b)
+            '(255 255 255 255 255 255 255 255
+                  255 255 255 255 255 255 255 253))
+      (test "37"
+       (let ((b (u8-list->bytevector '(1 2 3 255 1 2 1 2))))
+         (bytevector->sint-list b (endianness little) 2))
+       '(513 -253 513 513))
+
+      (test "38" (let ((b (u8-list->bytevector '(1 2 3 255 1 2 1 2))))
+              (bytevector->uint-list b (endianness little) 2))
+            '(513 65283 513 513)))
+
+
+      
+(let ((b (u8-list->bytevector
+          '(255 255 255 255 255 255 255 255
+                255 255 255 255 255 255 255 253))))
+  
+  (test "39"   65023 (bytevector-u16-ref b 14 'little))
+  (test "40"    -513 (bytevector-s16-ref b 14 'little))
+  (test "41"   65533 (bytevector-u16-ref b 14 'big))
+  (test "42"      -3 (bytevector-s16-ref b 14 'big))
+  
+  (test "43" (void) (bytevector-u16-set! b 0 12345 'little))
+  (test "44" 12345 (bytevector-u16-ref b 0 'little))
+  
+  (test "45.16" (void) (bytevector-u16-native-set! b 0 12005))
+  (test "46.16" 12005  (bytevector-u16-native-ref b 0))
+  (test "47.16" #t (not (not (memq 12005
+                                (list (bytevector-u16-ref b 0 'little)
+                                      (bytevector-u16-ref b 0 'big))))))
+
+  (test "45.32" (void) (bytevector-u32-native-set! b 0 32005))
+  (test "46.32" 32005  (bytevector-u32-native-ref b 0))
+  (test "47.32" #t (not (not (memq 32005
+                                   (list (bytevector-u32-ref b 0 'little)
+                                         (bytevector-u32-ref b 0 'big))))))
+
+  (test "45.64" (void) (bytevector-u64-native-set! b 0 101010102020))
+  (test "46.64" 101010102020 (bytevector-u64-native-ref b 0))
+  (test "47.64" #t (not (not (memq 101010102020
+                                   (list (bytevector-u64-ref b 0 'little)
+                                         (bytevector-u64-ref b 0 'big))))))
+
+  (test "45.16.s-" (void) (bytevector-s16-native-set! b 0 -12005))
+  (test "46.16.s-" -12005  (bytevector-s16-native-ref b 0))
+  (test "47.16.s-" #t (not (not (memq -12005
+                                (list (bytevector-s16-ref b 0 'little)
+                                      (bytevector-s16-ref b 0 'big))))))
+
+  (test "45.32.s-" (void) (bytevector-s32-native-set! b 0 -32005))
+  (test "46.32.s-" -32005  (bytevector-s32-native-ref b 0))
+  (test "47.32.s-" #t (not (not (memq -32005
+                                   (list (bytevector-s32-ref b 0 'little)
+                                         (bytevector-s32-ref b 0 'big))))))
+
+  (test "45.64.s-" (void) (bytevector-s64-native-set! b 0 -101010102020))
+  (test "46.64.s-" -101010102020 (bytevector-s64-native-ref b 0))
+  (test "47.64.s-" #t (not (not (memq -101010102020
+                                      (list (bytevector-s64-ref b 0 'little)
+                                            (bytevector-s64-ref b 0 'big))))))
+
+  (test "45.16.s+" (void) (bytevector-s16-native-set! b 0 12005))
+  (test "46.16.s+" 12005  (bytevector-s16-native-ref b 0))
+  (test "47.16.s+" #t (not (not (memq 12005
+                                (list (bytevector-s16-ref b 0 'little)
+                                      (bytevector-s16-ref b 0 'big))))))
+
+  (test "45.32.s+" (void) (bytevector-s32-native-set! b 0 +32005))
+  (test "46.32.s+" 32005  (bytevector-s32-native-ref b 0))
+  (test "47.32.s+" #t (not (not (memq 32005
+                                   (list (bytevector-s32-ref b 0 'little)
+                                         (bytevector-s32-ref b 0 'big))))))
+
+  (test "45.64.s+" (void) (bytevector-s64-native-set! b 0 101010102020))
+  (test "46.64.s+" 101010102020 (bytevector-s64-native-ref b 0))
+  (test "47.64.s+" #t (not (not (memq 101010102020
+                                      (list (bytevector-s64-ref b 0 'little)
+                                            (bytevector-s64-ref b 0 'big)))))))
+
+(let ((b (u8-list->bytevector
+          '(255 255 255 255 255 255 255 255
+                255 255 255 255 255 255 255 253))))
+  
+  (test "48" (bytevector-u32-ref b 12 (endianness little)) 4261412863)
+  (test "49" (bytevector-s32-ref b 12 (endianness little)) -33554433)
+  (test "50" (bytevector-u32-ref b 12 (endianness big)) 4294967293)
+  (test "51" (bytevector-s32-ref b 12 (endianness big)) -3))
+
+(let ((b (u8-list->bytevector
+          '(255 255 255 255 255 255 255 255
+                255 255 255 255 255 255 255 253))))
+  (test "52" (bytevector-u64-ref b 8 (endianness little)) 18302628885633695743)
+  (test "53" (bytevector-s64-ref b 8 (endianness little)) -144115188075855873)
+  (test "54" (bytevector-u64-ref b 8 (endianness big)) 18446744073709551613)
+  (test "55" (bytevector-s64-ref b 8 (endianness big)) -3))
+
+
+(for-each
+ (lambda (k)
+   (for-each
+    (lambda (n)
+      (if (zero? (fxand k 3))
+          (let ([b (make-bytevector 12)])
+            (test "56" (void) (bytevector-ieee-single-native-set! b k n))
+            (test/approx "57" (bytevector-ieee-single-native-ref b k) n))
+          (let ([b (make-bytevector 12)])
+            (test/error "58" (bytevector-ieee-single-native-set! b k n))
+            (test/error "59" (bytevector-ieee-single-native-ref b k))))
+      (let ([b (make-bytevector 12)])
+        (test "60" (void) (bytevector-ieee-single-set! b k n 'big))
+        (test/approx "61" (bytevector-ieee-single-ref b k 'big) n))
+      (let ([b (make-bytevector 12)])
+        (test "62" (void) (bytevector-ieee-single-set! b k n 'little))
+        (test/approx "63" (bytevector-ieee-single-ref b k 'little) n))
+      (if (zero? (fxand k 7))
+          (let ([b (make-bytevector 12)])
+            (test "64" (void) (bytevector-ieee-double-native-set! b k n))
+            (test/approx "65" (bytevector-ieee-double-native-ref b k) n))
+          (let ([b (make-bytevector 12)])
+            (test/error "66" (bytevector-ieee-double-native-set! b k n))
+            (test/error "67" (bytevector-ieee-double-native-ref b k))))
+      (let ([b (make-bytevector 12)])
+        (test "68" (void) (bytevector-ieee-double-set! b k n 'big))
+        (test/approx "69" (bytevector-ieee-double-ref b k 'big) n))
+      (let ([b (make-bytevector 12)])
+        (test "70" (void) (bytevector-ieee-double-set! b k n 'little))
+        (test/approx "71" (bytevector-ieee-double-ref b k 'little) n)))
+    '(1.0 25.78 +inf.0 -inf.0 +nan.0)))
+ '(0 1 2 3 4))
+
+
+    (test "72" (string->utf8 "apple") #u8(97 112 112 108 101))
+    (test "73" (string->utf8 "app\x3BB;e") #u8(97 112 112 206 187 101))
+    (test "74" (string->utf16 "app\x3BB;e" 'little) #u8(97 0 112 0 112 0 #xBB #x3 101 0))
+    (test "75" (string->utf16 "app\x3BB;e" 'big) #u8(0 97 0 112 0 112 #x3 #xBB 0 101))
+    (test "76" (string->utf16 "app\x3BB;e") #u8(0 97 0 112 0 112 #x3 #xBB 0 101))
+    (test "77" (string->utf32 "app\x3BB;e" 'little) #u8(97 0 0 0 112 0 0 0 112 0 0 0 #xBB #x3 0 0 101 0 0 0))
+    (test "78" (string->utf32 "app\x3BB;e" 'big) #u8(0 0 0 97 0 0 0 112 0 0 0 112 0 0 #x3 #xBB 0 0 0 101))
+    (test "79" (string->utf32 "app\x3BB;e") #u8(0 0 0 97 0 0 0 112 0 0 0 112 0 0 #x3 #xBB 0 0 0 101))
+    
+    (let ([bv-append
+           (lambda (bv1 bv2)
+             (let ([bv (make-bytevector (+ (bytevector-length bv1)
+                                           (bytevector-length bv2)))])
+               (bytevector-copy! bv1 0 bv 0  (bytevector-length bv1))
+               (bytevector-copy! bv2 0 bv (bytevector-length bv1) (bytevector-length bv2))
+               bv))])
+      (for-each
+       (lambda (str)
+         (test "80" (utf8->string (string->utf8 str)) str)
+         (test "81" (utf16->string (string->utf16 str 'big) 'big) str)
+         (test "82" (utf16->string (string->utf16 str 'little) 'little) str)
+         (test "83" (utf16->string (bv-append #u8(#xFF #xFE) (string->utf16 str 'little)) 'big) str)
+         (test "84" (utf16->string (bv-append #u8(#xFE #xFF) (string->utf16 str 'big)) 'little) str)
+         
+         (test "85"
+               (utf16->string (bv-append #u8(#xFF #xFE) (string->utf16 str 'little)) 'little #t)
+               (string-append "\xFEFF;" str))
+         (test "86"
+               (utf16->string (bv-append #u8(#xFE #xFF) (string->utf16 str 'little)) 'little #t)
+               (string-append "\xFFFE;" str))
+         (test "87"
+               (utf16->string (bv-append #u8(#xFE #xFF) (string->utf16 str 'big)) 'big #t)
+               (string-append "\xFEFF;" str))
+         (test "88"
+               (utf16->string (bv-append #u8(#xFF #xFE) (string->utf16 str 'big)) 'big #t)
+               (string-append "\xFFFE;" str))
+         
+         (test "89" (utf32->string (string->utf32 str 'big) 'big) str)
+         (test "90" (utf32->string (string->utf32 str 'little) 'little) str)
+         (test "91" (utf32->string (bv-append #u8(#xFF #xFE 0 0) (string->utf32 str 'little)) 'big) str)
+         (test "92" (utf32->string (bv-append #u8(0 0 #xFE #xFF) (string->utf32 str 'big)) 'little) str)
+         (test "93"
+               (utf32->string (bv-append #u8(#xFF #xFE 0 0)
+                                         (string->utf32 str 'little))
+                              'little #t)
+               (string-append "\xFEFF;" str))
+         (test "94" (utf32->string (bv-append #u8(#xFE #xFF 0 0) (string->utf32 str 'little)) 'little #t)
+               (string-append "\xFFFE;" str))
+         (test "95" (utf32->string (bv-append #u8(0 0 #xFE #xFF) (string->utf32 str 'big)) 'big #t)
+               (string-append "\xFEFF;" str))
+         (test "96" (utf32->string (bv-append #u8(0 0 #xFF #xFE) (string->utf32 str 'big)) 'big #t)
+               (string-append "\xFFFE;" str)))
+       (list "apple"
+             "app\x3BB;e"
+             "\x0;\x1;\x80;\xFF;\xD7FF;\xE000;\x10FFFF;")))
+             ;; (list->string (map integer->char (list 0 1 #x80 #xff #xd7ff #xe000 #x10ffff)))
+    )
+)
+
+(select-module test-scheme/bytevector)
+(run)
+(select-module STklos)
+

--- a/tests/test-libs.stk
+++ b/tests/test-libs.stk
@@ -1,0 +1,5 @@
+(test-section "libs")
+
+(load "lib/scheme/bytevector")
+
+(test-section-end)


### PR DESCRIPTION
These are the same as R6RS-bytevectors, which were chosen as part of R7RS-Large.

* As much as possible, operations are performed in C for performance (even the trivial `bytevector=?` was written in C).
* A known issue is that this introduces an incompatibility with R7RS (in `vector-copy!`), but since it's in a library, one can always rename when importing (which seems to be the consensus solution).
* Since this is not a SRFI, it includes the library in the `scheme` subdirectory (is this OK?)

~This depends on PR #414~ (that PR was already accepted)