### PR TITLE
Add date comparison functions to SRFI-19

### DIFF
--- a/doc/refman/srfi.adoc
+++ b/doc/refman/srfi.adoc
@@ -131,7 +131,7 @@ are given <<feature_identifiers>>.
 
 
 === Misc. Information
-//desactivate numbering 
+//desactivate numbering
 :sectnums!:
 Previous section described the general way to use the SRFIS implemented in
 {{stklos}}.  This section concentrates on information not given above.
@@ -183,6 +183,16 @@ this document (see _<<readerctor, primitive `define-reader-ctor`>>_).
 {{quick-link-srfi 17}} is fully supported. See the documentation of procedures `set!`
 and `setter`. However, requiring explicitly `srfi-17` permits
 to define the setters for the (numerous) `cXXXXr` list procedures.
+
+
+// **** SRFI-19
+{{srfi-subsection 19}}
+((("time")))
+{{quick-link-srfi 19}} is fully supported. STklos offers, as an extension,
+the procedures `date=?`, `date<?`, `date>?`, `date<=?` and `date>=?`. These
+will compare dates by first normalizing them to make the time zone offset
+irrelevant, so "2000 Nov 12 03:30:10 GMT-2" will be taken as equal to
+"2000 Nov 12 02:30:10 GMT-1".
 
 
 
@@ -292,7 +302,7 @@ load this file.
 {{srfi-subsection 55}}
 ((("require-extension")))
 {{quick-link-srfi 55}} is fully supported. Furthermore, {{stklos}}
-also accepts the symbols defined in <<feature_identifiers>> 
+also accepts the symbols defined in <<feature_identifiers>>
 in a _require-extension_ clause.
 
 
@@ -420,7 +430,7 @@ use with `cond-expand` in the compiled code only. It will not include
 // **** SRFI-145
 {{srfi-subsection 145}}
 (((assume)))
-{{quick-link-srfi 145}} is fully supported. See the 
+{{quick-link-srfi 145}} is fully supported. See the
 _<<assume,`assume` special form>>_.
 
 

--- a/lib/srfi/19.stk
+++ b/lib/srfi/19.stk
@@ -113,7 +113,14 @@
           time-tai->modified-julian-day
           time-tai->time-monotonic time-tai->time-monotonic!
           time-tai->time-utc time-tai->time-utc!
-          date->string string->date)
+          date->string string->date
+
+          ;; added by EG as an extension to SRFI-19
+          date=?
+          date<?
+          date>?
+          date<=?
+          date>=?)
 
 ;; Save the original definition of current-time since it will be changed later
 (define %stklos-current-time (symbol-value 'current-time (find-module 'SCHEME)))
@@ -1532,6 +1539,21 @@ doc>
         (tm:time-error 'string->date 'bad-date-format-string
                        (list "Incomplete date read. " newdate template-string)))))
 
+
+;; EG: Comparisons function on date (must be in SRFI-19)
+;;
+(define (%date-test compare?)
+  (lambda (d1 d2)
+    (unless (date? d1) (error "bad date ~s" d1))
+    (unless (date? d2) (error "bad date ~s" d2))
+    (compare? (date->time-tai d1)
+              (date->time-tai d2))))
+
+(define date=?  (%date-test time=?))
+(define date<?  (%date-test time<?))
+(define date>?  (%date-test time>?))
+(define date<=? (%date-test time<=?))
+(define date>=? (%date-test time>=?))
 
 ) ;; END of module srfi/19
 

--- a/tests/srfis/19.stk
+++ b/tests/srfis/19.stk
@@ -203,20 +203,6 @@
 
 
 
-;; EG: Comparisons function on date (must be in SRFI-19)
-;;
-(define (%date-test comparator)
-  (lambda (d1 d2)
-    (unless (date? d1) (error "bad date ~s" d1))
-    (unless (date? d2) (error "bad date ~s" d2))
-    (comparator (date->time-tai d1)
-                (date->time-tai d2))))
-
-(define date=?  (%date-test time=?))
-(define date<?  (%date-test time<?))
-(define date>?  (%date-test time>?))
-(define date<=? (%date-test time<=?))
-(define date>=? (%date-test time>=?))
 
 
 ;; Some extra tests


### PR DESCRIPTION
Now STklos offers, as an extension to SRFI-19, the procedures `date=?`, `date<?`, `date>?`, `date<=?` and `date>=?`. These will compare dates by first normalizing them to make the time zone offset irrelevant, so "2000 Nov 12 03:30:10 GMT-2" will be taken as equal to "2000 Nov 12 02:30:10 GMT-1".

@egallesio I'm not sure I got the documentation right...