### PR TITLE
Add `void?`

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -57,6 +57,7 @@
         with-mutex
         error-object-location %push-id
         define-constant
+        void?
         receive case-lambda
 
         %define-condition-type-accessors
@@ -1800,6 +1801,26 @@ doc>
            (define ,@args)
            (symbol-immutable! ',(car args)))
         (error "bad constant definition ~S" `(define-constant ,@args)))))
+
+#|
+<doc EXT void?
+ * (void? obj)
+ *
+ * Returns `#t` is |obj| is `#void`, and `#f` otherwise.
+ * The usual "unspecified" result in Scheme standard and in SRFIs is `#void`
+ * in STklos, and it is also returned by the procedure |void|.
+ *
+ * @lisp
+ * (void? (void))                    => #t
+ * (define x (if #f 'nope))
+ * (void? x)                         => #t
+ * (void? '())                       => #f
+ * (void? 'something)                => #f
+ * (void? (for-each print '(1 2 3))) => #t
+ * @end lisp
+doc>
+|#
+(define (void? obj) (eq? obj #void))
 
 ;;;; ======================================================================
 ;;;;

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -112,6 +112,16 @@ b|)
   (test "any.4" 6  (any fct '(2 4 6) '(1 2 5)))
   (test "any.5" 2  (any fct '(2 4 6 8 10) '(-1 -3 -4))))
 
+(test "void? #void" #t (void? #void))
+(test "void? (void)"     #t (void? (void)))
+(test "void? (if #f #t)" #t (void? (if #f #t)))
+(test "void? set!"       #t (let ((a 0)) (void? (set! a 1))))
+(test "void number"      #f (void? -2))
+(test "void string"      #f (void? "str"))
+(test "void nil"         #f (void? '()))
+(test "void closure"     #f (void? (lambda () -1)))
+(define-macro %%tmp (lambda lst 'ok))
+(test "void syntax"      #f (void? %%tmp))
 
 ;;----------------------------------------------------------------------
 (test-subsection "Escaped octals in strings")


### PR DESCRIPTION
For completeness. We have `null?`, `eof-object?`, `zero?`, and other procedures that are essentially convenience for
`(lambda (x) (eq? x some-special-object))`, so why not this one also?

This would be similar, I think, to the `unspecified?` procedure in MIT Scheme.