### PR TITLE
Implement SRFI 238 (Codesets)

### DIFF
--- a/src/stklos.h
+++ b/src/stklos.h
@@ -1185,6 +1185,8 @@ EXTERN_PRIMITIVE("regexp-match", regexec, subr2, (SCM re, SCM str));
   ----
   ------------------------------------------------------------------------------
 */
+extern struct codeset signal_codeset;
+
 int STk_get_signal_value(SCM sig);
 int STk_init_signal(void);
 
@@ -1283,6 +1285,29 @@ int STk_init_syntax(void);
   ----
   ------------------------------------------------------------------------------
 */
+
+struct codeset_code {
+    const char *name;
+    int number;
+    SCM symbol;
+};
+
+struct codeset {
+    const char *name;
+    struct codeset_code *codes;
+    char *(*get_message)(int);
+    size_t count;
+    char *messages;
+    char *messages_limit;
+};
+
+void codeset_init(struct codeset *codeset);
+SCM codeset_number_to_symbol(struct codeset *codeset, int number);
+const char *codeset_number_to_message(struct codeset *codeset, int number);
+int codeset_symbol_to_number(struct codeset *codeset, SCM symbol);
+const char *codeset_name_to_message(struct codeset *codeset, const char *name);
+
+extern struct codeset errno_codeset;
 
 extern SCM  STk_posix_error_condition;  /* condition type &posix-error */
 


### PR DESCRIPTION
Here's a working implementation of SRFI 238 which was finalized this week. It converts STklos' existing errno and signal lists into a form that works with the SRFI, while also preserving STklos' existing behavior.

Examples from the REPL:

```Scheme
stklos> (codeset-list)
(signal errno)
stklos> (codeset-symbols 'signal)
(SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGIOT SIGEMT SIGFPE SIGKILL SIGBUS SIGSEGV SIGSYS ...)
stklos> SIGINT
2
stklos> (codeset-message 'signal SIGINT)
"Interrupt"
stklos> (codeset-message 'signal 'SIGINT)
"Interrupt"
stklos> (map (lambda (code) (codeset-message 'signal code)) (codeset-symbols 'signal))
("Hangup" "Interrupt" "Quit" "Illegal instruction" "Trace/BPT trap" "Abort trap" "Abort trap" "EMT trap"
"Floating point exception" "Killed" "Bus error" "Segmentation fault" "Bad system call" "Broken pipe" ...)
```

There are some TODO comment in the code about a few missing things.

* The string buffer for the messages should grow dynamically if it doesn't have enough space. Does STklos have a ready-made buffer we can use?

* A library hasn't yet been added, so `(import (srfi 238))` does not work.