### PR TITLE
Inline `fx=` `fx<` and similar

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -68,6 +68,11 @@
                          (fx<=?          . ,fx<=?)
                          (fx>?           . ,fx>?)
                          (fx>=?          . ,fx>=?)
+                         (fx=            . ,fx=?)
+                         (fx<            . ,fx<?)
+                         (fx<=           . ,fx<=?)
+                         (fx>            . ,fx>?)
+                         (fx>=           . ,fx>=?)
                          (cons           . ,cons)
                          (car            . ,car)
                          (cdr            . ,cdr)
@@ -1143,16 +1148,17 @@ doc>
                                 ((>=) 'IN-NUMGE))))
                 (else  (compile-normal-call fct actuals len env epair #f))))
 
-      ((fx=? fx<? fx>? fx<=? fx>=?)
+      ((fx=? fx<? fx>? fx<=? fx>=?
+        fx=  fx<  fx>  fx<=  fx>= )
                 (case len
                 ((O)   (compiler-error fct epair
                                         "needs at least one argument" fct))
                 ((2)   (comp2 (case fct
-                                ((fx=?)  'IN-FXEQ)
-                                ((fx<?)  'IN-FXLT)
-                                ((fx>?)  'IN-FXGT)
-                                ((fx<=?) 'IN-FXLE)
-                                ((fx>=?) 'IN-FXGE))))
+                                ((fx=?  fx=)  'IN-FXEQ)
+                                ((fx<?  fx<)  'IN-FXLT)
+                                ((fx>?  fx>)  'IN-FXGT)
+                                ((fx<=? fx<=) 'IN-FXLE)
+                                ((fx>=? fx>=) 'IN-FXGE))))
                 (else  (compile-normal-call fct actuals len env epair #f))))
 
       ((cons)   (comp2 'IN-CONS))


### PR DESCRIPTION
The ones without question mark at the end were not optimized:

```
stklos> (disassemble-expr '(fx< 1 a))

000:  PREPARE-CALL
001:  ONE-PUSH
002:  GLOBAL-REF-PUSH      0
004:  GREF-INVOKE          1 2
007:
stklos> (disassemble-expr '(fx<? 1 a))

000:  ONE-PUSH
001:  GLOBAL-REF           0
003:  IN-FXLT
004:
```

With this PR, bothe produce the same output (without the procedure call).

The speed difference can be quite large.
Out of curiosity, I timed two code chinks, compiling STklos with both `-O2` and with `-O0`:

```scheme
(define a 10)

(time
 (repeat 1_000_000_000
         (fx<? 1 a)))   ;; with -O2: 44835.161 ms
                        ;; with -O0: 77795.824 ms

(time
 (repeat 1_000_000_000
         (fx<  1 a)))   ;; with -O2: 60694.25 ms
                        ;; with -O0: 117426.244 ms
```

So, from 44.8s to 60.9s in an usual (optimized) setting.

That said, I suppose the ideal thing would be to have a list of aliases for procedures so we wouldn't have to hardcode them as I just did in this PR... (Maybe later?)