### PR TITLE
Describe uvectors

### DIFF
--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -132,6 +132,9 @@ doc>
                               (format port "an empty bytevector")
                               (format port "a bytevector of length ~s"
                                       n))))
+     ((is-a? x
+             <uvector>) (format port "an uniform vector of type ~s"
+                                (%uvector-type x)))
      ((vector?  x)      (if (eqv? x '#())
                             (format port "an empty vector")
                             (format port "a vector of length ~s"


### PR DESCRIPTION
But we still don't give their length in the description.

@egallesio -- the `%uvector-length` procedure takes an integer (the tip) and a uvector. For `describe`, it would make sense to have a wrapper that does not need the tip, so we can also report the length.

What do you think is better?
1. Add a new procedure, like `%general-uvector-length` that only takes a uvector? Something that would only do
```c
  return MAKE_INT(UVECTOR_SIZE(v));
```
and just return the length?

2. Change `%uvector-length` to `subr12`, so it can be called with args `(tip uvec)` or `(uvec)`
3. Write a general API for uvectors that do not require the user to include the uvector type? That would include
`uvector-length`, `uvector-{ref,set}`, `uvector->list`, `uvector?`... (The last one really makes sense - -SRFI 4 does not offer a general `uvector?` predicate... See that the code in this PR uses `is-a?`)
4. not report the length
5. Some other possibility?