### PR TITLE
Declare support for SRFI 244

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -133,3 +133,4 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-233: INI files
     - SRFI-236: Evaluating expressions in an unspecified order
     - SRFI-238: Codesets
+    - SRFI-244: Multiple-value definitions

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -283,7 +283,7 @@
     ;; 241 Match -- Simple Pattern-Matching Syntax to Express Catamorphisms on Scheme Data (drafr)
     ;; 242 The CFG Language (draft)
     ;; 243 Unreadable objects (draft)
-    ;; 244 Multiple-value definitions (draft)
+    (244 "Multiple-value definitions")
     ))
 
 ;; Some shortcuts to add to the SRFI-features which permit to load seveal file


### PR DESCRIPTION
It's `define-values`, which is part of R7RS; the SRFI is intended for R6RS systems. But since R7RS systems do support it out of the box, advertising it would seem the right thing to do.