### PR TITLE
Fixes to SRFI-19

### DIFF
--- a/lib/srfi/19.stk
+++ b/lib/srfi/19.stk
@@ -205,11 +205,10 @@
 ;;;
 
 (define (copy-time time)
-  (let ((ntime (make-time #f #f #f)))
-    (set-time-type! ntime (time-type time))
-    (set-time-second! ntime (time-second time))
-    (set-time-nanosecond! ntime (time-nanosecond time))
-    ntime))
+  (let ((type (time-type time))
+        (second (time-second time))
+        (nanosecond (time-nanosecond time)))
+    (make-time type nanosecond second)))
 
 ;;;
 ;;; CURRENT-TIME VARIATIONS
@@ -701,8 +700,11 @@ doc>
   (tm:time->date time tz-offset time-utc))
 
 ;; again, time-monotonic is the same as time tai
+;; we just use time-tai->date
 (define (time-monotonic->date time . tz-offset)
-  (tm:time->date time tz-offset time-monotonic))
+  (if (null? tz-offset)
+      (time-tai->date (time-monotonic->time-tai time))
+      (time-tai->date (time-monotonic->time-tai time) (car tz-offset))))
 
 
 ;;;

--- a/lib/srfi/19.stk
+++ b/lib/srfi/19.stk
@@ -205,10 +205,7 @@
 ;;;
 
 (define (copy-time time)
-  (let ((type (time-type time))
-        (second (time-second time))
-        (nanosecond (time-nanosecond time)))
-    (make-time type nanosecond second)))
+  (make-time (time-type time) (time-nanosecond time) (time-second time)))
 
 ;;;
 ;;; CURRENT-TIME VARIATIONS

--- a/lib/time.stk
+++ b/lib/time.stk
@@ -420,7 +420,22 @@ doc>
                         (day 1) (month 1) (year 1970) (zone-offset #f))
   (%make-date nanosecond second minute hour day month year zone-offset))
 
+(define (check name arg min max)
+  (unless (and (integer? arg)
+               (<= min arg max))
+    (error "bad ~s ~s" name arg)))
+
 (define (%make-date   nanosecond second minute hour day month year zone-offset)
+  (check 'nanosecond nanosecond 0 999999999)
+  (check 'second second 0 60)
+  (check 'minute minute 0 59)
+  (check 'hour hour 0 23)
+  (check 'day day 1 31)
+  (check 'month month 1 12)
+  (unless (integer? year) (error "bad year ~s" year))
+  (unless (or (integer? zone-offset)
+              (not zone-offset))
+    (error "bad zone offset ~s" zone-offset))
   (let ((res (make-struct %date
                           nanosecond
                           second

--- a/tests/srfis/19.stk
+++ b/tests/srfis/19.stk
@@ -56,7 +56,6 @@
         #t
         (time=? t4 (time-difference t2 t1))))
 
-
 (define (test-one-utc-tai-edge utc tai-diff tai-last-diff)
   (let* (;; right on the edge they should be the same
          (utc-basic (make-time 'time-utc 0 utc))
@@ -201,3 +200,107 @@
                                       0)
                            "~V"))))
    dates))
+
+
+;; Some extra tests
+;; -- jpellegrini
+;;
+
+(test "srfi-19 current time increases monotonically"
+      #t
+      (time<? (current-time 'time-monotonic)
+              (current-time 'time-monotonic)))
+
+(let ((d (make-date 05     ; nano
+                    10     ; sec
+                    15     ; min
+                    20     ; hour
+                    25     ; day
+                    06     ; month
+                    2000   ; year
+                   -10800))) ; offset
+  (test "srfi-19 date?" #t (date? d))
+  (test "srfi-19 date nanosecond" 05 (date-nanosecond d))
+  (test "srfi-19 date second"     10 (date-second d))
+  (test "srfi-19 date minute"     15 (date-minute d))
+  (test "srfi-19 date hour"       20 (date-hour d))
+  (test "srfi-19 date day"        25 (date-day d))
+  (test "srfi-19 date month"      06 (date-month d))
+  (test "srfi-19 date year"     2000 (date-year d))
+  (test "srfi-19 date offset" -10800 (date-zone-offset d))
+
+  (let ((m (date->time-monotonic d)))
+    (test "srfi 19 date conversions 1" #t (time? m))
+    (test "srfi 19 date conversions 2" 'time-monotonic (time-type m))
+    (test "srfi 19 date conversions 3" #t (equal? d (time-monotonic->date m)))
+    (test "srfi 19 date conversions 4" #t (time? (time-monotonic->time-tai m)))
+    (test "srfi 19 date conversions 5" 'time-tai (time-type (time-monotonic->time-tai m)))
+    (test "srfi 19 date conversions 6" #t (equal? (time-tai->date (time-monotonic->time-tai m))
+                                                  d)))
+  (let ((m (date->time-utc d)))
+    (test "srfi 19 date conversions 7" #t (time? m))
+    (test "srfi 19 date conversions 8" 'time-utc (time-type m))
+    (test "srfi 19 date conversions 9" #t (equal? d (time-utc->date m)))
+    (test "srfi 19 date conversions 10" #t (time? (time-utc->time-tai m)))
+    (test "srfi 19 date conversions 11" 'time-tai (time-type (time-utc->time-tai m)))
+    (test "srfi 19 date conversions 12" #t (equal? (time-tai->date (time-utc->time-tai m))
+                                                  d)))
+  (let ((m (date->time-tai d)))
+    (test "srfi 19 date conversions 13" #t (time? m))
+    (test "srfi 19 date conversions 14" 'time-tai (time-type m))
+    (test "srfi 19 date conversions 15" #t (equal? d (time-tai->date m)))
+    (test "srfi 19 date conversions 16" #t (time? (time-tai->time-utc m)))
+    (test "srfi 19 date conversions 17" 'time-utc (time-type (time-tai->time-utc m)))
+    (test "srfi 19 date conversions 18" #t (equal? (time-utc->date (time-tai->time-utc m))
+                                                  d))))
+
+
+(test/error "srfi 19 wrong args to make-date 1"
+            (make-date 05     ; nano
+                       10     ; sec
+                       90     ; min   -- WRONG
+                       20     ; hour
+                       25     ; day
+                       06     ; month
+                       2000   ; year
+                       -10800))
+
+(test/error "srfi 19 wrong args to make-date 2"
+            (make-date 05     ; nano
+                       10     ; sec
+                       15     ; min
+                       20     ; hour
+                       25     ; day
+                       20     ; month - -WRONG
+                       2000   ; year
+                       -10800))
+
+(test/error "srfi 19 wrong args to make-date 3"
+            (make-date 05     ; nano
+                       10     ; sec
+                       'a     ; min  -- WRONG
+                       20     ; hour
+                       25     ; day
+                       06     ; month
+                       2000   ; year
+                       -10800))
+
+(test/error "srfi 19 wrong args to make-date 3"
+            (make-date 05     ; nano
+                       10     ; sec
+                       15     ; min
+                       1+1i   ; hour -- WRONG
+                       25     ; day
+                       06     ; month
+                       2000   ; year
+                       -10800))
+
+(test/error "srfi 19 wrong args to make-date 3"
+            (make-date 05     ; nano
+                       10     ; sec
+                       15     ; min
+                       20     ; hour
+                       25     ; day
+                       2/3    ; month -- WRONG
+                       2000   ; year
+                       -10800))


### PR DESCRIPTION
- The `copy-time` procedure would call `make-time` with parameters `#f #f #f`, but the `make-time` procedure only accepts proper integers for second and nanosecond

- `time-monotonic->date` should do the same as `time-tai->date`, but was not, so the results were wrong

- We now check the arguments to `make-date` (`make-time` already did this).

Added tests for several more cases.