### PR TITLE
Don't allow non-integer stack sizes

### DIFF
--- a/src/thread-common.c
+++ b/src/thread-common.c
@@ -139,6 +139,7 @@ DEFINE_PRIMITIVE("%make-thread", make_thread, subr3,(SCM thunk, SCM name, SCM ss
     /* If no size is specified, use primordial thread stack size */
     stack_size = THREAD_STACK_SIZE(STk_primordial_thread);
   else {
+    if (!INTP(stack_size)) STk_error("bad integer ~S", ssize);
     stack_size = STk_integer_value(ssize);
     if (stack_size < 0)
       STk_error("bad stack size ~S", ssize);


### PR DESCRIPTION
`%make-thread` does not check if the stack size is integer, so this:

```
(thread-start!
  (make-thread
    (lambda ()
      (print (stack-size (current-thread))))
      "name"
      'a-symbol))
```

will likely crash.