### PR TITLE
Optimize calls to no-argument lambdas

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1214,6 +1214,35 @@ doc>
         (compiler-error 'lambda epair "bad number of parameters ~S" actuals))))
 
 
+;; DEFINING-FORM? is used in COMPILE-CALL.
+;;
+;; We need to be able to tell if a defining for is at the beginning of
+;; a lambda form. We avoid converting
+;;
+;; ( (lambda () (define ...) ...) )
+;;
+;; into
+;;
+;; (begin (define ...) ...)
+;;
+;; because the first form is wrong (internal defines are not allowed in
+;; a lambda-form), and we'd be transforming it into a correct form.
+;;
+;; We also disallow (begin ...), since
+;;
+;; (begin (begin (define ...) ...) ...)
+;;
+;; would also be correct, although
+;;
+;; ( (lambda () (begin (define ...) ...) ... ) )
+;;
+;; is not.
+;;
+;; For that, we need the DEFINING-FORM? procedure:
+(define (defining-form? f)
+  ;; Problem: what if the user shadows "define" or similar?
+  (memq f '(define begin define-syntax define-macro)))
+
 (define (compile-call args env tail?)
   (let* ((fct     (car args))
          (actuals (cdr args))
@@ -1247,7 +1276,8 @@ doc>
           ;; However, we do not transform if the CDDR to be null, since (lambda ()) is not
           ;; allowed.
           (if (and (null? (cadr fct))
-                   (not (null? (cddr fct))))
+                   (not (null? (cddr fct)))
+                   (not (defining-form? (caddr fct))))
               (compile-body (cddr fct) env args tail?)
               (compile-lambda-call fct actuals len env ep tail?)))
 

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1219,7 +1219,7 @@ doc>
          (actuals (cdr args))
          (len     (length actuals)))
     (if (and (pair? fct) (or (eq? (car fct) 'lambda)
-                          (eq? (car fct) '|λ|)))
+                             (eq? (car fct) '|λ|)))
         ;; fct is (lambda (...) ...)
         ;;    if fct is not an epair, it is probably because it has been
         ;;    built programmatically. Anyway its body is probably an epair
@@ -1227,7 +1227,30 @@ doc>
                     ((%epair? fct) fct)
                     ((>= (length fct) 3) (cddr fct))
                     (else fct))))
-          (compile-lambda-call fct actuals len env ep tail?))
+
+          ;; If we're applying a lambda without arguments, ((lambda () ...)), we may
+          ;; transform it into (begin ...), which is much more efficient. Given
+          ;; how common it is to pass chunks to procedures, this can speed up
+          ;; execution considerably:
+          ;;
+          ;; (disassemble-expr '((lambda () a b)))
+          ;;
+          ;; 000:  PREPARE-CALL             <==
+          ;; 001:  ENTER-LET            0   <==
+          ;; 003:  GLOBAL-REF           0
+          ;; 005:  GLOBAL-REF           1
+          ;; 007:  LEAVE-LET                <==
+          ;;
+          ;; The PREPARE-CALL, ENTER-LET and LEAVE-LET instructions are not necessary,
+          ;; and will not be generated if we actually transform the lambda into a begin.
+          ;;
+          ;; However, we do not transform if the CDDR to be null, since (lambda ()) is not
+          ;; allowed.
+          (if (and (null? (cadr fct))
+                   (not (null? (cddr fct))))
+              (compile-body (cddr fct) env args tail?)
+              (compile-lambda-call fct actuals len env ep tail?)))
+
         (if (can-be-inlined? fct env)
             (compile-primitive-call fct actuals len env args tail?)
             (compile-normal-call    fct actuals len env args tail?)))))


### PR DESCRIPTION
Hi @egallesio ! What do you think of this?

We transform `((lambda () ...))` into `(begin ...)`.                                                                                                                                                                                

If we're applying a lambda without arguments, ((lambda () ...)), we may transform it into (begin ...), which is much more efficient. Given how common it is to pass thunks to procedures, this can speed up execution considerably in cases where code is generated by macros  (although full inlining would be much better, but also more complex):

    
```
(disassemble-expr '((lambda () a b)))

000:  PREPARE-CALL             <==
001:  ENTER-LET            0   <==
003:  GLOBAL-REF           0
005:  GLOBAL-REF           1
007:  LEAVE-LET                <==
```
 
The `PREPARE-CALL`, `ENTER-LET` and `LEAVE-LET` instructions are not necessary, and will not be generated if we actually transform the lambda into a begin.
    
We do not transform if the CDDR to be null, since `(lambda ())` is not allowed.

However, this fails:

```
(require "full-syntax")
(let-syntax ((foo (syntax-rules ()
                    ((_ expr) (+ expr 1)))))
  (let ((+ *))
    (foo 3)))
```

(expected 4 but got 3)

Likely because `"full-syntax"` was not provided/loaded, but I could't see exactly why.
Anyway, rewriting the syntax system is on the TODO list, so this may be fixed in the future with a new syntax system.

Also two other failure in the test suite, but I can't reproduce them:

```
test Test #3.1 on (let-syntax ((foo (syntax-rules () ((_ expr) (+ expr 1))))) (let ((+ *)) (foo 3))) expected 4 but got 3 
test Test #3.2 on (let-syntax ((foo (syntax-rules () ((_ var) (define var 1))))) (let ((x 2)) (begin (define foo +)) (cond (else (foo x))) x)) expected 2 but got 1 
test Test #8.1 on (let - ((n (- 1))) n) expected -1 but got 1
```

I'll mark this as not yet ready (draft), but I thought it would be nice to keep it here. Maybe soon it'll be possible to merge it?


