### PR TITLE
Add missing Makefile dependencies

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: timestamp correction
@@ -14,7 +14,7 @@ jobs:
     - name: configure
       run: ./configure
     - name: make
-      run: make
+      run: make -j$(nproc)
     - name: make check
       run: make check
 #    - name: make distcheck

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -209,7 +209,7 @@ readline-complete.@SH_SUFFIX@: readline-complete.c
 #
 # If ./srfis.stk we must rebuild
 #     - srfis-data.scm (used by SRFI0 and features)
-srfis-data.scm: srfis.stk
+srfis-data.scm: srfis.stk getopt.ostk
 	$(STKLOS_BINARY) -q -l srfis.stk \
 	                 -f ../utils/update-srfi-list.stk \
                      -- --internal > $@

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -34,6 +34,7 @@ scheme_BOOT = assembler.stk \
           bonus.stk         \
           boot.stk          \
           callcc.stk        \
+          compfile.stk      \
           compiler.stk      \
           computils.stk     \
           date.stk          \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -913,7 +913,7 @@ readline-complete.@SH_SUFFIX@: readline-complete.c
 #
 # If ./srfis.stk we must rebuild
 #     - srfis-data.scm (used by SRFI0 and features)
-srfis-data.scm: srfis.stk
+srfis-data.scm: srfis.stk getopt.ostk
 	$(STKLOS_BINARY) -q -l srfis.stk \
 	                 -f ../utils/update-srfi-list.stk \
                      -- --internal > $@


### PR DESCRIPTION
`update-srfi-list.stk` uses the procedure `parse-arguments`, which is defined in `getopt.stk`.  But the Makefile dependencies were not reflecting that.

Fixes #427 

update: included a commit from @amirouche 