### PR TITLE
Change `%procedure-signature` to `procedure-formals`, describe closures and primitives better, and also describe bytevectors

### DIFF
--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -131,10 +131,15 @@ doc>
                             (format port "an empty vector")
                             (format port "a vector of length ~s"
                                     (vector-length x))))
-     ((procedure? x)    (if (%procedure-signature x)
-                            (format port "a procedure, whose arguments are ~s"
-                                    (%procedure-signature x))
-                            (format port "a procedure")))
+     ((closure? x)      (format port "a procedure")
+                        ;; We don't need to show the formals, because they're already
+                        ;; displayed in the object. For example, [closure g (a b)].
+                        ;; But we offer the user a way to read the source, if it is
+                        ;; available.
+                        (when (procedure-source x)
+                          (format port
+                                  ".~%The source code is available -- call `procedure-source` on it")))
+     ((procedure? x)    (format port "a primitive procedure"))
      ((eof-object? x)   (format port "the end-of-file object"))
      ((struct-type? x)  (format port "the type structure named ~A"
                                 (struct-type-name x)))

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -127,6 +127,11 @@ doc>
                             (format port "an empty string")
                             (format port "a string of length ~s"
                                     (string-length x))))
+     ((bytevector? x)   (let ((n (bytevector-length x)))
+                          (if (zero? n)
+                              (format port "an empty bytevector")
+                              (format port "a bytevector of length ~s"
+                                      n))))
      ((vector?  x)      (if (eqv? x '#())
                             (format port "an empty vector")
                             (format port "a vector of length ~s"

--- a/lib/help.stk
+++ b/lib/help.stk
@@ -61,7 +61,7 @@
     (set! str (regexp-replace-all "\\|([^|]+)\\|" str (format "~a\\1~a" hc nc)))
     (set! str (regexp-replace-all "`([^`]+)`"     str (format "~a\\1~a" hc nc)))
 
-    ;; Colorize => 
+    ;; Colorize =>
     (set! str (regexp-replace-all "=>"            str (format "~a=>~a" ac hc)))
 
     ;; Some function calls
@@ -170,8 +170,8 @@ doc>
 ;; (f x y), or
 ;; (_ x y)  if it is unnamed.
 (define (%help-signature obj)
-  (if (procedure? obj)
-      (let* ((sig (%procedure-signature obj)))
+  (if (closure? obj) ;; procedures don't have formals available for now
+      (let* ((sig (procedure-formals obj)))
         (if sig
             (cons (%get-object-name obj '_) sig)
             #f))


### PR DESCRIPTION
In `help.stk` and `describe.stk`

Also describe closures and primitives separately in `describe.stk`.

And don't try to call `procedure-signature` on primitives...

Some examples:

```
stklos> (describe +)
 #[primitive +] is a primitive procedure.
stklos> (define (f a b) (+ a b))
;; f

stklos> (compiler:keep-source #t)

stklos> (define (g a b) (- a b))
;; g

stklos> (compiler:keep-formals #t)

stklos> (define (h a b) (/ a b))
;; h

stklos> (compiler:keep-source #f)

stklos> (define (i a b) (* a b))
;; i

stklos> (describe f)
 #[closure f] is a procedure.

stklos> (describe g)          ;; keep-source also keep formals:
 #[closure g (a b)] is a procedure.
 The source code is available -- call `procedure-source` on it

stklos> (describe h)
 #[closure h (a b)] is a procedure.
 The source code is available -- call `procedure-source` on it

stklos> (describe i)
 #[closure i (a b)] is a procedure.
```