### PR TITLE
allocation accounting (`time` reports # of bytes, SCM cells and quantity of allocations)

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -856,19 +856,78 @@ doc>
  * (time expr1 expr2 ...)
  *
  * Evaluates the expressions |expr1|, |expr2|, ... and returns the
- * result of the last expression. This form prints also the time spent
- * for this evaluation, in milliseconds, on the current error port.
+ * result of the last expression. This form also prints the time spent
+ * for this evaluation, in milliseconds, and the quantity of bytes
+ * alocated on the current error port.
  * This is CPU time, and not real ("wall") time.
+ *
+ * @lisp
+ * (time (begin (make-list 200) 'finish))
+ * Elapsed time: 0.0640000000000072 ms
+ * Allocated: 6704 bytes (~ 838 Scheme objects) in 209 allocation calls
+ *   => finish
+ * @end lisp
+ *
+ * In the example above, the result of the expression is only the symbol
+ * |finish|. The two other lines are written to the standard error port.
+ *
+ * The accounting is independent for each thread, and allocations in
+ * children threads do not increase the parent thread counters, as the
+ * example below illustrates.
+ *
+ * @lisp
+ * (let ((T (make-thread (lambda ()
+ *                         (let-values (( (b s k)
+ *                                        (%thread-allocations (current-thread))))
+ *                           (make-list 1_000_000)
+ *                           (let-values (( (B S K)
+ *                                          (%thread-allocations (current-thread))))
+ *                             (format #t "In child thread: ~a bytes, ~a objects in ~a calls~%"
+ *                                     (- B b) (- S s) (- K k))))))))
+ *   (let-values (( (b s k)
+ *                  (%thread-allocations (current-thread))))
+ *     ;; The million allocations in thread T won't affect
+ *     ;; the counting in parent thread:
+ *     (thread-start! T)
+ *     (thread-sleep! 2) ;; wait for the child thread to allocate a million cells
+ *     (let-values (( (B S K)
+ *                    (%thread-allocations (current-thread))))
+ *       (format #t "In parent thread: ~a bytes, ~a objects in ~a calls~%"
+ *               (- B b) (- S s) (- K k))))
+ *   (thread-join! T))
+ *
+ * In parent thread: 800672 bytes, 100084 objects in 17 calls
+ * In child thread: 32000272 bytes, 4000034 objects in 1000008 calls
+ * @end lisp
 doc>
 |#
 (define-macro time
   (lambda args
-    (let ((tmp1 (gensym))
-          (tmp2 (gensym)))
-      `(let* ((,tmp1 (clock))
-              (,tmp2 (begin ,@args)))
-         (format (current-error-port) "Elapsed time: ~S ms\n" (- (clock) ,tmp1))
-         ,tmp2))))
+    (let ((time-start        (gensym))
+          (res               (gensym))
+          (alloc-bytes-start (gensym))
+          (alloc-objs-start  (gensym))
+          (alloc-times-start (gensym))
+          (alloc-bytes-end   (gensym))
+          (alloc-objs-end    (gensym))
+          (alloc-times-end   (gensym)))
+      `(let* ((,time-start (clock)))
+         ;; %thread-allocations returns three values,
+         ;; bytes allocated, approximage number of SCM cells and
+         ;; number of calls to allocation
+         (let-values (( (,alloc-bytes-start ,alloc-objs-start ,alloc-times-start)
+                        (%thread-allocations (current-thread))))
+           (let ((,res (begin ,@args)))
+
+             (let-values (( (,alloc-bytes-end ,alloc-objs-end ,alloc-times-end)
+                            (%thread-allocations (current-thread))))
+
+               (format (current-error-port) "Elapsed time: ~S ms\n" (- (clock) ,time-start))
+               (format (current-error-port) "Allocated: ~S bytes (~~ ~S Scheme objects) in ~S allocation calls\n"
+                       (- ,alloc-bytes-end ,alloc-bytes-start)
+                       (- ,alloc-objs-end  ,alloc-objs-start)
+                       (- ,alloc-times-end ,alloc-times-start))
+               ,res)))))))
 
 
 #|

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -152,8 +152,8 @@ extern "C"
   /* Scheme interface. *** THIS IS THE INTERFACE TO USE ***  */
 
 
-#define STk_must_malloc(size)           GC_MALLOC(size)
-#define STk_must_malloc_atomic(size)    GC_MALLOC_ATOMIC(size)
+#define STk_must_malloc(size)           STk_must_malloc_real(size)
+#define STk_must_malloc_atomic(size)    STk_must_malloc_atomic_real(size)
 #define STk_must_realloc(ptr, size)     GC_REALLOC((ptr), (size))
 #define STk_free(ptr)                   GC_FREE(ptr)
 #define STk_register_finalizer(ptr, f)  GC_REGISTER_FINALIZER( \
@@ -1458,6 +1458,18 @@ int STk_init_vm(void);
 int STk_late_init_vm(void);   // run when env.c is fully initialized
 
 /*****************************************************************************/
+
+void thread_inc_allocs(SCM thr, int size);
+extern SCM STk_primordial_thread;
+
+static inline void* STk_must_malloc_real(size_t size) {
+  if (STk_primordial_thread) thread_inc_allocs(STk_current_thread(), size);
+  return GC_MALLOC(size);
+}
+static inline void* STk_must_malloc_atomic_real(size_t size) {
+  if (STk_primordial_thread) thread_inc_allocs(STk_current_thread(), size);
+  return GC_MALLOC_ATOMIC(size);
+}
 
 extern char *STk_boot_consts;
 extern STk_instr STk_boot_code[];

--- a/src/thread-common.c
+++ b/src/thread-common.c
@@ -297,9 +297,34 @@ DEFINE_PRIMITIVE("thread-start!", thread_start, subr1, (SCM thr))
   THREAD_VM(thr)      = new;
   THREAD_STATE(thr)   = th_runnable;
 
+  THREAD_ALLOCATIONS(thr)     = 0;
+  THREAD_BYTES_ALLOCATED(thr) = 0;
+
   STk_sys_thread_start(thr);
 
   return thr;
+}
+
+void thread_inc_allocs(SCM thr, int size) {
+  THREAD_ALLOCATIONS(thr) ++;
+  THREAD_BYTES_ALLOCATED(thr) += size;
+}
+
+DEFINE_PRIMITIVE("%thread-allocations-reset!", thread_allocs_reset, subr1, (SCM thr)) {
+  if (!THREADP(thr)) STk_error_bad_thread(thr);
+  THREAD_BYTES_ALLOCATED(thr) = 0;
+  THREAD_ALLOCATIONS(thr) = 0;
+  return STk_void;
+}
+
+DEFINE_PRIMITIVE("%thread-allocations", thread_allocs, subr1, (SCM thr)) {
+  if (!THREADP(thr)) STk_error_bad_thread(thr);
+  unsigned long bytes = THREAD_BYTES_ALLOCATED(thr);
+  unsigned long cells = bytes / sizeof(SCM);
+  return STk_n_values(3,
+                      STk_ulong2integer(THREAD_BYTES_ALLOCATED(thr)),
+                      STk_ulong2integer(cells),
+                      STk_ulong2integer(THREAD_ALLOCATIONS(thr)));
 }
 
 /* ======================================================================
@@ -367,6 +392,8 @@ int STk_init_threads(int stack_size, void *start_stack)
                               stack_size);
   THREAD_STATE(primordial) = th_runnable;
   THREAD_VM(primordial)    = vm;
+  THREAD_ALLOCATIONS(primordial) = 0;
+  THREAD_BYTES_ALLOCATED(primordial) = 0;
   vm->scheme_thread        = primordial;
   vm->start_stack          = start_stack;
   STk_primordial_thread    = primordial;
@@ -391,6 +418,8 @@ int STk_init_threads(int stack_size, void *start_stack)
   ADD_PRIMITIVE(thread_join);
   ADD_PRIMITIVE(thread_sleep);
   ADD_PRIMITIVE(thread_system);
+  ADD_PRIMITIVE(thread_allocs);
+  ADD_PRIMITIVE(thread_allocs_reset);
 
   return TRUE;
 }

--- a/src/thread-common.h
+++ b/src/thread-common.h
@@ -48,19 +48,23 @@ struct thread_obj {
   enum thread_state state;
   int stack_stize;
   vm_thread_t *vm;
+  unsigned long allocations;
+  unsigned long bytes_allocated;
   struct sys_thread_obj sys_thread;
 };
 
 
-#define THREADP(p)              (BOXED_TYPE_EQ((p), tc_thread))
-#define THREAD_THUNK(p)         (((struct thread_obj *) (p))->thunk)
-#define THREAD_NAME(p)          (((struct thread_obj *) (p))->name)
-#define THREAD_SPECIFIC(p)      (((struct thread_obj *) (p))->specific)
-#define THREAD_RESULT(p)        (((struct thread_obj *) (p))->end_result)
-#define THREAD_EXCEPTION(p)     (((struct thread_obj *) (p))->end_exception)
-#define THREAD_STATE(p)         (((struct thread_obj *) (p))->state)
-#define THREAD_STACK_SIZE(p)    (((struct thread_obj *) (p))->stack_stize)
-#define THREAD_VM(p)            (((struct thread_obj *) (p))->vm)
+#define THREADP(p)                (BOXED_TYPE_EQ((p), tc_thread))
+#define THREAD_THUNK(p)           (((struct thread_obj *) (p))->thunk)
+#define THREAD_NAME(p)            (((struct thread_obj *) (p))->name)
+#define THREAD_SPECIFIC(p)        (((struct thread_obj *) (p))->specific)
+#define THREAD_RESULT(p)          (((struct thread_obj *) (p))->end_result)
+#define THREAD_EXCEPTION(p)       (((struct thread_obj *) (p))->end_exception)
+#define THREAD_STATE(p)           (((struct thread_obj *) (p))->state)
+#define THREAD_STACK_SIZE(p)      (((struct thread_obj *) (p))->stack_stize)
+#define THREAD_VM(p)              (((struct thread_obj *) (p))->vm)
+#define THREAD_ALLOCATIONS(p)     (((struct thread_obj *) (p))->allocations)
+#define THREAD_BYTES_ALLOCATED(p) (((struct thread_obj *) (p))->bytes_allocated)
 
 extern void STk_error_bad_thread(SCM obj);
 double STk_verify_timeout(SCM tm);


### PR DESCRIPTION
Hi @egallesio !

This is one thing I have been thinking about, and I've finally implemented it. Not sure if it's worth it. What do you think -- is this interesting?


The first commit:
    
- Adds two fields to the VM structure, `allocations` and `bytes_allocated`.  These are initialized when the thread starts.
    
- Changes the standard `STk_must_malloc` and `STk_must_malloc_atomic` to increment those two counters for the current thread
    
- Adds a `%thread-allocations` primitive that will return three values,  the number of allocated bytes, the approximate number of SCM cells, and the number of allocation calls  since the thread started
    
- Adds a `%thread-allocations-reset!` primitive that zeroes the two counters (just in case someone wants it)
    
A helper function `thread_inc_allocs(SCM thr, int size)` was added to `vm.c`
    
Example:
    
```
stklos> (%thread-allocations (current-thread))
2348284
293535
87928
```
    
In this case, 2348284 bytes (*approximately* 293535 SCM objects) were allocated in 87928 calls since the start of the thread.

* _**Caveat I**_: the number of allocations is kept in an unsigned long int, and there is no provision for recovering from overflow (it will wrap around) -- although I don't think this is an issue (The computed differences in allocations will be mod $2^{64}$).
    
* _**Caveat II**_: reallocations are not computed, since it would be ~a bit~ a lot more complicated to get a meaninful number from them (or not?).

* _**Caveat III**_: we only report the approximate number of SCM objects as a convenience. It is not precise -- it is more like "the equivalent number, in SCM cells" -- since not all allocations are of type `SCM` (a string, for example, has data allocated in bytes). We do `bytes / sizeof(SCM)` to obtain that number. Is this useful? Or should only the other two values be returned?

The second commit changes the `time` macro so it reports all that data, using the new `%thread-allocations` primitive.
    
Example:
    
```
stklos> (time (begin (make-list 200) 'finish))
Elapsed time: 0.0640000000000072 ms
Allocated: 6704 bytes (~ 838 Scheme objects) in 209 allocation calls
finish
```

The accounting is local to each thread:

```scheme
(let ((T (make-thread (lambda ()
                        (let-values (( (b s k)
                                       (%thread-allocations (current-thread))))
                          (make-list 1_000_000)
                          (let-values (( (B S K)
                                         (%thread-allocations (current-thread))))
                            (format #t "In child thread: ~a bytes, ~a objects in ~a calls~%"
                                    (- B b) (- S s) (- K k))))))))
  (let-values (( (b s k)
                 (%thread-allocations (current-thread))))
    ;; The million allocations in thread T won't affect
    ;; the counting in parent thread:
    (thread-start! T)
    (thread-sleep! 2) ;; wait for the child thread to allocate a million cells
    (let-values (( (B S K)
                   (%thread-allocations (current-thread))))
      (format #t "In parent thread: ~a bytes, ~a objects in ~a calls~%"
              (- B b) (- S s) (- K k))))
  (thread-join! T))

In parent thread: 800672 bytes, 100084 objects in 17 calls
In child thread: 32000272 bytes, 4000034 objects in 1000008 calls
```
