### PR TITLE
Add SRFI-233: INI files

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -126,3 +126,4 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-224: Integer Mappings
     - SRFI-229: Tagged Procedures
     - SRFI-230: Atomic Operations
+    - SRFI-233: INI files

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -179,7 +179,7 @@ am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/stklos-compile.1.in \
 	$(srcdir)/stklos-config.1.in $(srcdir)/stklos-genlex.1.in \
 	$(srcdir)/stklos-pkg.1.in $(srcdir)/stklos-script.1.in \
-	$(srcdir)/stklos.1.in $(top_srcdir)/mkinstalldirs TODO
+	$(srcdir)/stklos.1.in $(top_srcdir)/mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@

--- a/lib/srfi/233.stk
+++ b/lib/srfi/233.stk
@@ -1,0 +1,212 @@
+;;;;
+;;;; srfi-223.stk         -- SRFI-223: INI files
+;;;;
+;;;; Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 13-Oct-2022 18:11
+;;;; Last file update: 15-Oct-2022 07:22
+;;;;
+
+(define-module srfi/233
+
+  (import (scheme base)
+          (scheme write))
+  (export make-ini-file-generator
+          make-ini-file-accumulator)
+
+(define make-ini-file-accumulator
+  (case-lambda
+    ((port)
+     (make-accumulator port #\= #\;))
+    ((port key-value-sep)
+     (make-accumulator port key-value-sep #\;))
+    ((port key-value-sep comment-delim)
+     (make-accumulator port key-value-sep comment-delim))))
+
+(define (make-accumulator port key-value-sep comment-delim)
+  (define current-section '||)
+
+  (define (write-comment str)
+    (display comment-delim port)
+    (display " " port)
+    (display str port)
+    (newline port))
+
+  (define (write-data section key value)
+    (unless (equal? section current-section)
+      (set! current-section section)
+      (display "[" port)
+      (display section port)
+      (display "]" port)
+      (newline port))
+    (display key port)
+    (display key-value-sep port)
+    (display value port)
+    (newline port))
+
+  (define (data-triple? arg)
+    (and (list? arg)
+         (= 3 (length arg))
+         (symbol? (list-ref arg 0))
+         (symbol? (list-ref arg 1))
+         (string? (list-ref arg 2))))
+
+  (lambda (arg)
+    (cond
+     ((eof-object? arg) (eof-object))
+     ((string? arg) (write-comment arg))
+     ((data-triple? arg) (apply write-data arg))
+     (else (error "Unexpected input")))))
+
+(define make-ini-file-generator
+  (case-lambda
+    ((port)
+     (make-generator port #\= #\;))
+    ((port key-value-sep)
+     (make-generator port key-value-sep #\;))
+    ((port key-value-sep comment-delim)
+     (make-generator port key-value-sep comment-delim))))
+
+(define (make-generator port key-value-sep comment-delim)
+
+  ;; remove whitespace from the start of the line
+  (define (trim-head line)
+    (let loop ((chars (string->list line)))
+      (cond
+       ((null? chars) "")
+       ((equal? #\space (car chars)) (loop (cdr chars)))
+       (else (list->string chars)))))
+
+  ;; remove whitespace from the end of the line
+  (define (trim-tail line)
+    (let loop ((chars (string->list line))
+               (chars/rev '())
+               (spaces '()))
+      (cond
+       ((null? chars)
+        (list->string (reverse chars/rev)))
+       ((equal? #\space (car chars))
+        (loop (cdr chars)
+              chars/rev
+              (cons #\space spaces)))
+       (else (loop (cdr chars)
+                   (append (list (car chars)) spaces chars/rev)
+                   '())))))
+
+  (define (trim line)
+    (trim-tail (trim-head line)))
+
+  ;; return #t if the line is a comment,
+  ;; #f otherwise
+  (define (comment line)
+    (let loop ((chars (string->list line)))
+      (cond
+       ((null? chars) #f)
+       ((equal? (car chars) #\space) (loop (cdr chars)))
+       ((equal? (car chars) comment-delim) #t)
+       (else #f))))
+
+  ;; return section name as a symbol the line is a section declaration,
+  ;; #f otheriwse
+  (define (section line)
+    (define chars (string->list line))
+    (define first (car chars))
+    (if (equal? first #\[)
+        (let loop ((chars (cdr chars))
+                   (chars/rev '()))
+          (cond
+           ((null? chars) #f)
+           ((and (null? (cdr chars))
+                 (equal? (car chars) #\]))
+            (string->symbol (list->string (reverse chars/rev))))
+           (else (loop (cdr chars)
+                       (cons (car chars) chars/rev)))))
+        #f))
+
+  ;; return pair of key and value
+  ;;
+  ;; if line has a separator char,
+  ;; key is a (whitespace trimmed) symbol up to first separator char, value is a (whitespace trimmed) string
+  ;;
+  ;; if line doesn't have a separator char
+  ;; key is a #f, value is the entire line
+  ;;
+  ;; if separator char is encounted multiple times, only first one is used to distinguish key from value
+  (define (key-value line)
+    (let loop ((chars (string->list line))
+               (key-parsed #f)
+               (first-reversed '())
+               (second-reversed '()))
+      (cond
+       ;; line parsed, return
+       ((null? chars)
+        (if key-parsed
+          (cons (string->symbol (trim-tail (list->string (reverse first-reversed))))
+                (trim-head (list->string (reverse second-reversed))))
+          (cons #f (list->string (reverse first-reversed)))))
+       ;; encountered separator for first time
+       ((and (equal? (car chars) key-value-sep)
+             (not key-parsed))
+        (loop (cdr chars)
+              #t
+              first-reversed
+              second-reversed))
+       ;; append char to either first or second, depending on if separator was seen
+       (else (loop (cdr chars)
+                   key-parsed
+                   (if key-parsed
+                       first-reversed
+                       (cons (car chars) first-reversed))
+                   (if key-parsed
+                       (cons (car chars) second-reversed)
+                       second-reversed))))))
+
+  (define current-section '||)
+  (define eof #f)
+
+  (lambda ()
+    (call/cc
+     (lambda (k)
+       (when eof
+         (k (eof-object)))
+       (let loop ()
+         (define line (read-line port))
+         (when (eof-object? line)
+           (begin
+             (set! eof #t)
+             (k (eof-object))))
+         (let ((trimmed-line (trim line)))
+           (cond
+            ((= 0 (string-length trimmed-line))
+             (loop))
+            ((comment trimmed-line)
+             (loop))
+            ((section trimmed-line) => (lambda (section)
+                                         (set! current-section section)
+                                         (loop)))
+            ((key-value trimmed-line) => (lambda (key-value-pair)
+                                           (list current-section
+                                                 (car key-value-pair)
+                                                 (cdr key-value-pair)))))))))))
+
+)
+
+(provide "srfi-233")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -126,7 +126,8 @@ SRC_STK   = 1.stk   \
             223.stk \
             224.stk \
             229.stk \
-            230.stk
+            230.stk \
+            233.stk
 
 SRC_OSTK =  1.ostk   \
             2.ostk   \
@@ -223,7 +224,8 @@ SRC_OSTK =  1.ostk   \
             223.ostk \
             224.ostk \
             229.ostk \
-            230.ostk
+            230.ostk \
+            233.ostk
 
 #
 # SRFIs written in C and Scheme

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -441,7 +441,8 @@ SRC_STK = 1.stk   \
             223.stk \
             224.stk \
             229.stk \
-            230.stk
+            230.stk \
+            233.stk
 
 SRC_OSTK = 1.ostk   \
             2.ostk   \
@@ -538,7 +539,8 @@ SRC_OSTK = 1.ostk   \
             223.ostk \
             224.ostk \
             229.ostk \
-            230.ostk
+            230.ostk \
+            233.ostk
 
 
 #

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -270,6 +270,9 @@
     ;; 228 A further comparator library (draft)
     (229 "Tagged Procedures" () "srfi-229")
     (230 "Atomic Operations" () "srfi-230")
+    ;; 231 Intervals and Generalized Arrays (Updated^2) (draft)
+    ;; 232 Flexible Curried Procedures
+    (233 "INI files" (ini-files) "srfi-233")
     ))
 
 ;; Some shortcuts to add to the SRFI-features which permit to load seveal file

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -267,7 +267,7 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/extraconf.h.in \
 	$(srcdir)/stklosconf.h.in $(top_srcdir)/depcomp \
-	$(top_srcdir)/mkinstalldirs TODO
+	$(top_srcdir)/mkinstalldirs
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@

--- a/tests/srfis/233.stk
+++ b/tests/srfis/233.stk
@@ -1,0 +1,109 @@
+
+;;(test-group
+;; "make-ini-file-accumulator"
+
+ (define res
+   (let* ((port (open-output-string))
+          (acc (make-ini-file-accumulator port)))
+
+     ;; write leading section-less data
+     (acc '(|| key1 "value1"))
+
+     ;; write comment
+     (acc "test comment")
+
+     ;; write new section
+     (acc '(section key2 "value2"))
+
+     (get-output-string port)))
+
+(test "srfi-233.1"
+      "key1=value1\n; test comment\n[section]\nkey2=value2\n"
+      res)
+
+;; (test-group
+;;  "make-ini-file-generator"
+
+(define (read-to-list generator)
+  (let loop ((lst '()))
+    (define entry-lst (generator))
+    (cond
+     ((eof-object? entry-lst)
+      (reverse lst))
+     (else (loop (cons entry-lst lst))))))
+
+(define source "key1 = value1\n
+; comment\n
+\n
+[section]\n
+ key2 = value2\n
+[section2]\n
+key3\n
+[key]4\n
+\n
+\n")
+
+(define res (read-to-list (make-ini-file-generator (open-input-string source))))
+
+(test "srfi-233.2"
+      '((|| key1 "value1")
+        (section key2 "value2")
+        (section2 #f "key3")
+        (section2 #f "[key]4"))
+res)
+
+
+;; (test-group
+;;  "make-ini-file-accumulator custom delimeters"
+
+(define res
+  (let* ((port (open-output-string))
+         (acc (make-ini-file-accumulator port #\- #\#)))
+
+    ;; write leading section-less data
+    (acc '(|| key1 "value1"))
+
+    ;; write comment
+    (acc "test comment")
+
+    ;; write new section
+    (acc '(section key2 "value2"))
+
+    (get-output-string port)))
+
+(test "srfi-233.3"
+      "key1-value1\n# test comment\n[section]\nkey2-value2\n"
+      res)
+
+;; (test-group
+;;  "make-ini-file-generator custom delimeters"
+
+(define (read-to-list generator)
+  (let loop ((lst '()))
+    (define entry-lst (generator))
+    (cond
+     ((eof-object? entry-lst)
+      (reverse lst))
+     (else (loop (cons entry-lst lst))))))
+
+(define source "key1 - value1\n
+# comment\n
+\n
+[section]\n
+ key2 - value2\n
+[section2]\n
+key3\n
+[key]4\n
+\n
+\n")
+
+(define res (read-to-list (make-ini-file-generator (open-input-string source) #\- #\#)))
+
+(test "srfi-233.4"
+    '((|| key1 "value1")
+      (section key2 "value2")
+      (section2 #f "key3")
+      (section2 #f "[key]4"))
+  res)
+
+;; (test-end)


### PR DESCRIPTION
Hi @egallesio ! I'm not dead either! :)

This PR adds SRFI 233 (INI files) to STklos. The module `(srfi 233)` exports two procedures,

```
make-ini-file-generator
make-ini-file-accumulator
```

which can be used to read and write traditional `.ini` files.

A very simple SRFI, easy to implement.