### PR TITLE
Add SRFI 43 - Vector Library

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -49,6 +49,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-38: External representation of shared structures
     - SRFI-39: Parameters objects
     - SRFI-41: Streams
+    - SRFI-43: Vector-Library
     - SRFI-45: Primitives for Expressing Iterative Lazy Algorithms
     - SRFI-48: Intermediate Format Strings
     - SRFI-51: Handling rest list

--- a/lib/srfi/43.stk
+++ b/lib/srfi/43.stk
@@ -1,0 +1,400 @@
+
+;; Incompatible procedures, which are taken from the SRFI-43
+;; reference implementation:
+;;
+;; * vector-map
+;; * vector-map!
+;; * vector-for-each
+;; * vector-fold
+;; * vector-fold-right
+;; * vector-count
+
+(define-module srfi/43
+  (import (prefix (srfi 133) s133-))
+  (export
+   ;;; Constructors
+   make-vector vector
+   vector-unfold                   vector-unfold-right
+   vector-copy                     vector-reverse-copy
+   vector-append                   vector-concatenate
+
+   ;;; Predicates
+   vector?
+   vector-empty?
+   vector=
+   
+   ;;; Selectors
+   vector-ref
+   vector-length
+
+   ;;; Iteration
+   vector-fold                     vector-fold-right
+   vector-map                      vector-map!
+   vector-for-each
+   vector-count
+
+   ;;; Searching
+   vector-index                    vector-skip
+   vector-index-right              vector-skip-right
+   vector-binary-search
+   vector-any                      vector-every
+   
+   ;;; Mutators
+   vector-set!
+   vector-swap!
+   vector-fill!
+   vector-reverse!
+   vector-copy!                    vector-reverse-copy!
+   vector-reverse!
+
+   ;;; Conversion
+   vector->list                    reverse-vector->list
+   list->vector                    reverse-list->vector
+   )
+
+
+;; We'll be bringing lots of bindings from the SCHEME module, so we
+;; give it a short name.
+(define scheme (find-module 'SCHEME))
+
+;; Let's not write the fill line for each defined symbol, as they are
+;; all very similar.
+;;
+(define-syntax from-scheme
+  (syntax-rules ()
+    ((_ name)
+     (define name (symbol-value (quote name) scheme)))))
+
+(define-macro (from-133 name)
+  `(define ,name ,(string->symbol
+                   (string-append "s133-"
+                                  (symbol->string name)))))
+
+
+
+
+(define unspecified-value void)
+
+;++ This should be implemented more efficiently.  It shouldn't cons a
+;++ closure, and the cons cells used in the loops when using this could
+;++ be reused.
+(define (vectors-ref vectors i)
+  (map (lambda (v) (vector-ref v i)) vectors))
+
+
+;;; (CHECK-TYPE <type-predicate?> <value> <callee>) -> value
+;;;   Ensure that VALUE satisfies TYPE-PREDICATE?; if not, signal an
+;;;   error stating that VALUE did not satisfy TYPE-PREDICATE?, showing
+;;;   that this happened while calling CALLEE.  Return VALUE if no
+;;;   error was signalled.
+(define (check-type pred? value callee)
+  (if (pred? value)
+      value
+      ;; Recur: when (or if) the user gets a debugger prompt, he can
+      ;; proceed where the call to ERROR was with the correct value.
+      (check-type pred?
+                  (error "erroneous value"
+                         (list pred? value)
+                         `(while calling ,callee))
+                  callee)))
+
+;;; (%SMALLEST-LENGTH <vector-list> <default-length> <callee>)
+;;;       -> exact, nonnegative integer
+;;;   Compute the smallest length of VECTOR-LIST.  DEFAULT-LENGTH is
+;;;   the length that is returned if VECTOR-LIST is empty.  Common use
+;;;   of this is in n-ary vector routines:
+;;;     (define (f vec . vectors)
+;;;       (let ((vec (check-type vector? vec f)))
+;;;         ...(%smallest-length vectors (vector-length vec) f)...))
+;;;   %SMALLEST-LENGTH takes care of the type checking -- which is what
+;;;   the CALLEE argument is for --; thus, the design is tuned for
+;;;   avoiding redundant type checks.
+(define %smallest-length
+  (letrec ((loop (lambda (vector-list length callee)
+                   (if (null? vector-list)
+                       length
+                       (loop (cdr vector-list)
+                             (min (vector-length
+                                   (check-type vector?
+                                               (car vector-list)
+                                               callee))
+                                  length)
+                             callee)))))
+    loop))
+    
+;; Constructors
+
+(from-scheme make-vector)
+(from-scheme vector)
+(from-133    vector-unfold)
+(from-133    vector-unfold-right)
+
+(define r7rs-vector-copy (symbol-value 'vector-copy scheme))
+(define (vector-copy v :optional (start 0) stop (fill #f fill?))
+  (let ((stop (if stop stop (vector-length v))))
+    (if (not fill?)
+        (r7rs-vector-copy v start stop)
+        (let ((w (make-vector (- stop start))))
+          (dotimes (i (- (vector-length v) start))
+            (vector-set! w i (vector-ref v (+ start i))))
+          (dotimes (i (- stop (vector-length v)))
+            (vector-set! w (+ i (- (vector-length v) start))  fill))
+          w))))
+
+      
+
+(from-133    vector-reverse-copy)
+(from-scheme vector-append)
+(from-133    vector-concatenate)
+
+;; Predicates
+
+(from-scheme vector?)
+(from-133    vector-empty?)
+(from-133    vector=)
+
+;; Selectors
+
+(from-scheme vector-ref)
+(from-scheme vector-length)
+
+;; Iteration
+
+;;; (%VECTOR-FOLD1 <kons> <knil> <vector>) -> knil'
+;;;     (KONS <index> <knil> <elt>) -> knil'
+(define %vector-fold1
+  (letrec ((loop (lambda (kons knil len vec i)
+                   (if (= i len)
+                       knil
+                       (loop kons
+                             (kons i knil (vector-ref vec i))
+                             len vec (+ i 1))))))
+    (lambda (kons knil len vec)
+      (loop kons knil len vec 0))))
+
+;;; (%VECTOR-FOLD2+ <kons> <knil> <vector> ...) -> knil'
+;;;     (KONS <index> <knil> <elt> ...) -> knil'
+(define %vector-fold2+
+  (letrec ((loop (lambda (kons knil len vectors i)
+                   (if (= i len)
+                       knil
+                       (loop kons
+                             (apply kons i knil
+                                    (vectors-ref vectors i))
+                             len vectors (+ i 1))))))
+    (lambda (kons knil len vectors)
+      (loop kons knil len vectors 0))))
+
+;;; (VECTOR-FOLD <kons> <initial-knil> <vector> ...) -> knil
+;;;     (KONS <knil> <elt> ...) -> knil' ; N vectors -> N+1 args
+;;;   The fundamental vector iterator.  KONS is iterated over each
+;;;   index in all of the vectors in parallel, stopping at the end of
+;;;   the shortest; KONS is applied to an argument list of (list I
+;;;   STATE (vector-ref VEC I) ...), where STATE is the current state
+;;;   value -- the state value begins with KNIL and becomes whatever
+;;;   KONS returned at the respective iteration --, and I is the
+;;;   current index in the iteration.  The iteration is strictly left-
+;;;   to-right.
+;;;     (vector-fold KONS KNIL (vector E_1 E_2 ... E_N))
+;;;       <=>
+;;;     (KONS (... (KONS (KONS KNIL E_1) E_2) ... E_N-1) E_N)
+(define (vector-fold kons knil vec . vectors)
+  (let ((kons (check-type procedure? kons vector-fold))
+        (vec  (check-type vector?    vec  vector-fold)))
+    (if (null? vectors)
+        (%vector-fold1 kons knil (vector-length vec) vec)
+        (%vector-fold2+ kons knil
+                        (%smallest-length vectors
+                                          (vector-length vec)
+                                          vector-fold)
+                        (cons vec vectors)))))
+
+;;; (VECTOR-FOLD-RIGHT <kons> <initial-knil> <vector> ...) -> knil
+;;;     (KONS <knil> <elt> ...) -> knil' ; N vectors => N+1 args
+;;;   The fundamental vector recursor.  Iterates in parallel across
+;;;   VECTOR ... right to left, applying KONS to the elements and the
+;;;   current state value; the state value becomes what KONS returns
+;;;   at each next iteration.  KNIL is the initial state value.
+;;;     (vector-fold-right KONS KNIL (vector E_1 E_2 ... E_N))
+;;;       <=>
+;;;     (KONS (... (KONS (KONS KNIL E_N) E_N-1) ... E_2) E_1)
+;;;
+;;; Not implemented in terms of a more primitive operations that might
+;;; called %VECTOR-FOLD-RIGHT due to the fact that it wouldn't be very
+;;; useful elsewhere.
+(define vector-fold-right
+  (letrec ((loop1 (lambda (kons knil vec i)
+                    (if (negative? i)
+                        knil
+                        (loop1 kons (kons i knil (vector-ref vec i))
+                               vec
+                               (- i 1)))))
+           (loop2+ (lambda (kons knil vectors i)
+                     (if (negative? i)
+                         knil
+                         (loop2+ kons
+                                 (apply kons i knil
+                                        (vectors-ref vectors i))
+                                 vectors
+                                 (- i 1))))))
+    (lambda (kons knil vec . vectors)
+      (let ((kons (check-type procedure? kons vector-fold-right))
+            (vec  (check-type vector?    vec  vector-fold-right)))
+        (if (null? vectors)
+            (loop1  kons knil vec (- (vector-length vec) 1))
+            (loop2+ kons knil (cons vec vectors)
+                    (- (%smallest-length vectors
+                                         (vector-length vec)
+                                         vector-fold-right)
+                       1)))))))
+
+;;; (%VECTOR-MAP! <f> <target> <length> <vector>) -> target
+;;;     (F <index> <elt>) -> elt'
+(define %vector-map1!
+  (letrec ((loop (lambda (f target vec i)
+                   (if (zero? i)
+                       target
+                       (let ((j (- i 1)))
+                         (vector-set! target j
+                                      (f j (vector-ref vec j)))
+                         (loop f target vec j))))))
+    (lambda (f target vec len)
+      (loop f target vec len))))
+
+;;; (%VECTOR-MAP2+! <f> <target> <vectors> <len>) -> target
+;;;     (F <index> <elt> ...) -> elt'
+(define %vector-map2+!
+  (letrec ((loop (lambda (f target vectors i)
+                   (if (zero? i)
+                       target
+                       (let ((j (- i 1)))
+                         (vector-set! target j
+                           (apply f j (vectors-ref vectors j)))
+                         (loop f target vectors j))))))
+    (lambda (f target vectors len)
+      (loop f target vectors len))))
+
+;;; (VECTOR-MAP <f> <vector> ...) -> vector
+;;;     (F <elt> ...) -> value ; N vectors -> N args
+;;;   Constructs a new vector of the shortest length of the vector
+;;;   arguments.  Each element at index I of the new vector is mapped
+;;;   from the old vectors by (F I (vector-ref VECTOR I) ...).  The
+;;;   dynamic order of application of F is unspecified.
+(define (vector-map f vec . vectors)
+  (let ((f   (check-type procedure? f   vector-map))
+        (vec (check-type vector?    vec vector-map)))
+    (if (null? vectors)
+        (let ((len (vector-length vec)))
+          (%vector-map1! f (make-vector len) vec len))
+        (let ((len (%smallest-length vectors
+                                     (vector-length vec)
+                                     vector-map)))
+          (%vector-map2+! f (make-vector len) (cons vec vectors)
+                          len)))))
+
+;;; (VECTOR-MAP! <f> <vector> ...) -> unspecified
+;;;     (F <elt> ...) -> element' ; N vectors -> N args
+;;;   Similar to VECTOR-MAP, but rather than mapping the new elements
+;;;   into a new vector, the new mapped elements are destructively
+;;;   inserted into the first vector.  Again, the dynamic order of
+;;;   application of F is unspecified, so it is dangerous for F to
+;;;   manipulate the first VECTOR.
+(define (vector-map! f vec . vectors)
+  (let ((f   (check-type procedure? f   vector-map!))
+        (vec (check-type vector?    vec vector-map!)))
+    (if (null? vectors)
+        (%vector-map1!  f vec vec (vector-length vec))
+        (%vector-map2+! f vec (cons vec vectors)
+                        (%smallest-length vectors
+                                          (vector-length vec)
+                                          vector-map!)))
+    (unspecified-value)))
+
+;;; (VECTOR-FOR-EACH <f> <vector> ...) -> unspecified
+;;;     (F <elt> ...) ; N vectors -> N args
+;;;   Simple vector iterator: applies F to each index in the range [0,
+;;;   LENGTH), where LENGTH is the length of the smallest vector
+;;;   argument passed, and the respective element at that index.  In
+;;;   contrast with VECTOR-MAP, F is reliably applied to each
+;;;   subsequent elements, starting at index 0 from left to right, in
+;;;   the vectors.
+(define vector-for-each
+  (letrec ((for-each1
+            (lambda (f vec i len)
+              (cond ((< i len)
+                     (f i (vector-ref vec i))
+                     (for-each1 f vec (+ i 1) len)))))
+           (for-each2+
+            (lambda (f vecs i len)
+              (cond ((< i len)
+                     (apply f i (vectors-ref vecs i))
+                     (for-each2+ f vecs (+ i 1) len))))))
+    (lambda (f vec . vectors)
+      (let ((f   (check-type procedure? f   vector-for-each))
+            (vec (check-type vector?    vec vector-for-each)))
+        (if (null? vectors)
+            (for-each1 f vec 0 (vector-length vec))
+            (for-each2+ f (cons vec vectors) 0
+                        (%smallest-length vectors
+                                          (vector-length vec)
+                                          vector-for-each)))))))
+
+
+;;; (VECTOR-COUNT <predicate?> <vector> ...)
+;;;       -> exact, nonnegative integer
+;;;     (PREDICATE? <index> <value> ...) ; N vectors -> N+1 args
+;;;   PREDICATE? is applied element-wise to the elements of VECTOR ...,
+;;;   and a count is tallied of the number of elements for which a
+;;;   true value is produced by PREDICATE?.  This count is returned.
+(define (vector-count pred? vec . vectors)
+  (let ((pred? (check-type procedure? pred? vector-count))
+        (vec   (check-type vector?    vec   vector-count)))
+    (if (null? vectors)
+        (%vector-fold1 (lambda (index count elt)
+                         (if (pred? index elt)
+                             (+ count 1)
+                             count))
+                       0
+                       (vector-length vec)
+                       vec)
+        (%vector-fold2+ (lambda (index count . elts)
+                          (if (apply pred? index elts)
+                              (+ count 1)
+                              count))
+                        0
+                        (%smallest-length vectors
+                                          (vector-length vec)
+                                          vector-count)
+                        (cons vec vectors)))))
+
+;; Searching
+
+(from-133 vector-index)
+(from-133 vector-index-right)
+(from-133 vector-skip)
+(from-133 vector-skip-right)
+(from-133 vector-binary-search)
+(from-133 vector-any)
+(from-133 vector-every)
+
+;; Mutators
+
+(from-scheme vector-set!)
+(from-133    vector-swap!)
+(from-scheme vector-fill!)
+(from-133    vector-reverse!)
+(from-scheme vector-copy!)
+(from-133    vector-reverse-copy!)
+
+;; Conversion
+
+
+(from-scheme vector->list)
+(from-133    reverse-vector->list)
+(from-scheme list->vector)
+(from-133    reverse-list->vector)
+
+
+)
+
+(provide "srfi-43")

--- a/lib/srfi/43.stk
+++ b/lib/srfi/43.stk
@@ -43,7 +43,6 @@
    vector-set!
    vector-swap!
    vector-fill!
-   vector-reverse!
    vector-copy!                    vector-reverse-copy!
    vector-reverse!
 

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -60,6 +60,7 @@ SRC_STK   = 1.stk   \
             38.stk  \
             39.stk  \
             41.stk  \
+            43.stk  \
             45.stk  \
             48.stk  \
             51.stk  \
@@ -164,6 +165,7 @@ SRC_OSTK =  1.ostk   \
             38.ostk  \
             39.ostk  \
             41.ostk  \
+            43.ostk  \
             45.ostk  \
             48.ostk  \
             51.ostk  \

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -375,6 +375,7 @@ SRC_STK = 1.stk   \
             38.stk  \
             39.stk  \
             41.stk  \
+            43.stk  \
             45.stk  \
             48.stk  \
             51.stk  \
@@ -479,6 +480,7 @@ SRC_OSTK = 1.ostk   \
             38.ostk  \
             39.ostk  \
             41.ostk  \
+            43.ostk  \
             45.ostk  \
             48.ostk  \
             51.ostk  \

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -81,7 +81,7 @@
     ;; 40  A Library of Streams
     (41 "Streams" (streams) "srfi-41")
     ;; 42  Eager Comprehensions
-    ;; 43  Vector library
+    (43 "Vector library" () "srfi-43")
     ;; 44  Collections
     (45 "Primitives for Expressing Iterative Lazy Algorithms")
     ;; 46 Basic Syntax-rules Extensions

--- a/tests/srfis/43.stk
+++ b/tests/srfis/43.stk
@@ -1,0 +1,705 @@
+
+(define-module srfi-43-test
+
+(define *extended-test* #f)
+
+(define-syntax assert-equal
+  (syntax-rules ()
+    ((_ name expr expect)
+     (test name expect expr))))
+
+(define-syntax assert-error
+  (syntax-rules ()
+    ((_ name expr)
+     (test/error name expr))))
+
+(define (char-cmp c1 c2)
+  (cond ((char<? c1 c2) -1)
+        ((char=? c1 c2) 0)
+        (else 1)))
+
+(define (run-srfi-43-tests)
+  
+;;;
+;;; Constructors
+;;;
+
+(assert-equal "make-vector 0"
+              (vector-length (make-vector 5))
+              5)
+(assert-equal "make-vector 1"
+              (make-vector 0)
+              '#())
+(assert-error "make-vector 2"
+              (make-vector -4))
+
+(assert-equal "make-vector 3"
+              (make-vector 5 3)
+              '#(3 3 3 3 3))
+(assert-equal "make-vector 4"
+              (make-vector 0 3)
+              '#())
+(assert-error "make-vector 5"
+              (make-vector -1 3))
+
+(assert-equal "vector 0"
+              (vector)
+              '#())
+(assert-equal "vector 1"
+              (vector 1 2 3 4 5)
+              '#(1 2 3 4 5))
+
+(assert-equal "vector-unfold 0"
+              (vector-unfold (lambda (i x) (values x (- x 1)))
+                             10 0)
+              '#(0 -1 -2 -3 -4 -5 -6 -7 -8 -9))
+(assert-equal "vector-unfold 1"
+              (vector-unfold values 10)
+              '#(0 1 2 3 4 5 6 7 8 9))
+(assert-equal "vector-unfold 2"
+              (vector-unfold values 0)
+              '#())
+(assert-error "vector-unfold 3"
+              (vector-unfold values -1))
+
+(assert-equal "vector-unfold-right 0"
+              (vector-unfold-right (lambda (i x) (values x (+ x 1))) 10 0)
+              '#(9 8 7 6 5 4 3 2 1 0))
+(assert-equal "vector-unfold-right 1"
+              (let ((vector '#(a b c d e)))
+                (vector-unfold-right
+                 (lambda (i x) (values (vector-ref vector x) (+ x 1)))
+                 (vector-length vector)
+                 0))
+              '#(e d c b a))
+(assert-equal "vector-unfold-right 2"
+              (vector-unfold-right values 0)
+              '#())
+(assert-error "vector-unfold-right 3"
+              (vector-unfold-right values -1))
+
+(assert-equal "vector-copy 0"
+              (vector-copy '#(a b c d e f g h i))
+              '#(a b c d e f g h i))
+(assert-equal "vector-copy 1"
+              (vector-copy '#(a b c d e f g h i) 6)
+              '#(g h i))
+(assert-equal "vector-copy 2"
+              (vector-copy '#(a b c d e f g h i) 3 6)
+              '#(d e f))
+(assert-equal "vector-copy 3"
+              (vector-copy '#(a b c d e f g h i) 6 12 'x)
+              '#(g h i x x x))
+(assert-equal "vector-copy 4"
+              (vector-copy '#(a b c d e f g h i) 6 6)
+              '#())
+(assert-error "vector-copy 5"
+              (vector-copy '#(a b c d e f g h i) 4 2))
+
+(assert-equal "vector-reverse-copy 0"
+              (vector-reverse-copy '#(a b c d e))
+              '#(e d c b a))
+(assert-equal "vector-reverse-copy 1"
+              (vector-reverse-copy '#(a b c d e) 1 4)
+              '#(d c b))
+(assert-equal "vector-reverse-copy 2"
+              (vector-reverse-copy '#(a b c d e) 1 1)
+              '#())
+(assert-error "vector-reverse-copy 3"
+              (vector-reverse-copy '#(a b c d e) 2 1))
+
+
+(assert-equal "vector-append 0" 
+              (vector-append '#(x) '#(y))
+              '#(x y))
+(assert-equal "vector-append 1"
+              (let ((v '#(x y)))
+                (vector-append v v v))
+              '#(x y x y x y))
+(assert-equal "vector-append 2"
+              (vector-append '#(x) '#() '#(y))
+              '#(x y))
+(assert-equal "vector-append 3"
+              (vector-append)
+              '#())
+(assert-error "vector-append 4"
+              (vector-append '#() 'b 'c))
+
+(assert-equal "vector-concatenate 0"
+              (vector-concatenate '(#(a b) #(c d)))
+              '#(a b c d))
+(assert-equal "vector-concatenate 1"
+              (vector-concatenate '())
+              '#())
+(assert-error "vector-concatenate 2"
+              (vector-concatenate '(#(a b) c)))
+
+;;;
+;;; Predicates
+;;;
+
+(assert-equal "vector? 0" (vector? '#()) #t)
+(assert-equal "vector? 1" (vector? '#(a b)) #t)
+(assert-equal "vector? 2" (vector? '(a b)) #f)
+(assert-equal "vector? 3" (vector? 'a) #f)
+
+(assert-equal "vector-empty? 0" (vector-empty? '#()) #t)
+(assert-equal "vector-empty? 1" (vector-empty? '#(a)) #f)
+
+(assert-equal "vector= 0" 
+              (vector= eq? '#(a b c d) '#(a b c d))
+              #t)
+(assert-equal "vector= 1" 
+              (vector= eq? '#(a b c d) '#(a b c d) '#(a b c d))
+              #t)
+(assert-equal "vector= 2" 
+              (vector= eq? '#() '#())
+              #t)
+(assert-equal "vector= 3" 
+              (vector= eq?)
+              #t)
+(assert-equal "vector= 4" 
+              (vector= eq? '#(a))
+              #t)
+(assert-equal "vector= 5" 
+              (vector= eq? '#(a b c d) '#(a b d c))
+              #f)
+(assert-equal "vector= 6" 
+              (vector= eq? '#(a b c d) '#(a b c d) '#(a b d c))
+              #f)
+(assert-equal "vector= 7" 
+              (vector= eq? '#(a b c) '#(a b d c))
+              #f)
+(assert-equal "vector= 8" 
+              (vector= eq? '#() '#(a b d c))
+              #f)
+(assert-equal "vector= 9" 
+              (vector= eq? '#(a b d c) '#())
+              #f)
+(assert-equal "vector= 10" 
+              (vector= equal? '#("a" "b" "c") '#("a" "b" "c"))
+              #t)
+(assert-error "vector= 11" 
+              (vector= equal? '#("a" "b" "c") '("a" "b" "c")))
+
+;;;
+;;; Selectors
+;;;
+
+(assert-equal "vector-ref 0" (vector-ref '#(a b c) 0) 'a)
+(assert-equal "vector-ref 1" (vector-ref '#(a b c) 1) 'b)
+(assert-equal "vector-ref 2" (vector-ref '#(a b c) 2) 'c)
+(assert-error "vector-ref 3" (vector-ref '#(a b c) -1))
+(assert-error "vector-ref 4" (vector-ref '#(a b c) 3))
+(assert-error "vector-ref 5" (vector-ref '#() 0))
+
+(assert-equal "vector-length 0" (vector-length '#()) 0)
+(assert-equal "vector-length 1" (vector-length '#(a b c)) 3)
+(assert-error "vector-length 2" (vector-length '(a b c)))
+
+;;;
+;;; Iteration
+;;;
+
+(assert-equal "vector-fold 0"
+              (vector-fold (lambda (i seed val) (+ seed val))
+                           0
+                           '#(0 1 2 3 4))
+              10)
+(assert-equal "vector-fold 1"
+              (vector-fold (lambda (i seed val) (+ seed val))
+                           'a
+                           '#())
+              'a)
+(assert-equal "vector-fold 2"
+              (vector-fold (lambda (i seed val) (+ seed (* i val)))
+                           0
+                           '#(0 1 2 3 4))
+              30)
+(assert-equal "vector-fold 3"
+              (vector-fold (lambda (i seed x y) (cons (- x y) seed))
+                           '()
+                           '#(6 1 2 3 4) '#(7 0 9 2))
+              '(1 -7 1 -1))
+
+(assert-equal "vector-fold-right 0"
+              (vector-fold-right (lambda (i seed val) (cons (cons i val) seed))
+                                 '()
+                                 '#(a b c d e))
+              '((0 . a) (1 . b) (2 . c) (3 . d) (4 . e)))
+(assert-equal "vector-fold-right 1"
+              (vector-fold-right (lambda (i seed x y) (cons (- x y) seed))
+                                 '()
+                                 '#(6 1 2 3 7) '#(7 0 9 2))
+              '(-1 1 -7 1))
+
+(assert-equal "vector-map 0"
+              (vector-map cons '#(a b c d e))
+              '#((0 . a) (1 . b) (2 . c) (3 . d) (4 . e)))
+(assert-equal "vector-map 1"
+              (vector-map cons '#())
+              '#())
+(assert-equal "vector-map 2"
+              (vector-map + '#(0 1 2 3 4) '#(5 6 7 8))
+              '#(5 8 11 14))
+
+(assert-equal "vector-map! 0"
+              (let ((v (vector 0 1 2 3 4)))
+                (vector-map! * v)
+                v)
+              '#(0 1 4 9 16))
+(assert-equal "vector-map! 1"
+              (let ((v (vector)))
+                (vector-map! * v)
+                v)
+              '#())
+(assert-equal "vector-map! 2"
+              (let ((v (vector 0 1 2 3 4)))
+                (vector-map! + v '#(5 6 7 8))
+                v)
+              '#(5 8 11 14 4))
+
+(assert-equal "vector-for-each 0"
+              (let ((sum 0))
+                (vector-for-each (lambda (i x)
+                                   (set! sum (+ sum (* i x))))
+                                 '#(0 1 2 3 4))
+                sum)
+              30)
+(assert-equal "vector-for-each 1"
+              (let ((sum 0))
+                (vector-for-each (lambda (i x)
+                                   (set! sum (+ sum (* i x))))
+                                 '#())
+                sum)
+              0)
+
+(assert-equal "vector-count 0"
+              (vector-count (lambda (i x) (even? x)) '#(0 1 2 3 4 5 6))
+              4)
+(assert-equal "vector-count 1"
+              (vector-count values '#())
+              0)
+(assert-equal "vector-count 2"
+              (vector-count (lambda (i x y) (< x y))
+                            '#(8 2 7 4 9 1 0)
+                            '#(7 6 8 3 1 1 9))
+              3)
+
+;;;
+;;; Searching
+;;;
+
+(assert-equal "vector-index 0"
+              (vector-index even? '#(3 1 4 1 5 9))
+              2)
+(assert-equal "vector-index 1"
+              (vector-index < '#(3 1 4 1 5 9 2 5 6) '#(2 7 1 8 2))
+              1)
+(assert-equal "vector-index 2"
+              (vector-index = '#(3 1 4 1 5 9 2 5 6) '#(2 7 1 8 2))
+              #f)
+(assert-equal "vector-index 3"
+              (vector-index < '#() '#(2 7 1 8 2))
+              #f)
+
+(assert-equal "vector-index-right 0"
+              (vector-index-right even? '#(3 1 4 1 5 9 2))
+              6)
+(assert-equal "vector-index-right 1"
+              (vector-index-right < '#(3 1 4 1 5) '#(2 7 1 8 2))
+              3)
+(assert-equal "vector-index-right 2"
+              (vector-index-right = '#(3 1 4 1 5) '#(2 7 1 8 2))
+              #f)
+(assert-equal "vector-index-right 3"
+              (vector-index-right even? #())
+              #f)
+
+(assert-equal "vector-skip 0"
+              (vector-skip odd? '#(3 1 4 1 5 9))
+              2)
+(assert-equal "vector-skip 1"
+              (vector-skip < '#(3 1 4 1 5 9 2 5 6) '#(4 9 5 0 2 4))
+              3)
+(assert-equal "vector-skip 2"
+              (vector-skip < '#(3 1 4 1 5 2 5 6) '#(4 9 5 9 9 9))
+              #f)
+(assert-equal "vector-skip 3"
+              (vector-skip < '#() '#(4 9 5 9 9 9))
+              #f)
+
+(assert-equal "vector-skip-right 0"
+              (vector-skip-right odd? '#(3 1 4 1 5 9 2 6 5 3))
+              7)
+(assert-equal "vector-skip-right 1"
+              (vector-skip-right < '#(8 3 7 3 1 0) '#(4 9 5 0 2 4))
+              3)
+(assert-equal "vector-skip-right 2"
+              (vector-skip-right < '#() '#(4 9 5 0 2 4))
+              #f)
+
+
+(assert-equal "vector-binary-search 0"
+              (vector-binary-search
+               '#(#\a #\b #\c #\d #\e #\f #\g #\h)
+               #\g
+               char-cmp)
+              6)
+(assert-equal "vector-binary-search 1"
+              (vector-binary-search
+               '#(#\a #\b #\c #\d #\e #\f #\g)
+               #\q
+               char-cmp)
+              #f)
+(assert-equal "vector-binary-search 2"
+              (vector-binary-search
+               '#(#\a)
+               #\a
+               char-cmp)
+              0)
+(assert-equal "vector-binary-search 3"
+              (vector-binary-search
+               '#()
+               #\a
+               char-cmp)
+              #f)
+(assert-error "vector-binary-search 4"
+              (vector-binary-search
+               '(#\a #\b #\c)
+               #\a
+               char-cmp))
+
+(cond
+ (*extended-test*
+  (assert-equal "vector-binary-search 5"
+                (vector-binary-search
+                 '#(#\a #\b #\c #\d #\e #\f #\g #\h)
+                 #\d
+                 char-cmp
+                 2 6)
+                3)
+  (assert-equal "vector-binary-search 6"
+                (vector-binary-search
+                 '#(#\a #\b #\c #\d #\e #\f #\g #\h)
+                 #\g
+                 char-cmp
+                 2 6)
+                #f)
+  ))
+
+(assert-equal "vector-any 0"
+              (vector-any even? '#(3 1 4 1 5 9 2))
+              #t)
+(assert-equal "vector-any 1"
+              (vector-any even? '#(3 1 5 1 5 9 1))
+              #f)
+(assert-equal "vector-any 2"
+              (vector-any even? '#(3 1 4 1 5 #f 2))
+              #t)
+(assert-equal "vector-any 3"
+              (vector-any even? '#())
+              #f)
+(assert-equal "vector-any 4"
+              (vector-any < '#(3 1 4 1 5 #f) '#(1 0 1 2 3))
+              #t)
+(assert-equal "vector-any 5"
+              (vector-any < '#(3 1 4 1 5 #f) '#(1 0 1 0 3))
+              #f)
+
+(assert-equal "vector-every 0"
+              (vector-every odd? '#(3 1 4 1 5 9 2))
+              #f)
+(assert-equal "vector-every 1"
+              (vector-every odd? '#(3 1 5 1 5 9 1))
+              #t)
+(assert-equal "vector-every 2"
+              (vector-every odd? '#(3 1 4 1 5 #f 2))
+              #f)
+(assert-equal "vector-every 3"
+              (vector-every even? '#())
+              #t)
+(assert-equal "vector-every 4"
+              (vector-every >= '#(3 1 4 1 5) '#(1 0 1 2 3 #f))
+              #f)
+(assert-equal "vector-every 5"
+              (vector-every >= '#(3 1 4 1 5) '#(1 0 1 0 3 #f))
+              #t)
+
+;;;
+;;; Mutators
+;;;
+
+(assert-equal "vector-set! 0"
+              (let ((v (vector 0 1 2)))
+                (vector-set! v 1 'a)
+                v)
+              '#(0 a 2))
+(assert-error "vector-set! 1" (vector-set! (vector 0 1 2) 3 'a))
+(assert-error "vector-set! 2" (vector-set! (vector 0 1 2) -1 'a))
+(assert-error "vector-set! 3" (vector-set! (vector) 0 'a))
+
+(assert-equal "vector-swap! 0"
+              (let ((v (vector 'a 'b 'c)))
+                (vector-swap! v 0 1)
+                v)
+              '#(b a c))
+(assert-equal "vector-swap! 1"
+              (let ((v (vector 'a 'b 'c)))
+                (vector-swap! v 1 1)
+                v)
+              '#(a b c))
+(assert-error "vector-swap! e0" (vector-swap! (vector 'a 'b 'c) 0 3))
+(assert-error "vector-swap! e1" (vector-swap! (vector 'a 'b 'c) -1 1))
+(assert-error "vector-swap! e2" (vector-swap! (vector) 0 0))
+
+(assert-equal "vector-fill! 0"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-fill! v 'z)
+                v)
+              '#(z z z z z))
+(assert-equal "vector-fill! 1"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-fill! v 'z 2)
+                v)
+              '#(a b z z z))
+(assert-equal "vector-fill! 2"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-fill! v 'z 1 3)
+                v)
+              '#(a z z d e))
+(assert-equal "vector-fill! 3"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-fill! v 'z 0 5)
+                v)
+              '#(z z z z z))
+(assert-equal "vector-fill! 4"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-fill! v 'z 2 2)
+                v)
+              '#(a b c d e))
+(assert-error "vector-fill! e0" (vector-fill! (vector 'a 'b 'c) 'z 0 4))
+(assert-error "vector-fill! e1" (vector-fill! (vector 'a 'b 'c) 'z 2 1))
+(assert-error "vector-fill! e2" (vector-fill! (vector 'a 'b 'c) 'z -1 1))
+(assert-error "vector-fill! e3" (vector-fill! (vector) 'z 0 0))
+
+(assert-equal "vector-reverse! 0"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse! v)
+                v)
+              '#(e d c b a))
+(assert-equal "vector-reverse! 1"
+              (let ((v (vector 'a 'b 'c 'd 'e 'f)))
+                (vector-reverse! v 1 4)
+                v)
+              '#(a d c b e f))
+(assert-equal "vector-reverse! 2"
+              (let ((v (vector 'a 'b 'c 'd 'e 'f)))
+                (vector-reverse! v 3 3)
+                v)
+              '#(a b c d e f))
+(assert-equal "vector-reverse! 3"
+              (let ((v (vector 'a 'b 'c 'd 'e 'f)))
+                (vector-reverse! v 3 4)
+                v)
+              '#(a b c d e f))
+(assert-equal "vector-reverse! 4"
+              (let ((v (vector)))
+                (vector-reverse! v)
+                v)
+              '#())
+(assert-error "vector-reverse! e0" (vector-reverse! (vector 'a 'b) 0 3))
+(assert-error "vector-reverse! e1" (vector-reverse! (vector 'a 'b) 2 1))
+(assert-error "vector-reverse! e2" (vector-reverse! (vector 'a 'b) -1 1))
+(assert-error "vector-reverse! e3" (vector-reverse! (vector) 0 0))
+
+(assert-equal "vector-copy! 0"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 0 '#(1 2 3))
+                v)
+              '#(1 2 3 d e))
+(assert-equal "vector-copy! 1"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 2 '#(1 2 3))
+                v)
+              '#(a b 1 2 3))
+(assert-equal "vector-copy! 2"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 2 '#(1 2 3) 1)
+                v)
+              '#(a b 2 3 e))
+(assert-equal "vector-copy! 3"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 2 '#(1 2 3 4 5) 2 5)
+                v)
+              '#(a b 3 4 5))
+(assert-equal "vector-copy! 4"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 2 '#(1 2 3) 1 1)
+                v)
+              '#(a b c d e))
+(assert-equal "vector-copy! self0"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 0 v 1 3)
+                v)
+              '#(b c c d e))
+(assert-equal "vector-copy! self1"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 2 v 1 4)
+                v)
+              '#(a b b c d))
+(assert-equal "vector-copy! self2"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-copy! v 0 v 0)
+                v)
+              '#(a b c d e))
+(assert-error "vector-copy! e0" (vector-copy! (vector 1 2) 3 '#(1 2 3)))
+(assert-error "vector-copy! e1" (vector-copy! (vector 1 2) 0 '#(1 2 3)))
+(assert-error "vector-copy! e2" (vector-copy! (vector 1 2) 1 '#(1 2 3) 1))
+
+(assert-equal "vector-reverse-copy! 0"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 0 '#(1 2 3))
+                v)
+              '#(3 2 1 d e))
+(assert-equal "vector-reverse-copy! 1"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 2 '#(1 2 3))
+                v)
+              '#(a b 3 2 1))
+(assert-equal "vector-reverse-copy! 2"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 2 '#(1 2 3) 1)
+                v)
+              '#(a b 3 2 e))
+(assert-equal "vector-reverse-copy! 3"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 2 '#(1 2 3 4 5) 1 4)
+                v)
+              '#(a b 4 3 2))
+(assert-equal "vector-reverse-copy! 4"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 2 '#(1 2 3 4 5) 2 2)
+                v)
+              '#(a b c d e))
+(assert-equal "vector-reverse-copy! self0"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 0 v)
+                v)
+              '#(e d c b a))
+(assert-equal "vector-reverse-copy! self1"
+              (let ((v (vector 'a 'b 'c 'd 'e)))
+                (vector-reverse-copy! v 0 v 0 2)
+                v)
+              '#(b a c d e))
+(assert-error "vector-reverse-copy! e0"
+              (vector-reverse-copy! (vector 'a 'b) 2 '#(a b)))
+(assert-error "vector-reverse-copy! e1"
+              (vector-reverse-copy! (vector 'a 'b) -1 '#(a b)))
+(assert-error "vector-reverse-copy! e2"
+              (vector-reverse-copy! (vector 'a 'b) 0 '#(a b c)))
+(assert-error "vector-reverse-copy! e3"
+              (vector-reverse-copy! (vector 'a 'b) 0 '#(a b c) 1 4))
+(assert-error "vector-reverse-copy! e4"
+              (vector-reverse-copy! (vector 'a 'b) 0 '#(a b c) -1 2))
+(assert-error "vector-reverse-copy! e5"
+              (vector-reverse-copy! (vector 'a 'b) 0 '#(a b c) 2 1))
+
+;;;
+;;; Conversion
+;;;
+
+(assert-equal "vector->list 0"
+              (vector->list '#(a b c))
+              '(a b c))
+(assert-equal "vector->list 1"
+              (vector->list '#(a b c) 1)
+              '(b c))
+(assert-equal "vector->list 2"
+              (vector->list '#(a b c d e) 1 4)
+              '(b c d))
+(assert-equal "vector->list 3"
+              (vector->list '#(a b c d e) 1 1)
+              '())
+(assert-equal "vector->list 4"
+              (vector->list '#())
+              '())
+(assert-error "vector->list e0" (vector->list '#(a b c) 1 6))
+(assert-error "vector->list e1" (vector->list '#(a b c) -1 1))
+(assert-error "vector->list e2" (vector->list '#(a b c) 2 1))
+
+(assert-equal "reverse-vector->list 0"
+              (reverse-vector->list '#(a b c))
+              '(c b a))
+(assert-equal "reverse-vector->list 1"
+              (reverse-vector->list '#(a b c) 1)
+              '(c b))
+(assert-equal "reverse-vector->list 2"
+              (reverse-vector->list '#(a b c d e) 1 4)
+              '(d c b))
+(assert-equal "reverse-vector->list 3"
+              (reverse-vector->list '#(a b c d e) 1 1)
+              '())
+(assert-equal "reverse-vector->list 4"
+              (reverse-vector->list '#())
+              '())
+(assert-error "reverse-vector->list e0" (reverse-vector->list '#(a b c) 1 6))
+(assert-error "reverse-vector->list e1" (reverse-vector->list '#(a b c) -1 1))
+(assert-error "reverse-vector->list e2" (reverse-vector->list '#(a b c) 2 1))
+
+(assert-equal "list->vector 0"
+              (list->vector '(a b c))
+              '#(a b c))
+(assert-equal "list->vector 1"
+              (list->vector '())
+              '#())
+(cond
+ (*extended-test*
+  (assert-equal "list->vector 2"
+                (list->vector '(0 1 2 3) 2)
+                '#(2 3))
+  (assert-equal "list->vector 3"
+                (list->vector '(0 1 2 3) 0 2)
+                '#(0 1))
+  (assert-equal "list->vector 4"
+                (list->vector '(0 1 2 3) 2 2)
+                '#())
+  (assert-error "list->vector e0" (list->vector '(0 1 2 3) 0 5))
+  (assert-error "list->vector e1" (list->vector '(0 1 2 3) -1 1))
+  (assert-error "list->vector e2" (list->vector '(0 1 2 3) 2 1))
+  ))
+                
+(assert-equal "reverse-list->vector 0"
+              (reverse-list->vector '(a b c))
+              '#(c b a))
+(assert-equal "reverse-list->vector 1"
+              (reverse-list->vector '())
+              '#())
+(cond
+ (*extended-test*
+  (assert-equal "reverse-list->vector 2"
+                (reverse-list->vector '(0 1 2 3) 2)
+                '#(3 2))
+  (assert-equal "reverse-list->vector 3"
+                (reverse-list->vector '(0 1 2 3) 0 2)
+                '#(1 0))
+  (assert-equal "reverse-list->vector 4"
+                (reverse-list->vector '(0 1 2 3) 2 2)
+                '#())
+  (assert-error "reverse-list->vector e0"
+                (reverse-list->vector '(0 1 2 3) 0 5))
+  (assert-error "reverse-list->vector e1"
+                (reverse-list->vector '(0 1 2 3) -1 1))
+  (assert-error "reverse-list->vector e2"
+                (reverse-list->vector '(0 1 2 3) 2 1))
+  ))
+
+) ;; run-srfi-43-test
+
+) ;; module
+
+
+;;(define module-before (module-name (current-module)))
+(select-module srfi-43-test)
+(run-srfi-43-tests)
+(select-module STklos)


### PR DESCRIPTION
This SRFI was being considered to inclusion in R7RS large when it was found that it was actually incompatible with R7RS small. Then SRFI 133 was designed, but it did not officially supersede SRFI 43.

I thought it would be interesting to have this one, just in case someone wants it (for running old code, for example).

Since there are only 6 incompatible procedures, and it's easy to rename symbols when importing and exporting R7RS libraries, there is no harm in having SRFI 43 available also.

(This one is available in Gauche, Gerbil, Guile, Larceny, Sagittarius and perhaps others)

This implementation:

* Takes as many procedures as possible from the `SCHEME` module;
* Takes others from SRFI-133;
* And finally, provides code for the 6 incompatible procedures, `vector-map`, `vector-map!`, `vector-for-each`, `vector-fold`, `vector-fold-right`, `vector-count`.
