### PR TITLE
Add hyperbolic trigonometric functions

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -52,6 +52,10 @@ static unsigned int log10_maxint;
 
 #define FINITE_REALP(n) isfinite(REAL_VAL(n))
 
+/* Complex i:
+   will be used as a constant when computing some functions. */
+static SCM complex_i;
+
 /* Forward declarations */
 static void integer_division(SCM x, SCM y, SCM *quotient, SCM* remainder);
 
@@ -1433,7 +1437,7 @@ doc>
 DEFINE_PRIMITIVE("integer-length", integer_length, subr1, (SCM z))
 {
    switch (TYPEOF(z)) {
-    case tc_integer:{ 
+    case tc_integer:{
       long n = INT_VAL(z);
       if (n == -1 || n == 0) return MAKE_INT(0);
       if (n>0)  return MAKE_INT( (long) log2( (float) n) + 1 ); /* n >  0 */
@@ -2456,6 +2460,16 @@ DEFINE_PRIMITIVE("round", round, subr1, (SCM x))
   return STk_void; /* never reached */
 }
 
+/* ============== TRANSCENDENTALS */
+
+
+#define transcendental(name)                            \
+  DEFINE_PRIMITIVE(#name, name, subr1, (SCM z))         \
+  {                                                     \
+     return my_##name(z);                               \
+  }
+
+
 /*
 <doc  exp log sin cos tan asin acos atan
  * (exp z)
@@ -2705,21 +2719,278 @@ static SCM my_atan2(SCM y, SCM x)
                            REAL_VAL(exact2inexact(STk_real_part(x)))));
 }
 
-
-/*=============================================================================*/
-
-#define transcendental(name)                            \
-  DEFINE_PRIMITIVE(#name, name, subr1, (SCM z))         \
-  {                                                     \
-     return my_##name(z);                               \
-  }
-
 transcendental(exp)
 transcendental(sin)
 transcendental(cos)
 transcendental(tan)
 transcendental(asin)
 transcendental(acos)
+
+
+/* ========== HYPERBOLIC */
+
+/*
+<doc sinh asinh cosh acosh tanh atanh
+ * (sinh z)
+ * (cosh z)
+ * (tanh z)
+ * (asinh z)
+ * (acosh z)
+ * (atanh z)
+ *
+ * These procedures compute the hyperbolic trigonometric functions.
+ * @lisp
+ * (sinh 1)     => 1.1752011936438
+ * (sinh 0+1i)  => 0.0+0.841470984807897i
+ * (cosh 1)     => 1.54308063481524
+ * (cosh 0+1i)  => 0.54030230586814
+ * (tanh 1)     => 0.761594155955765
+ * (tanh 0+1i)  => 0.0+1.5574077246549i
+ * (asinh 1)    => 0.881373587019543
+ * (asinh 0+1i) => 0+1.5707963267949i
+ * (acosh 0)    => 0+1.5707963267949i
+ * (acosh 0+1i) => 1.23340311751122+1.5707963267949i
+ * (atanh 1)    => error
+ * (atanh 0+1i) => 0.0+0.785398163397448i
+ * @end lisp
+ *
+ * In general, |(asinh (sinh x))| and similar compositions should be
+ * equal to |x|, except for inexactness due to the internal floating
+ * point number approximation for real numbers.
+ * @lisp
+ * (sinh (asinh 0+1i)) => 0.0+1.0i
+ * (cosh (acosh 0+1i)) => 8.65956056235493e-17+1.0i
+ * (tanh (atanh 0+1i)) => 0.0+1.0i
+ * @enb lisp
+ *
+ * These functions will always return an exact result for the following
+ * arguments:
+ * @lisp
+ * (sinh 0.0)     => 0
+ * (cosh 0.0)     => 1
+ * (tanh 0.0)     => 0
+ * (asinh 0.0)    => 0
+ * (acosh 1.0)    => 0
+ * (atanh 0.0)    => 0
+ * @end lisp
+doc>
+*/
+
+static SCM my_cosh(SCM z)
+{
+  switch (TYPEOF(z)) {
+  /* 1. fastest for reals/fixnums is to use C 'cosh'.
+
+     2. cosh(z) = [  1 + exp(-2x)  ] /  2exp(-x)
+                = [ exp(x) + exp(-x) ] / 2
+        faster for the rest.
+
+     3. cosh(z) = cos(i z),
+        but it's always slow. (not used) */
+  case tc_real:     if (fpclassify(REAL_VAL(z)) == FP_ZERO) return MAKE_INT(1);
+                    return double2real(cosh(REAL_VAL(z)));
+  case tc_integer:  if (INT_VAL(z) == 0) return MAKE_INT(1);
+                    return double2real(cosh(INT_VAL(z)));
+  case tc_complex:
+  case tc_bignum:
+  case tc_rational:
+      SCM ez = my_exp(z);
+      SCM inv_ez = div2 (MAKE_INT(1), ez);
+      return div2(add2(ez,inv_ez),
+                  double2real(2.0));
+  default:          error_bad_number(z);
+  }
+}
+
+static SCM my_sinh(SCM z)
+{
+  /* 1. fastest for reals/fixnums is to use C 'sinh'.
+
+     2. cosh(z) = [  1 - exp(-2x)  ] /  2exp(-x)
+                = [ exp(x) - exp(-x) ] / 2
+        (faster for all but reals/fixnums)
+
+     3. sinh(z) = -i sin(i z),
+        but it is almost always faster to use exponentials
+        (not used) */
+  switch (TYPEOF(z)) {
+  case tc_real:     if (fpclassify(REAL_VAL(z)) == FP_ZERO) return MAKE_INT(0);
+                    return double2real(sinh(REAL_VAL(z)));
+  case tc_integer:  if (INT_VAL(z) == 0) return MAKE_INT(0);
+                    return double2real(sinh(INT_VAL(z)));
+  case tc_complex:
+  case tc_bignum:
+  case tc_rational:
+      SCM ez = my_exp(z);
+      SCM inv_ez = div2 (MAKE_INT(1), ez);
+      return div2(sub2(ez,inv_ez),
+                  double2real(2.0));
+  default:          error_bad_number(z);
+  }
+}
+
+
+static SCM my_tanh(SCM z)
+{
+  /* 1. fastest for reals/fixnums is to use C 'tanh'.
+
+     2. tanh(z) = [  exp(2x) - 1  ] /  [ exp(2x) + 1  ]
+        (faster for all but reals/fixnums)
+
+     3. tanh(z) = -i tan(i z)
+        but this is always slower than using exponentials...
+        (not used) */
+  switch (TYPEOF(z)) {
+  case tc_real:     if (fpclassify(REAL_VAL(z)) == FP_ZERO) return MAKE_INT(0);
+                    return double2real(tanh(REAL_VAL(z)));
+  case tc_integer:  if (INT_VAL(z) == 0) return MAKE_INT(0);
+                    return double2real(tanh(INT_VAL(z)));
+  case tc_complex:
+  case tc_bignum:
+  case tc_rational:
+      SCM ez = my_exp(z);
+      SCM inv_ez = div2 (MAKE_INT(1), ez);
+      return div2(sub2 (ez, inv_ez),
+                  add2 (ez, inv_ez));
+  default:          error_bad_number(z);
+  }
+}
+
+
+/* asinh is defined for all real numbers, so we can safely use
+   the C function "asinh". */
+static SCM my_asinh(SCM z) {
+  /* asinh(z) = ln (z + SQRT(z^2 + 1)) */
+  switch (TYPEOF(z)) {
+  case tc_real:     if (fpclassify(REAL_VAL(z)) == FP_ZERO) return MAKE_INT(0);
+                    return double2real(asinh(REAL_VAL(z)));
+  case tc_integer:  if (INT_VAL(z) == 0) return MAKE_INT(0);
+                    return double2real(asinh(INT_VAL(z)));
+  case tc_complex:
+  case tc_bignum:
+  case tc_rational: return my_log(add2(z, STk_sqrt(add2(mul2(z,z), MAKE_INT(1)))));
+  default:          error_bad_number(z);
+  }
+}
+
+
+/* acosh_aux computes acosh of *non-complex* z (zz), using fast C
+   math but reverting to my_log, add2 and STk_sqrt for values less
+   than +1, which will produce a NaN from the C library. */
+static inline SCM
+acosh_aux(SCM z, double zz) {
+    double r = zz*zz - 1;
+    if (!isinf(r) && r >= 0) { /* can be too large for a double if
+                                zz is too large; can be negative if
+                                zz is in (0,+1). */
+        double zzz = sqrt(r) + zz;
+        if (!isinf(zzz)) /* did it overflow when we summed zz? */
+            return double2real(log(zzz));
+    }
+    return my_log(add2(z, STk_sqrt(sub2(mul2(z,z), MAKE_INT(1)))));
+}
+
+static SCM my_acosh(SCM z) {
+  /* acosh(z) = ln (z + SQRT(z^2 - 1)) */
+  switch (TYPEOF(z)) {
+  case tc_real:     {
+      if (fpclassify(REAL_VAL(z)-1.0) == FP_ZERO) return MAKE_INT(0);
+      return acosh_aux(z, REAL_VAL(z));
+  }
+  case tc_integer:  {
+      if (INT_VAL(z) == 1) return MAKE_INT(0);
+      return acosh_aux(z, (double)INT_VAL(z));
+  }
+  case tc_complex:
+  case tc_bignum:
+  case tc_rational: return my_log(add2(z, STk_sqrt(sub2(mul2(z,z), MAKE_INT(1)))));
+  default:          error_bad_number(z);
+  }
+}
+
+
+/*
+  atanh_aux computes
+  (1/2) [ ln (numer) - ln (denom) ],
+  which is the value of atanh(z) when
+  numer = 1+z
+  denom = 1-z
+  This avoids NaNs when z is outside (-1,+1).
+*/
+static inline SCM
+atanh_aux(double numer, double denom) {
+      if (numer > 0.0 && denom > 0)
+          return double2real((log(numer) -
+                              log(denom)) / 2.0);
+      SCM l = sub2(my_log(double2real(numer)),
+                   my_log(double2real(denom)));
+      if (REALP(l)) return double2real(REAL_VAL(l)/2.0);
+      return div2(l, double2real(2.0));
+}
+
+static SCM my_atanh(SCM z) {
+  /* When z=1 or z=-1:
+     Chez, Gambit and most Common Lisp implementations signal an error, because
+     the argument is out of range.
+     Gauche, Guile, Kawa return +inf.0 or -inf.0.
+     We do the same as Chez and Gambit */
+
+  /* We do not use atanh from C for values outside the interval (-1,1)
+     even if the argument is native double or long, because the C
+     implementation doesn't handle complex numbers, and the value returned
+     can be a NaN (but Scheme implementations will define atanh for all
+     numbers). */
+
+  /* atanh(z) = (1/2) ln [ (1+z) / (1-z) ]
+              = (1/2) [ ln (1+z) - ln (1-z) ] */
+  switch (TYPEOF(z)) {
+  case tc_real:    {
+      double zz = REAL_VAL(z);
+      if (zz == -1.0 || zz == +1.0)
+          STk_error("argument out of range ~s", z);
+      if (fpclassify(zz) == FP_ZERO) return MAKE_INT(0);
+      return atanh_aux(1.0 + zz, 1.0 - zz);
+  }
+  case tc_integer:  {
+      long zz = INT_VAL(z);
+      if (zz == -1 || zz == +1)
+          STk_error("argument out of range ~s", z);
+      if (zz == 0) return MAKE_INT(0);
+      return atanh_aux(1.0 + zz, 1.0 - zz);
+  }
+  case tc_complex:
+  case tc_bignum:
+  case tc_rational: {
+      SCM numer = add2(MAKE_INT(1),z);
+      SCM denom = sub2(MAKE_INT(1),z);
+      if (zerop(numer) || zerop(denom))
+          STk_error("argument out of range ~s", z);
+      /* Too slow to use div2 here, since my_log will return
+         inexact, except when log returns zero or a complex.
+         Also, log(a)-log(b) is twice as fast as log(a/b)
+         when working with bignums!
+         However, zero will never happen, since numer = denom+2,
+         and log(x) is never log(x-2), so we don't check for
+         zero. */
+      SCM l = sub2(my_log(numer), my_log(denom));
+      if (REALP(l)) return double2real(REAL_VAL(l)/2.0);
+      return div2(l, double2real(2.0));
+  }
+  default:          error_bad_number(z);
+  }
+}
+
+
+transcendental(cosh)
+transcendental(sinh)
+transcendental(tanh)
+transcendental(acosh)
+transcendental(asinh)
+transcendental(atanh)
+
+
+
+/*=============================================================================*/
 
 DEFINE_PRIMITIVE("log", log, subr12, (SCM x, SCM b))
 {
@@ -3366,6 +3637,8 @@ int STk_init_number(void)
   minus_inf = -HUGE_VAL;
   STk_NaN   =  strtod("NAN", NULL);
 
+  complex_i = make_complex(MAKE_INT(0),MAKE_INT(1));
+
   /* Force the LC_NUMERIC locale to "C", since Scheme definition
      imposes that decimal numbers use a '.'
   */
@@ -3447,6 +3720,13 @@ int STk_init_number(void)
   ADD_PRIMITIVE(asin);
   ADD_PRIMITIVE(acos);
   ADD_PRIMITIVE(atan);
+
+  ADD_PRIMITIVE(cosh);
+  ADD_PRIMITIVE(sinh);
+  ADD_PRIMITIVE(tanh);
+  ADD_PRIMITIVE(acosh);
+  ADD_PRIMITIVE(asinh);
+  ADD_PRIMITIVE(atanh);
 
   ADD_PRIMITIVE(sqrt);
   ADD_PRIMITIVE(expt);

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -142,7 +142,7 @@
 
 (test "rational reader" '(1 #t) (rational-test (string->number "3/03")))
 (test/error "rational reader" (string->number "3/0"))
-(test/error "rational reader" '3/3/4)            
+(test/error "rational reader" '3/3/4)
 (test/error "rational reader" (rational-test (string->number "1/2.")))
 (test/error "rational reader" (rational-test (string->number "1.3/2")))
 
@@ -1321,7 +1321,7 @@
              (i (imag-part z)))
         (and (<  1.99999999 r  2.00000001)
              (< -3.00000001 i -2.99999999))))
-       
+
 (test "sin 1-1i"
       #t
       (let* ((z (sin 1-1i))
@@ -1436,6 +1436,121 @@
 (test "atan tan 1 1"
       1.0
       (atan (tan 1) 1))
+
+;; hyperbolic trigs
+
+(test "sinh 5"
+      #t
+      (< 74.20321057770000
+         (sinh 5)
+         74.20321057780000))
+
+(test "cosh 0.5"
+      #t
+      (< 1.1276259650000000
+         (cosh 0.5)
+         1.1276259660000000))
+
+(test "sinh 0.5"
+      #t
+      (< 0.521095305000000
+         (sinh 0.5)
+         0.521095306000000))
+
+(test "cosh 7"
+      #t
+      (< 548.31703515400000
+         (cosh 7)
+         548.31703515600000))
+
+(test "tanh 0.5"
+      #t
+      (< 0.4621171572000000
+         (tanh 0.5)
+         0.4621171573000000))
+
+(test "tanh 2"
+      #t
+      (< 0.9640275800000000
+         (tanh 2)
+         0.9640275801000000))
+
+
+(test "sinh asinh 2"
+      #t
+      (< 1.9999999999
+         (sinh (asinh 2))
+         2.0000000001))
+
+(test "cosh acosh 2"
+      #t
+      (< 1.9999999999
+         (cosh (acosh 2))
+         2.0000000001))
+
+
+(test "tanh atanh 1/2"
+      #t
+      (< 0.4999999999
+         (tanh (atanh 1/2))
+         0.5000000001))
+
+
+(test "asinh 2"
+      #t
+      (< 1.4436354751000000
+         (asinh 2)
+         1.4436354752000000))
+
+(test "asinh 2^75"
+      #t
+      (< 52.67918572000000
+         (asinh (expt 2 75))
+         52.67918573000000))
+
+(test "acosh 3"
+      #t
+      (< 1.7627471740000000
+         (acosh 3)
+         1.7627471750000000))
+
+(test "acosh 2^75"
+      #t
+      (< 52.67918572000000
+         (acosh (expt 2 75))
+         52.67918573000000))
+
+(test "asinh 1"
+      #t
+      (< 0.8813735870000000
+         (asinh 1)
+         0.8813735880000000))
+
+;; Domain error:
+(test/error "atanh 1"    (atanh +1))
+(test/error "atanh -1"   (atanh -1))
+(test/error "atanh 1.0"  (atanh +1.0))
+(test/error "atanh -1.0" (atanh -1.0))
+
+(test "atanh 1/2"
+      #t
+      (< 0.5493061440000000
+         (atanh 1/2)
+         0.5493061450000000))
+
+;; These should return exact results:
+(test "sinh 0.0"  0 (sinh  0.0))
+(test "cosh 0.0"  1 (cosh  0.0))
+(test "tanh 0.0"  0 (tanh  0.0))
+(test "asinh 0.0" 0 (asinh 0.0))
+(test "acosh 1.0" 0 (acosh 1.0))
+(test "atanh 0.0" 0 (atanh 0.0))
+(test "sinh 0"    0 (sinh  0))
+(test "cosh 0"    1 (cosh  0))
+(test "tanh 0"    0 (tanh  0))
+(test "asinh 0"   0 (asinh 0))
+(test "acosh 1"   0 (acosh 1))
+(test "atanh 0"   0 (atanh 0))
 
 ;;------------------------------------------------------------------
 (test-subsection "Misc")


### PR DESCRIPTION
Specifically for `(atanh 1)` and `(atanh -1)` we trigger an error, as in Chez, Gambit and most Common Lisp implementations (as opposed to doing math with infinities).

Also included some (very few) tests.

A survey of which Schemes support these functions is available here: https://github.com/schemedoc/surveys/blob/master/surveys/hyperbolic-trigonometric.md

* I changed the placement of `#define transcendental(name)` to make things clearer (the hyperbolic trigs are defined after several others)

In general, `(asinh (sinh x))` and similar compositions should be equal to x, except for inexactness due to the internal floating point number approximation for real numbers.
```scheme
(sinh (asinh 0+1i)) => 0.0+1.0i
(cosh (acosh 0+1i)) => 8.65956056235493e-17+1.0i
(tanh (atanh 0+1i)) => 0.0+1.0i
```
These functions will always return an exact result for the following  arguments:
```scheme
(sinh 0.0)     => 0
(cosh 0.0)     => 1
(tanh 0.0)     => 0
(asinh 0.0)    => 0
(acosh 1.0)    => 0
(atanh 0.0)    => 0
``` 
The methods used are reasonably fast. Faster methods would make the code a bit too unclear, perhaps.
