### PR TITLE
Identify all Darwin OS versions

### DIFF
--- a/configure
+++ b/configure
@@ -6816,19 +6816,15 @@ BUILD_ARCH=`uname -m`
 OS_NAME=$OS
 case $OS in
    LINUX)
-      v=`echo $version | sed -e 's/\([0-9]*\)\.\([0-9\]*\).*/\1_\2/'`
-      OS_NAME_VERSION=LINUX_$v
+      v=`echo $version | sed -e 's/^\([0-9]*\)\.\([0-9\]*\).*/\1_\2/'`
       ;;
    DARWIN)
-      case $version in
-         9*)  OS_NAME_VERSION=DARWIN_9;;
-         *)   OS_NAME_VERSION=DARWIN_OLD;;
-      esac
+      v=`echo $version | sed -e 's/^\([0-9]*\).*/\1/'`
       ;;
   *)
       v=`echo $version | sed -e 's/[^0-9]/_/g'`
-      OS_NAME_VERSION=$OS\_$v;
 esac
+OS_NAME_VERSION=${OS}_$v;
 
 
 ###

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 ###
 ###           Author: Erick Gallesio [eg@unice.fr]
 ###    Creation date: 28-Dec-1999 21:19 (eg)
-### Last file update: 10-Mar-2023 11:15 (ryandesign)
+### Last file update: 11-Mar-2023 06:40 (ryandesign)
 
 AC_PREREQ([2.69])
 AC_INIT([stklos],[1.70])
@@ -119,19 +119,15 @@ BUILD_ARCH=`uname -m`
 OS_NAME=$OS
 case $OS in
    LINUX)
-      v=`echo $version | sed -e 's/\([[0-9]]*\)\.\([[0-9\]]*\).*/\1_\2/'`
-      OS_NAME_VERSION=LINUX_$v
+      v=`echo $version | sed -e 's/^\([[0-9]]*\)\.\([[0-9\]]*\).*/\1_\2/'`
       ;;
    DARWIN)
-      case $version in
-         9*)  OS_NAME_VERSION=DARWIN_9;;
-         *)   OS_NAME_VERSION=DARWIN_OLD;;
-      esac
+      v=`echo $version | sed -e 's/^\([[0-9]]*\).*/\1/'`
       ;;
   *)
       v=`echo $version | sed -e 's/[[^0-9]]/_/g'`
-      OS_NAME_VERSION=$OS\_$v;
 esac
+OS_NAME_VERSION=${OS}_$v;
 
 
 ###


### PR DESCRIPTION
This fixes the configure summary so that it doesn't identify most Darwin versions by the nickname "DARWIN_OLD" which was strange to see on current OS versions. Previously the only Darwin versions not identified as "OLD" were 9, 10, and 11, even though they were released over 15, 13, and 11 years ago, respectively. Whereas before the summary on my system would show:

```
SUMMARY
*******
               System:  Darwin-21.4.0
              OS nick:  DARWIN_OLD
```

it now shows:

```
SUMMARY
*******
               System:  Darwin-21.4.0
              OS nick:  DARWIN_21
```

I realize this changes the preprocessor macros. Previously a macro called `DARWIN_OLD` would have been defined. But I don't see anywhere in the code that made use of that macro.