### PR TITLE
Don't compare long witn unsigned long

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2090,7 +2090,7 @@ doc>
 DEFINE_PRIMITIVE("abs", abs, subr1, (SCM x))
 {
   switch (TYPEOF(x)) {
-    case tc_integer:  if (INT_VAL(x) == (unsigned long)INT_MIN_VAL)
+    case tc_integer:  if (INT_VAL(x) == (long)INT_MIN_VAL)
                         return long2scheme_bignum(-INT_VAL(x));
                       return (INT_VAL(x) < 0) ? MAKE_INT(-INT_VAL(x)) : x;
     case tc_bignum:   if (mpz_cmp_ui(BIGNUM_VAL(x), 0L) < 0) {


### PR DESCRIPTION
Sorry @egallesio  for even another small PR. This one fixes a thinko in the recent "fix abs" PR (#471)...
Without this, GCC (with `-Wextra` warns about a comparison between long and unsigned long.

Perhaps `-Wextra` should be default for compiling STklos? This would help catch these small issues in advance.