### PR TITLE
Fix `(abs fx-least)` being negative

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2090,7 +2090,9 @@ doc>
 DEFINE_PRIMITIVE("abs", abs, subr1, (SCM x))
 {
   switch (TYPEOF(x)) {
-    case tc_integer:  return (INT_VAL(x) < 0) ? MAKE_INT(-INT_VAL(x)) : x;
+    case tc_integer:  if (INT_VAL(x) == (unsigned long)INT_MIN_VAL)
+                        return long2scheme_bignum(-INT_VAL(x));
+                      return (INT_VAL(x) < 0) ? MAKE_INT(-INT_VAL(x)) : x;
     case tc_bignum:   if (mpz_cmp_ui(BIGNUM_VAL(x), 0L) < 0) {
                         mpz_t tmp;
 


### PR DESCRIPTION
The problem is that `-INT_VAL(x)` is not a fixnum when `x` is `fx-least`, but the C code was assuming it was.

Fix #470 