### PR TITLE
Use GMP for bignum GCD (results in a really good speedup)

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2277,10 +2277,11 @@ static SCM gcd2_fixnums(SCM n1, SCM n2)
 
 
 /* In the specific case we have bignums, GMP is absolutely faster than
-   doing it ourselves. gcd2_bignum computes the GCD of two numbers,
-   assuming that the first one is a bignum, while the second may be a
-   bignum or a fixnum (no type check is done here -- this is done in
-   the gcd2 function. */
+   doing it ourselves. gcd2_bignum computes the GCD of two numbers.
+   The function expects n1 and n2 to be either reals, bignums or fixnums.
+   When it happens that two reals end up being converted to two FIXNUMS
+   (or if two FIXNUMS were passed as arguments -- which doesn't make much
+   sense, and we don't anyway), then gcd2_fixnums() is called. */
 static SCM gcd2_bignum(SCM n1, SCM n2) {
   int exact = 1;
 

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -971,7 +971,105 @@
 (test "mersenne prime? 100" #f (mersenne-prime? 100))
 (test "mersenne prime? (* 61 19)" #f (mersenne-prime? (* 61 19)))
 
+;;------------------------------------------------------------------
+(test-subsection "gcd and lcm")
 
+(test "gcd" 0   (gcd))
+(test "gcd" 5   (gcd 0 5))
+(test "gcd" 5   (gcd 0 -5))
+(test "gcd" 5.0 (gcd 0.0 -5))
+(test "gcd" 1   (gcd 11 7))
+(test "gcd" 1   (gcd 1 10))
+(test "gcd" 1   (gcd -1 10))
+(test "gcd" 4   (gcd 20 8))
+(test "gcd" 4   (gcd -20 8))
+(test "gcd" 4.0 (gcd 20.0 8))
+(test "gcd" 4.0 (gcd 20 4.0))
+(test "gcd" 1   (gcd 1208925819614629174706189 929192))   ; first is prime
+(test "gcd" 1.0 (gcd 1208925819614629174706189 929192.0)) ; first is prime
+
+(test "gcd with real turned into bignum"
+      1.0
+      (gcd 20000000000000000000.0 3))
+
+(test "gcd 2 bignums -> fixnum"
+      4857223
+      ;; first: 2^65 * 7^5 * 17^2
+      ;; second: 7^5 * 17^50
+      (gcd 179199899179871458857844736
+           559675465285191576525278231414576190110023838138985405765037623943))
+
+(test "gcd 2 bignums -> bignum"
+      569468379011812486801
+      (gcd 21009674891402273592944939027143256440832
+           460916811707362526506357210533854319331779361732494458019956379934890049))
+
+(test "gcd"
+      4
+      (gcd 1099511627776 ;; 2^40
+           274877906944  ;; 2^38
+           10000         ;; 2^4 5^4
+           44444))       ;; 2^2 41 271
+
+
+(test/error "gcd" (gcd 1.2  1))
+(test/error "gcd" (gcd 1/2  1))
+(test/error "gcd" (gcd 1+2i 1))
+(test/error "gcd" (gcd 'a   1))
+(test/error "gcd" (gcd #\a  1))
+(test/error "gcd" (gcd "a"  1))
+(test/error "gcd" (gcd gcd  1))
+
+(test "gcd" fx-greatest (gcd 0 fx-greatest))
+
+(test "gcd" (+ fx-greatest 1) (gcd 0 (+ fx-greatest 1)))
+(test "gcd" (- fx-least)      (gcd 0 fx-least))
+(test "gcd"
+      (- (- fx-least 1))
+      (gcd 0 (- fx-least 1)))
+
+(test "gcd" 15.0 (gcd -15.0))
+
+
+(test "lcm" 1    (lcm))
+(test "lcm" 11   (lcm 11))
+(test "lcm" 11.0 (lcm 11.0))
+(test "lcm" 6    (lcm 2 3))
+(test "lcm" 60   (lcm 12 20))
+(test "lcm" 60   (lcm -12 20))
+(test "lcm" 60.0 (lcm 12.0 20))
+
+(test "lcm"
+      3298534883328        ;; 2^30 * 3
+      (lcm 824633720832    ;; 2^38 * 3
+           1099511627776)) ;; 2^40
+
+(test "lcm"
+      7635421060136960000 ;; 2^40  5^4 41 271
+      (lcm 1099511627776  ;; 2^40
+           274877906944   ;; 2^38
+           10000          ;; 2^4 5^4
+           44444))        ;; 2^2 41 271
+
+(test "lcm"
+      687194767360000.0   ;; 2^40 5^4
+      (lcm 1099511627776  ;; 2^40
+           274877906944   ;; 2^38
+           10000.0))      ;; 2^4 5^4
+
+(test "lcm"
+      189054653969025946927236298201845439024134660015551794280371585024       ;; 2^200 7^6
+      (lcm 120472576                                                           ;; 2^10  7^6
+           27007807709860849561033756885977919860590665716507399182910226432)) ;; 2^200 7^5
+
+
+(test/error "lcm" (lcm 1.2  1))
+(test/error "lcm" (lcm 1/2  1))
+(test/error "lcm" (lcm 1+2i 1))
+(test/error "lcm" (lcm 'a   1))
+(test/error "lcm" (lcm #\a  1))
+(test/error "lcm" (lcm "a"  1))
+(test/error "lcm" (lcm lcm  1))
 
 ;;------------------------------------------------------------------
 (test-subsection "expt")


### PR DESCRIPTION
If at least one of the arguments is a bignum, call the GMP.

This brings a really nice speedup to gcd *and* to lcm (which uses gcd internally):

1. GCD bignum x bignum   4.960 -> 0.175
2. LCM bignum x bignum   4.771 -> 0.330
3. GCD bignum x fixnum   7.490 -> 2.106
4. LCM bignum x fixnum  11.648 -> 6.681

(Times in seconds)

1: calculate GCD of two bignums 100_000 times
2: calculate LCM of the same two bignums from (1), 100_000 times
3: calculate GCD of a bignum and a fixnum 10_000_000 times
4: calculate LCM of the same two numbers from (3), 10_000_000 times

Each benchmark was repeated 20 times.

**CAVEAT**: I did not test with different numbers, and this *may* make a difference (the GCD can be calculated quicker, depending on its arguments).

**EDIT**: this also fixes a problem I've seen:

```
(gcd 0.0 -5) => 5
```

With the current PR, STklos will return an inexact number, as expected.

**NOTE** While working on this, I also noticed a small glitch in `abs` (Issue #470) and proposed a fix (PR #471). So this PR will fail one test, but that is because STklos currently returns a negative result for `(abs fx_least)`. With that fix (#471) the new GCD will pass all tests.