### PR TITLE
Don't use readline completion on android

### DIFF
--- a/lib/readline.stk
+++ b/lib/readline.stk
@@ -175,7 +175,13 @@
   (let* ((suffix (%shared-library-suffix))
          (res (or (try-initialize (string-append "libreadline." suffix))
                   (try-initialize (string-append "libedit."  suffix)))))
-    (when (and res (try-load (string-append "readline-complete." suffix)))
+    (when (and res
+               ;; It seems that rl_attempted_completion_function is not
+               ;; usable or some reason on Android, so we temporarilly
+               ;; disable it:
+               (not (eq? 'android (running-os)))
+               ;;
+               (try-load (string-append "readline-complete." suffix)))
       ;; We have found a readline library. Try to load completion support
       (%init-readline-completion-function readline-completion-generator))
     res))


### PR DESCRIPTION
Hi @egallesio !

I'm not sure about this one. While we don't find the reason for the readline completion failure on Android, maybe we could avoid using it?  If you feel like this is OK... There it is! :)