### PR TITLE
Don't implicitly declare exit in configure check

### DIFF
--- a/configure
+++ b/configure
@@ -7571,8 +7571,8 @@ then :
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
- void inner (char *foo) { char bar; exit (!(foo >= &bar)); }
-             void main () { char foo; inner (&foo); }
+ int inner (char *foo) { char bar; return !(foo >= &bar); }
+             int main (void) { char foo; return inner (&foo); }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
-### configure.in for STklos
+### configure.ac for STklos
 ###
 ###           Author: Erick Gallesio [eg@unice.fr]
 ###    Creation date: 28-Dec-1999 21:19 (eg)
-### Last file update:  2-Feb-2023 10:58 (eg)
+### Last file update:  7-Mar-2023 07:19 (ryandesign)
 
 AC_PREREQ([2.69])
 AC_INIT([stklos],[1.70])
@@ -452,8 +452,8 @@ fi
 ###
 ### See in what direction the stack grows (code stolen from Sawfish)
 ###
-AC_RUN_IFELSE([AC_LANG_SOURCE([[ void inner (char *foo) { char bar; exit (!(foo >= &bar)); }
-             void main () { char foo; inner (&foo); } ]])],[STACK_DIRECTION="DOWN"],[STACK_DIRECTION="UP"],[echo "Stack direction is not detected when cross compiling for now"])
+AC_RUN_IFELSE([AC_LANG_SOURCE([[ int inner (char *foo) { char bar; return !(foo >= &bar); }
+             int main (void) { char foo; return inner (&foo); } ]])],[STACK_DIRECTION="DOWN"],[STACK_DIRECTION="UP"],[echo "Stack direction is not detected when cross compiling for now"])
 
 
 


### PR DESCRIPTION
Your configure test "See in what direction the stack grows (code stolen from Sawfish)" fails to work correctly with the version of clang that comes with Xcode 12 and later on macOS (and any other compiler if you have `-Werror=implicit-function-declaration` in CFLAGS) because you use the `exit` function but haven't included the header where it is defined:

```
configure:7228: /usr/bin/clang -o conftest -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -I/opt/local/include -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 conftest.c -lpthread  >&5
conftest.c:83:37: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
 void inner (char *foo) { char bar; exit (!(foo >= &bar)); }
                                    ^
conftest.c:83:37: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
conftest.c:84:14: warning: return type of 'main' is not 'int' [-Wmain-return-type]
             void main () { char foo; inner (&foo); }
             ^
conftest.c:84:14: note: change return type to 'int'
             void main () { char foo; inner (&foo); }
             ^~~~
             int
1 warning and 1 error generated.
```

This could be fixed by including <stdlib.h> but this PR fixes it by returning instead of exiting.