### PR TITLE
Add SRFI 236 - Evaluating expressions in an unspecified order

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -128,3 +128,4 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-229: Tagged Procedures
     - SRFI-230: Atomic Operations
     - SRFI-233: INI files
+    - SRFI-236: Evaluating expressions in an unspecified order

--- a/doc/HTML/stklos-ref.html
+++ b/doc/HTML/stklos-ref.html
@@ -29074,7 +29074,7 @@ their use in free software.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-11-23 21:47:27 +0100
+Last updated 2022-11-23 22:52:34 -0300
 </div>
 </div>
 </body>

--- a/doc/HTML/stklos-ref.html
+++ b/doc/HTML/stklos-ref.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.18">
+<meta name="generator" content="Asciidoctor 2.0.17">
 <meta name="author" content="Erick Gallesio">
 <title>STklos Reference Manual : (version 1.70)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
@@ -85,10 +85,10 @@ code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;
 ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
 ul,ol{margin-left:1.5em}
 ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.square{list-style-type:square}
-ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
@@ -1158,7 +1158,7 @@ a symbol introduces a keyword.  Keywords are described in section
 Keywords (see _<a href="#_keywords">Section 4.14</a>).</p>
 </li>
 <li>
-<p><code>&#35;n=</code> 
+<p><code>&#35;n=</code>
  is used to represent circular structures.  The value given of <code>n</code>
 must be a number. It is used as a label, which can be referenced
 later by a <code>&#35;n&#35;</code> notation
@@ -23527,7 +23527,7 @@ SRFI <a href="http://srfi.schemers.org">site</a>.</p>
 <div class="sect2">
 <h3 id="_supported_srfis">14.1. Supported SRFIs</h3>
 <div class="paragraph">
-<p><strong><em>STklos</em></strong> supports <strong>112</strong> finalized SRFIS.
+<p><strong><em>STklos</em></strong> supports <strong>113</strong> finalized SRFIS.
 Some of these SRFIS are <em>embedded</em> and some are <em>external</em>.</p>
 </div>
 <div class="paragraph">
@@ -23649,7 +23649,8 @@ whereas an <em>external</em> needs to be loaded before use.</p>
 -  <strong><a href="http://srfi.schemers.org/srfi-224/srfi-224.html">SRFI-224</a></strong>&#8201;&#8212;&#8201;<em>Integer Mappings</em><br>
 -  <strong><a href="http://srfi.schemers.org/srfi-229/srfi-229.html">SRFI-229</a></strong>&#8201;&#8212;&#8201;<em>Tagged Procedures</em><br>
 -  <strong><a href="http://srfi.schemers.org/srfi-230/srfi-230.html">SRFI-230</a></strong>&#8201;&#8212;&#8201;<em>Atomic Operations</em><br>
--  <strong><a href="http://srfi.schemers.org/srfi-233/srfi-233.html">SRFI-233</a></strong>&#8201;&#8212;&#8201;<em>INI files</em><br></p>
+-  <strong><a href="http://srfi.schemers.org/srfi-233/srfi-233.html">SRFI-233</a></strong>&#8201;&#8212;&#8201;<em>INI files</em><br>
+-  <strong><a href="http://srfi.schemers.org/srfi-236/srfi-236.html">SRFI-236</a></strong>&#8201;&#8212;&#8201;<em>Evaluating expressions in an unspecified order</em><br></p>
 </div>
 </div>
 <div class="sect2">
@@ -23715,7 +23716,7 @@ with <strong>require</strong> or <strong>require-feature</strong>. As with embed
 </div>
 <div class="paragraph">
 <p><strong>List of external SRFIs:</strong>
-<code>srfi-1</code> <code>srfi-2</code> <code>srfi-4</code> <code>srfi-5</code> <code>srfi-7</code> <code>srfi-9</code> <code>srfi-13</code> <code>srfi-14</code> <code>srfi-17</code> <code>srfi-25</code> <code>srfi-26</code> <code>srfi-27</code> <code>srfi-29</code> <code>srfi-35</code> <code>srfi-36</code> <code>srfi-37</code> <code>srfi-41</code> <code>srfi-48</code> <code>srfi-51</code> <code>srfi-54</code> <code>srfi-59</code> <code>srfi-60</code> <code>srfi-61</code> <code>srfi-64</code> <code>srfi-66</code> <code>srfi-69</code> <code>srfi-74</code> <code>srfi-89</code> <code>srfi-94</code> <code>srfi-95</code> <code>srfi-96</code> <code>srfi-100</code> <code>srfi-113</code> <code>srfi-116</code> <code>srfi-117</code> <code>srfi-125</code> <code>srfi-127</code> <code>srfi-128</code> <code>srfi-129</code> <code>srfi-130</code> <code>srfi-132</code> <code>srfi-133</code> <code>srfi-134</code> <code>srfi-135</code> <code>srfi-137</code> <code>srfi-141</code> <code>srfi-144</code> <code>srfi-151</code> <code>srfi-152</code> <code>srfi-154</code> <code>srfi-156</code> <code>srfi-158</code> <code>srfi-160</code> <code>srfi-161</code> <code>srfi-162</code> <code>srfi-170</code> <code>srfi-171</code> <code>srfi-173</code> <code>srfi-174</code> <code>srfi-175</code> <code>srfi-180</code> <code>srfi-185</code> <code>srfi-189</code> <code>srfi-190</code> <code>srfi-196</code> <code>srfi-207</code> <code>srfi-214</code> <code>srfi-215</code> <code>srfi-216</code> <code>srfi-217</code> <code>srfi-221</code> <code>srfi-223</code> <code>srfi-224</code> <code>srfi-229</code> <code>srfi-230</code> <code>srfi-233</code></p>
+<code>srfi-1</code> <code>srfi-2</code> <code>srfi-4</code> <code>srfi-5</code> <code>srfi-7</code> <code>srfi-9</code> <code>srfi-13</code> <code>srfi-14</code> <code>srfi-17</code> <code>srfi-25</code> <code>srfi-26</code> <code>srfi-27</code> <code>srfi-29</code> <code>srfi-35</code> <code>srfi-36</code> <code>srfi-37</code> <code>srfi-41</code> <code>srfi-48</code> <code>srfi-51</code> <code>srfi-54</code> <code>srfi-59</code> <code>srfi-60</code> <code>srfi-61</code> <code>srfi-64</code> <code>srfi-66</code> <code>srfi-69</code> <code>srfi-74</code> <code>srfi-89</code> <code>srfi-94</code> <code>srfi-95</code> <code>srfi-96</code> <code>srfi-100</code> <code>srfi-113</code> <code>srfi-116</code> <code>srfi-117</code> <code>srfi-125</code> <code>srfi-127</code> <code>srfi-128</code> <code>srfi-129</code> <code>srfi-130</code> <code>srfi-132</code> <code>srfi-133</code> <code>srfi-134</code> <code>srfi-135</code> <code>srfi-137</code> <code>srfi-141</code> <code>srfi-144</code> <code>srfi-151</code> <code>srfi-152</code> <code>srfi-154</code> <code>srfi-156</code> <code>srfi-158</code> <code>srfi-160</code> <code>srfi-161</code> <code>srfi-162</code> <code>srfi-170</code> <code>srfi-171</code> <code>srfi-173</code> <code>srfi-174</code> <code>srfi-175</code> <code>srfi-180</code> <code>srfi-185</code> <code>srfi-189</code> <code>srfi-190</code> <code>srfi-196</code> <code>srfi-207</code> <code>srfi-214</code> <code>srfi-215</code> <code>srfi-216</code> <code>srfi-217</code> <code>srfi-221</code> <code>srfi-223</code> <code>srfi-224</code> <code>srfi-229</code> <code>srfi-230</code> <code>srfi-233</code> <code>srfi-236</code></p>
 </div>
 </div>
 <div class="sect3">

--- a/lib/srfi/236.stk
+++ b/lib/srfi/236.stk
@@ -1,0 +1,39 @@
+;;;;
+;;;;
+;;;; 236.stk         -- Implementation of SRFI-236
+;;;;
+;;;; Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pelelgrini [j_p@aleph0.info]
+;;;;    Creation date: 23-Nov-2022 09:51
+;;;; Last file update: 23-Nov-2022 09:56
+;;;;
+
+;;; This implementation is simpler than the SRFI reference implementation.
+;;; We just need to append a (void) to the expression being evaluated, and
+;;; wrap it with begin.
+
+(define-module srfi/236
+  (export independently)
+
+  (begin
+    (define-syntax independently
+      (syntax-rules ()
+	((independently expr ...)
+         (begin expr ... (void)))))))

--- a/lib/srfi/236.stk
+++ b/lib/srfi/236.stk
@@ -1,8 +1,8 @@
 ;;;;
-;;;;
 ;;;; 236.stk         -- Implementation of SRFI-236
 ;;;;
-;;;; Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;; Copyright © 2022 Jeronimo Pellegrini <j_p@aleph0.info> and
+;;;;                  Erick Gallesio <eg@stklos.net>
 ;;;;
 ;;;;
 ;;;; This program is free software; you can redistribute it and/or modify
@@ -20,20 +20,38 @@
 ;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
 ;;;; USA.
 ;;;;
-;;;;           Author: Jeronimo Pelelgrini [j_p@aleph0.info]
+;;;;          Authors: Jeronimo Pelelgrini [j_p@aleph0.info]
+;;;;                   Erick Gallesio [eg@unice.fr]
 ;;;;    Creation date: 23-Nov-2022 09:51
-;;;; Last file update: 23-Nov-2022 09:56
+;;;; Last file update: 23-Nov-2022 22:43
 ;;;;
 
-;;; This implementation is simpler than the SRFI reference implementation.
-;;; We just need to append a (void) to the expression being evaluated, and
-;;; wrap it with begin.
 
 (define-module srfi/236
   (export independently)
 
   (begin
-    (define-syntax independently
-      (syntax-rules ()
-	((independently expr ...)
-         (begin expr ... (void)))))))
+
+    ;; This implementation (by jpellegrini) is simpler than the SRFI
+    ;; reference implementation.  We just need to append a (void) to
+    ;; the expression being evaluated, and wrap it with begin.
+    ;; We keep it here as reference only, since the other one (below)
+    ;; will be used.
+    ;;
+    ;; (define-syntax independently
+    ;;   (syntax-rules ()
+	;; ((independently expr ...)
+    ;;      (begin expr ... (void)))))
+
+    ;; This implementation (by egallesio) shuffles the expressions to
+    ;; make sure that the user cannot tell how evaluation will be done.
+    ;;
+    (define-macro  (independently . body)
+      (let ((shuffle (lambda (lst)
+                       (map cdr
+                            (sort (map (lambda (x) (cons (random-real) x)) lst)
+                                  (lambda (x y) (< (car x) (car y))))))))
+        `(begin ,@(shuffle body) (void))))
+    ))
+
+(provide "srfi/236")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -131,7 +131,8 @@ SRC_STK   = 1.stk   \
             224.stk \
             229.stk \
             230.stk \
-            233.stk
+            233.stk \
+            236.stk
 
 SRC_OSTK =  1.ostk   \
             2.ostk   \
@@ -233,7 +234,8 @@ SRC_OSTK =  1.ostk   \
             224.ostk \
             229.ostk \
             230.ostk \
-            233.ostk
+            233.ostk \
+            236.ostk
 
 #
 # SRFIs written in C and Scheme

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -446,7 +446,8 @@ SRC_STK = 1.stk   \
             224.stk \
             229.stk \
             230.stk \
-            233.stk
+            233.stk \
+            236.stk
 
 SRC_OSTK = 1.ostk   \
             2.ostk   \
@@ -548,7 +549,8 @@ SRC_OSTK = 1.ostk   \
             224.ostk \
             229.ostk \
             230.ostk \
-            233.ostk
+            233.ostk \
+            236.ostk
 
 
 #

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -270,9 +270,19 @@
     ;; 228 A further comparator library (draft)
     (229 "Tagged Procedures" () "srfi-229")
     (230 "Atomic Operations" () "srfi-230")
-    ;; 231 Intervals and Generalized Arrays (Updated^2) (draft)
+    ;; 231 Intervals and Generalized Arrays (Updated^2)
     ;; 232 Flexible Curried Procedures
     (233 "INI files" (ini-files) "srfi-233")
+    ;; 234 Topological sorting (draft)
+    ;; 235 Compinators (draft)
+    (236 "Evaluating expressions in an unspecified order" () "srfi-236")
+    ;; 237 R6RS Records (refined) (draft)
+    ;; 238 Codesets (draft)
+    ;; 239 Destructuring lists (draft)
+    ;; 240 Reconciled records (draft)
+    ;; 241 Match -- Simple Pattern-Matching Syntax to Express Catamorphisms on Scheme Data (drafr)
+    ;; 242 The CFG Langauge (draft)
+    ;; 243 Unreadable objects (draft)
     ))
 
 ;; Some shortcuts to add to the SRFI-features which permit to load seveal file

--- a/tests/srfis/236.stk
+++ b/tests/srfis/236.stk
@@ -1,0 +1,52 @@
+;;; Adapted from the SRFI tests contributed by Shiro Kawai
+
+
+;; just to test edge case
+(test "srfi-236-1"
+      'ok
+      (let ((v 'ok))
+        (independently)
+        v))
+
+(test "srfi-236-2"
+      '(ok . #f)
+      (let ((v (cons #f #f)))
+        (independently
+         (set-car! v 'ok))
+        v))
+
+
+(define (set-car+cdr! p x y)
+  (independently
+   (set-car! p x)
+   (set-cdr! p y)))
+
+(test "srfi-236-3"
+      '(10 . 20)
+      (let ((p (cons 1 2)))
+        (set-car+cdr! p 10 20)
+        p))
+
+
+(test "srfi-236-4"
+      '#(10 20 30)
+ (let ((v (vector 1 2 3)))
+   (independently
+    (vector-set! v 0 10)
+    (vector-set! v 1 20)
+    (vector-set! v 2 30))
+   v))
+
+(test "srfi-236-5"
+      3
+      (let ((x '()))
+        (independently
+         (set! x (cons 1 x))
+         (set! x (cons 2 x)))
+        (apply + x)))
+
+(test "srfi-236-6"
+      10
+      (let ((x -1))
+        (independently (independently (set! x 10)))
+        x))


### PR DESCRIPTION
Hi @egallesio !
SRFI 236 went final, and since it's trivial, I've decided to make this PR. :)

The implementation I've included is different (and simpler) from the reference implementation: it just wraps the expressions in `begin`, but appending `(void)` as last expression.
