### PR TITLE
Create .gitattributes file so .stk files are Scheme-highlighted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.stk linguist-language=Scheme


### PR DESCRIPTION
The .stk file extension is not recognized by GitHub Linguist, the system used to syntax-highlight and analyze files on GitHub. Many files are detected as Scheme through text analysis but [some](https://github.com/egallesio/STklos/blob/master/lib/load.stk) are not, and are displayed as plain text.

This makes GitHub detect them as Scheme and properly highlight them. This should also allow for syntax highlighting in pull requests.