### PR TITLE
Fix typos and wording in fport.c and fport.h

### DIFF
--- a/src/fport.c
+++ b/src/fport.c
@@ -14,19 +14,19 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should hcave received a copy of the GNU General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
  * USA.
  *
  *           Author: Erick Gallesio [eg@unice.fr]
  *    Creation date:  8-Jan-2000 14:48 (eg)
- * Last file update:  9-Jan-2022 19:19 (eg)
+ * Last file update: 10-Mar-2023 12:43 (ryandesign)
  *
- * This implementation is built by reverse engineering on an old SUNOS 4.1.1
+ * This implementation is built by reverse engineering an old SUNOS 4.1.1
  * stdio.h. It has been simplified to fit the needs for STklos. In particular
- * non buffered file are not implemented. Anyway this is faster than an
- * implementation using the C buffered IO (at least on glibc)
+ * non-buffered files are not implemented. Anyway this is faster than an
+ * implementation using the C buffered IO (at least on glibc).
  *
  */
 #include <ctype.h>
@@ -43,12 +43,12 @@ SCM STk_stdin, STk_stdout, STk_stderr;    /* The unredirected ports */
 MUT_DECL(all_fports_mutex);
 
 /*
- * Implementation of our own popen/pclose. We use her file descriptor, instad
+ * Implementation of our own popen/pclose. We use its file descriptor instead
  * of FILE *.
  *
- * The fd_popen function returns also the pid of the shell process launched
+ * The fd_popen function also returns the pid of the shell process launched
  * for the redirection. This pid is stored in the internal file port
- * representation to wait on it during the fd_pclose.
+ * representation to wait on it during fd_pclose.
  */
 static int fd_popen(const char *cmd, const char *mode, int *pid)
 {
@@ -74,7 +74,7 @@ static int fd_popen(const char *cmd, const char *mode, int *pid)
       execlp("sh", "sh", "-c", cmd, NULL);
       STk_panic("*** shell error in fd_popen");
       return -1; /* for the compiler */
-    default:                                 /* Parent process*/
+    default:                                 /* Parent process */
       if (*mode == 'r') {
         close(p[1]);
         return p[0];
@@ -96,8 +96,8 @@ static int fd_pclose(int fd, int pid) {
 
 
 /*
- * Since we manage ourselves our ports, we need to keep a reference on
- * all the open ports such that all the port are flushed when we exit
+ * Since we manage our ports ourselves, we need to keep a reference to
+ * all the open ports such that all the ports are flushed when we exit
  * from the program. However, to avoid the that the GC "sees" these
  * references, we need to use a list of objects containing "masqueraded"
  * pointers.
@@ -115,7 +115,7 @@ static struct port_list {
 static void nop_release_port(SCM _UNUSED(port))
 {
   /* This function is used as a release procedure when closing all files
-   * at program exit. We use an empty procedure to avoid interferences
+   * at program exit. We use an empty procedure to avoid interference
    * in all_file_ports management
    */
 }
@@ -166,7 +166,7 @@ void STk_close_all_ports(void)
   }
   MUT_UNLOCK(all_fports_mutex);
 
-  /* Finally, close error and output port (must be done last) */
+  /* Finally, close error and output ports (must be done last) */
   STk_close(eport);
   STk_close(oport);
 }
@@ -368,7 +368,7 @@ static Inline int Fnputs(void *stream, const char *s, int len)
   int res, flush = (PORT_STREAM_FLAGS(stream) & STK_IOLBF);
 
   if (len > TTY_BUFSIZE) {
-    /* This is a long string don't use the buffer and write it directly on stream */
+    /* This is a long string so don't use the buffer; write it directly to the stream */
     res = Fwrite(stream, s, len);
   } else {
     int free, count = len;
@@ -475,7 +475,7 @@ make_fport(const char *fname, int fd, int flags)
   PORT_WEVENT(fs)        = STk_false;
   PORT_IDLE(fs)          = STk_nil;
 
-  /* Initialize now the port itsef */
+  /* Now initialize the port itself */
   NEWCELL(res, port);
 
   PORT_STREAM(res)      = fs;
@@ -515,9 +515,9 @@ make_fport(const char *fname, int fd, int flags)
 #ifdef WIN32_0000
 static char *convert_for_win32(char *mode)
 {
-  /* Things are complicated on Win32 (as always). So we onvert all files
-   * in binaries files. Note that this function is not called when we work
-   * on ports since they only accept version without "b" on Cygwin
+  /* Things are complicated on Win32 (as always) so we convert all files
+   * to binary files. Note that this function is not called when we work
+   * on ports since they only accept versions without "b" on Cygwin.
    */
   switch (*mode) {
     case 'r': if (mode[1] == '\0') return "rb";
@@ -734,29 +734,29 @@ DEFINE_PRIMITIVE("output-file-port?", output_fportp, subr1, (SCM port))
  * Opens the file whose name is |filename| with the specified string
  * |mode| which can be:
  *
- * - |"r"| to open file for reading. The stream is positioned at
+ * - |"r"| to open the file for reading. The stream is positioned at
  *   the beginning of the file.
  *
- * - |"r+"| to open file for reading and writing.  The stream is
+ * - |"r+"| to open the file for reading and writing. The stream is
  *   positioned at the beginning of the file.
  *
- * - |"w"| to truncate file to zero length or create file for writing.
+ * - |"w"| to truncate the file to zero length or create the file for writing.
  *   The stream is positioned at the beginning of the file.
  *
- * - |"w+"| to open  file for reading and writing. The file is created
+ * - |"w+"| to open the file for reading and writing. The file is created
  *   if it does not exist, otherwise it is truncated. The stream is positioned
  *   at the beginning of the file.
  *
- * - |"a"| to open for writing.  The file is created if  it  does
+ * - |"a"| to open the file for writing. The file is created if it does
  *   not exist. The stream is positioned at the end of the file.
  *
- * - |"a+"| to open file for reading and writing. The file is created
+ * - |"a+"| to open the file for reading and writing. The file is created
  *   if it does not exist. The stream is positioned at the end of the file.
  *
  * If the file can be opened, |open-file| returns the textual port associated
  * with the given file, otherwise it returns |#f|. Here again, the *_magic_*
- * string "@pipe " permits to open a pipe port (in this case mode can only be
- * |"r"| or |"w"|).
+ * string "@pipe " permits to open a pipe port. (In this case mode can only be
+ * |"r"| or |"w"|.)
 doc>
  */
 
@@ -898,7 +898,7 @@ static SCM load_file(SCM filename)
  * (((load-suffixes)))
  * |Filename| should be a string naming an existing file containing Scheme
  * expressions. |Load| has been extended in STklos to allow loading of
- * file containing Scheme compiled code as well as object files (_aka_
+ * files containing Scheme compiled code as well as object files (_aka_
  * shared objects). The loading of object files is not available on
  * all architectures. The value returned by |load| is *_void_*.
  *
@@ -920,11 +920,11 @@ DEFINE_PRIMITIVE("load", scheme_load, subr1, (SCM filename))
 <doc EXT try-load
  * (try-load filename)
  *
- * |try-load| tries to load the file named |filename|. As |load|,
+ * |try-load| tries to load the file named |filename|. As with |load|,
  * |try-load| tries to find the file given the current load path
  * and a set of suffixes if |filename| cannot be loaded. If |try-load|
  * is able to find a readable file, it is loaded, and |try-load| returns
- * |#t|. Otherwise,  |try-load| retuns |#f|.
+ * |#t|. Otherwise, |try-load| retuns |#f|.
 doc>
  */
 DEFINE_PRIMITIVE("try-load", scheme_try_load, subr1, (SCM filename))

--- a/src/fport.h
+++ b/src/fport.h
@@ -21,21 +21,21 @@
  *
  *           Author: Erick Gallesio [eg@unice.fr]
  *    Creation date:  8-Jan-2000 14:48 (eg)
- * Last file update: 10-May-2021 16:56 (eg)
+ * Last file update: 10-Mar-2023 12:43 (ryandesign)
  *
- * This implementation is built by reverse engineering on an old SUNOS 4.1.1
+ * This implementation is built by reverse engineering an old SUNOS 4.1.1
  * stdio.h. It has been simplified to fit the needs for STklos. In particular
- * non buffered file are not implemented. Anyway this is faster than an
- * implementation using the C buffered IO (at least on glibc)
+ * non-buffered files are not implemented. Anyway this is faster than an
+ * implementation using the C buffered IO (at least on glibc).
  *
  */
 
 #define TTY_BUFSIZE     256
 #define OTHER_BUFSIZE   4096
 
-#define STK_IOFBF   (1 << 0) /* Full buffered*/
-#define STK_IOLBF   (1 << 1) /* Line buffered */
-#define STK_IONBF   (1 << 2) /* Non buffered (unused for now) */
+#define STK_IOFBF   (1 << 0) /* Full-buffered */
+#define STK_IOLBF   (1 << 1) /* Line-buffered */
+#define STK_IONBF   (1 << 2) /* Non-buffered (unused for now) */
 #define STK_IOEOF   (1 << 3) /* EOF encountered on this file */
 #define STK_IOREAD  (1 << 4) /* File is opened in read */
 


### PR DESCRIPTION
I noticed a typo in the license header of fport.c and while reading through the file I made some other fairly nitpicky changes that I hope you don't mind too much.