### PR TITLE
Fix misreading of numbers

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -1230,7 +1230,7 @@ SCM STk_Cstr2number(char *str, long base)
         if (*p == 'i') {
           num1 = make_complex(num1, num2);
           p += 1;
-        } else STk_error("bad number %s", str);
+        } else return STk_false;
       }
     }
   } else if (*p == 'i' && is_signed) {

--- a/src/number.c
+++ b/src/number.c
@@ -1230,7 +1230,7 @@ SCM STk_Cstr2number(char *str, long base)
         if (*p == 'i') {
           num1 = make_complex(num1, num2);
           p += 1;
-        }
+        } else STk_error("bad number %s", str);
       }
     }
   } else if (*p == 'i' && is_signed) {
@@ -1433,7 +1433,7 @@ doc>
 DEFINE_PRIMITIVE("integer-length", integer_length, subr1, (SCM z))
 {
    switch (TYPEOF(z)) {
-    case tc_integer:{ 
+    case tc_integer:{
       long n = INT_VAL(z);
       if (n == -1 || n == 0) return MAKE_INT(0);
       if (n>0)  return MAKE_INT( (long) log2( (float) n) + 1 ); /* n >  0 */

--- a/tests/srfis/94.stk
+++ b/tests/srfis/94.stk
@@ -90,8 +90,8 @@
 (test "integer-expt 0^0" 1 (integer-expt 0 0))
 (test/error "integer-expt args 6" (integer-expt 0 -1))
 
-(test/error "real-expt args 1" (real-expt 1+01 1))
-(test/error "real-expt args 2" (real-expt 1 1+01))
+(test/error "real-expt args 1" (real-expt 1+0i 1))
+(test/error "real-expt args 2" (real-expt 1 1+0i))
 (test/error "real-expt args 3" (real-expt 0.0 -1))
 (test "real-expt" 2.25 (real-expt 1.5 2.0))
 

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -142,7 +142,7 @@
 
 (test "rational reader" '(1 #t) (rational-test (string->number "3/03")))
 (test/error "rational reader" (string->number "3/0"))
-(test/error "rational reader" '3/3/4)            
+(test/error "rational reader" '3/3/4)
 (test/error "rational reader" (rational-test (string->number "1/2.")))
 (test/error "rational reader" (rational-test (string->number "1.3/2")))
 
@@ -256,7 +256,6 @@
 (test "flonum from ratio reader" '(-1234.0 #t) (flonum-test '#i-1234/1))
 (test "flonum from ratio reader" '(-0.125 #t)  (flonum-test '#i-4/32))
 
-
 ;;------------------------------------------------------------------
 (test-subsection "complex reader")
 
@@ -324,6 +323,41 @@
 (test "complex from ratio reader (polar)" (make-polar #i2 #i5/-2)      '#i2@5/-2)
 (test "complex from ratio reader (polar)" (make-polar #i0 #i0)         '#i0/1@0/1)
 (test "complex from ratio reader (polar)" (make-polar #i-1/2 #i1/2)    '#i-1/2@1/2)
+
+;; missing "i" at the end of a complex number:
+(test/error "complex missing i 1" 2+3)
+(test/error "complex missing i 2" 2-3)
+(test/error "complex missing i 3" 2_2+3_3)
+(test/error "complex missing i 4" 2/3+4/5)
+(test/error "complex missing i 5" 2/3-4/5)
+(test/error "complex missing i 6" 1+1.0)
+(test/error "complex missing i 7" 1-1.0)
+
+;; these do trigger errors, but they also break the tests...
+;; (test/error "complex missing i 8" '#x2+2)
+;; (test/error "complex missing i 9" '#x2-2)
+;; (test/error "complex missing i 10" '#b11+11)
+;; (test/error "complex missing i 11" '#b11-11)
+
+;; complexes can be written in hex or binary.
+(test "complex hex ++"    '(#xab #x+c2)    (decompose-complex '#xab+c2i))
+(test "complex hex +-"    '(#xab #x-c2)    (decompose-complex '#xab-c2i))
+(test "complex hex -+"    '(#x-ab #x+c2)   (decompose-complex '#x-ab+c2i))
+(test "complex hex --"    '(#x-ab #x-c2)   (decompose-complex '#x-ab-c2i))
+(test "complex binary ++" '(#b101 #b111)   (decompose-complex '#b101+111i))
+(test "complex binary +-" '(#b101 #b-111)  (decompose-complex '#b101-111i))
+(test "complex binary -+" '(#b-101 #b111)  (decompose-complex '#b-101+111i))
+(test "complex binary --" '(#b-101 #b-111) (decompose-complex '#b-101-111i))
+
+(test "complex hex polar ++"    (make-polar #xa #xb)       #xa@b)
+(test "complex hex polar +-"    (make-polar #x-a #xb)      #x-a@b)
+(test "complex hex polar -+"    (make-polar #xa #x-b)      #xa@-b)
+(test "complex hex polar --"    (make-polar #x-a #x-b)     #x-a@-b)
+(test "complex binary polar ++" (make-polar #b101 #b111)   #b101@111)
+(test "complex binary polar +-" (make-polar #b-101 #b111)  #b-101@111)
+(test "complex binary polar -+" (make-polar #b101 #b-111)  #b101@-111)
+(test "complex binary polar --" (make-polar #b-101 #b-111) #b-101@-111)
+
 
 ;;------------------------------------------------------------------
 (test-subsection "integer writer syntax")
@@ -1321,7 +1355,7 @@
              (i (imag-part z)))
         (and (<  1.99999999 r  2.00000001)
              (< -3.00000001 i -2.99999999))))
-       
+
 (test "sin 1-1i"
       #t
       (let* ((z (sin 1-1i))


### PR DESCRIPTION
2+3 is not the same as 2. It's not even a number...

Fixes #461

(Is it ok to just do `STk_error("bad number %s", str)`?   Is `str` always zero-terminated?

All tests pass, and now the wrong "numbers" are not read as numbers anymore:

```
stklos> #xa+bi
10+11i

stklos> #xa+b
**** Error:
%read: bad number a+b
	(type ",help" for more information)

stklos> #b1+1
**** Error:
%read: bad number 1+1
	(type ",help" for more information)

stklos> #b1+1i
1+1i

stklos> 2+3
**** Error:
%read: bad number 2+3
	(type ",help" for more information)

stklos> 2+3i
2+3i

stklos> (string->number "#b10_1-111111")
**** Error:
string->number: bad number 101
	(type ",help" for more information)

stklos> (string->number "4+5")
**** Error:
string->number: bad number 4+5
	(type ",help" for more information)

stklos> (string->number "#b10_1-111111i")
5-63i

stklos> (string->number "4+5i")
4+5i
```

However... Shouldn't they then be read as symbols?
Gauche, Chez, Kawa, Chicken, Chicken, Gambit all interpret `2+3` as a symbol...
