### PR TITLE
Small enhancements

### DIFF
--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -37,7 +37,7 @@ on the same project across various editors and IDEs).
 
 The subdirectories in the STklos source tree are:
 
-* `doc` – documentation, written mostly in Skribe
+* `doc` – documentation, written mostly in asciidoctor
 * `etc` – various sample files for specific needs
 * `examples` – examples (oh, who could tell?)
 * `ffi` – `libffi` (a local copy)
@@ -260,11 +260,11 @@ See SRFI-25, SRFI-27 and SRFI-170 as a reference.
 
 === Documentation
 
-==== Documenting SRFIs in `srfi.skb`
+==== Documenting SRFIs in `srfi.adoc`
 
 General documentation is automatically generated for SRFIs. If you need
 to give a precision specific to a given SRFI, add it to the end of the
-`doc/skb/srfi.skb` file using the `gen-srfi-documentation` function.
+`doc/refman/srfi.adoc` file using the `gen-srfi-documentation` function.
 
 Note that the documentation is written in Skribe tool which is no more
 maintained. Consequently, the documentation will not be generated. The
@@ -1029,7 +1029,7 @@ reader can try the following:
 * Include one more optimization clause in the optimizer that performs the
   substitution
   `[IN-CDR; IN-CDR; IN-CDR] => IN-CDDDR`
-* And of course, implement `IN-CDDR`:
+* And of course, implement `IN-CDDDR`:
   - Change `lib/assembler.stk`
   - Change `src/vm-instr.h`
   - Add one more case to the VM state machine (use the case for `IN_CDR`

--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -818,9 +818,67 @@ DEFINE_PRIMITIVE("%fresh-continuation?", fresh_continuationp, subr1, (SCM obj))
 
 Their Scheme counterparts, `%continuation?`, `%make-continuation`, and
 `%restore-continuation` are used to implement the Scheme procedure
-`call/cc` (in `lib/callcc.stk`).
+`call/cc` (in `lib/callcc.stk`). The implementation of `call/cc` is
+actually complex because it needs to be interwined with the
+implementation of `dynamic-wind`, but in the same file there is
+another procedure, `%call/cc`, which does not do winding, and is
+therefore very simple (and it should be the starting point to
+understand the full-blown `call/cc`). We reproduce it here with some
+comments.
 
-Their behavior is better illustrated by an example in Scheme:
+[source, scheme]
+----
+(define (%call/cc proc)
+  (let ((k  (%make-continuation)))
+    (if  (%fresh-continuation? k)
+
+         ;; In the first time we get here, we create a closure (the lambda
+         ;; below) that will take a value v and restore the continuation
+         ;; k with it. So when we call
+         ;; (%call/cc (lambda (kont) ... (kont x) ...)),
+         ;; 'proc' below is the '(lambda (kont) ...)' in our code. And the
+         ;; '(lambda v ...)' below is kont. 'v' is the argument that will be
+         ;; given to kont.
+
+         (proc (lambda v (%restore-continuation k v)))
+
+         ;; Next time and everytime again, we just return values applied to k,
+         ;; because in this case, k will *not* be a continuation, but a list
+         ;; with the values passed (this is because the lambda above accepts
+         ;; 'v' as the arg list, and this list is passed to %restore-continuation
+         ;; as the value to be returned).
+         (apply values k))))
+----
+
+The `%call/cc` procedure is used in the same way the Scheme `call/cc`
+is used:
+
+[source, scheme]
+----
+stklos> (define c #f)
+(let ((a 1)
+      (b 2))
+  (format #t "start~%")
+  (set! b (%call/cc (lambda (k)
+                      (set! c k)
+                      -1)))
+  (set! a (+ 1 a))
+  (format #t "~a ~a ~a~%" a b c))
+
+start
+2 -1 #[closure 7fbcd9a122c0]
+
+stklos> (c 15)
+3 15 #[closure 7fbcd9a122c0]
+
+stklos> (c 'x)
+4 x #[closure 7fbcd9a122c0]
+----
+
+The behavior of the fundamental continuation procedures is better
+illustrated by an example in Scheme, which mimics the example of
+`%call/cc` given above, *ecxept* that it does not have the return
+value of `%call/cc`, so it does not set the value of `b`:
 
 [source, scheme]
 ----
@@ -830,7 +888,7 @@ stklos> (define c #f)  ; to be set later
   (format #t "start~%")
   (set! c (%make-continuation))
   (set! a (+ 1 a))
-  (format #t "~a ~a~%" a b))
+  (format #t "~a ~a ~a~%" a b c))
 
 start
 2 2
@@ -848,19 +906,19 @@ stklos> (%fresh-continuation? c)
 stklos> (%restore-continuation c c)          ;; since this is the continuation of
                                              ;; "(set! c ...)", we put "c" as value,
                                              ;; so we can use the continuation again
-3 2
+3 2 #[continuation (C=3992 S=1512) c069e000]
 
 stklos> (%fresh-continuation? c)
 #f
 
 stklos> (%restore-continuation c c)
-4 2
+4 2 #[continuation (C=3992 S=1512) c069e000]
 
 stklos> (%restore-continuation c c)
-5 2
+5 2 #[continuation (C=3992 S=1512) c069e000]
 
 stklos> (%restore-continuation c c)
-6 2
+6 2 #[continuation (C=3992 S=1512) c069e000]
 ----
 
 == The virtual machine

--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -46,7 +46,7 @@ The subdirectories in the STklos source tree are:
 * `lib` – Scheme files, including from basic things like the boot
 program up to high-level things like modules implementing libraries and
 SRFIs
-* `pcre` – `libpcre` (a local copy)
+* `pcre2` – `libpcre` (a local copy)
 * `pkgman` – the package manager
 * `src` – the STklos core, written in C
 * `tests` – the tests, of course!

--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -805,7 +805,8 @@ capture, check and restore continuations:
 * `SCM STk_restore_cont(SCM cont, SCM val)` restores continuation `cont`, passing it
    the value `val`
 
-There is also one function in `vm.c` which is not exported:
+There is also one function in `vm.c` which is not exported by `vm.h`, but is available
+as a Scheme primitive:
 
 [source, scheme]
 ----

--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -816,6 +816,10 @@ DEFINE_PRIMITIVE("%fresh-continuation?", fresh_continuationp, subr1, (SCM obj))
 }
 ----
 
+Their Scheme counterparts, `%continuation?`, `%make-continuation`, and
+`%restore-continuation` are used to implement the Scheme procedure
+`call/cc` (in `lib/callcc.stk`).
+
 Their behavior is better illustrated by an example in Scheme:
 
 [source, scheme]
@@ -835,12 +839,15 @@ stklos> (%continuation? c)
 #t
 
 stklos> c
-#[continuation (C=3992 S=1512) c069e000]
+#[continuation (C=3992 S=1512) c069e000]     ;; addresses: C stack, Scheme stack,
+                                             ;; continuation object
 
 stklos> (%fresh-continuation? c)
 #t
 
-stklos> (%restore-continuation c c)
+stklos> (%restore-continuation c c)          ;; since this is the continuation of
+                                             ;; "(set! c ...)", we put "c" as value,
+                                             ;; so we can use the continuation again
 3 2
 
 stklos> (%fresh-continuation? c)

--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -991,12 +991,25 @@ Another example is `GOTO` optimization:
 The procedure `optimize-goto-code`, also in the file `peephole.stk`,
 will perform the transformations indicated in the comments.
 
-The input code is represented as a list. Some relevant definitions are
-in the beginning of the file:
+The input code is represented as a list of the form
 
 [source,scheme]
 ----
-(label? code)      ; is thecurrent instruction a label?
+( (instruction1 op1 op2)    ;; one instruction with two operands
+  (instruction2 op1)        ;; one instruction with one operand
+  (instruction3)            ;; one instruction with no operands
+  ...
+  (instruction10 op1 op2)
+  10                        ;; this is a label!
+  (instruction11)
+  ... )
+----
+
+Some relevant definitions are in the beginning of the file:
+
+[source,scheme]
+----
+(label? code)      ; is the current instruction a label?
 (this-instr code)  ; the current instruction (reference to a position in the list)
 (next-instr code)  ; the next instruction (cdr of the current one)
 (this-arg1 code)   ; argument 1 of current instruction
@@ -1004,6 +1017,25 @@ in the beginning of the file:
 (next-arg1 code)   ; argument 1 of next instruction
 (next-arg2 code)   ; argument 2 of next instruction
 ----
+
+There are only procedures for dealing with the current and the next
+instruction because the peephole optimizer currently only substitutes
+sequences of two instructions. It is an interesting exercise to try to
+implement three-instruction peephole operation. As a suggestion, the
+reader can try the following:
+
+* Implement `third-instr`. Be careful to not try to take the `cdr` of
+  an empty list...
+* Include one more optimization clause in the optimizer that performs the
+  substitution
+  `[IN-CDR; IN-CDR; IN-CDR] => IN-CDDDR`
+* And of course, implement `IN-CDDR`:
+  - Change `lib/assembler.stk`
+  - Change `src/vm-instr.h`
+  - Add one more case to the VM state machine (use the case for `IN_CDR`
+    as a starting point).
+* Finally, write some benchmark to verify if the new optimization is worth
+  the trouble (and the use of a new opcode).
 
 == Garbage collection
 

--- a/doc/refman/idiosync.adoc
+++ b/doc/refman/idiosync.adoc
@@ -46,6 +46,7 @@ For now, supported libraries of the *Red edition* are
 - box _(srfi 111)_
 - charset _(srfi 14)_
 - comparator _(srfi 128)_
+- generator _(srfi 158)_ -- Red edition included SRFI 121, but it was superseded by SRFI 158.
 - hash-table _(srfi 125)_
 - ideque _(srfi 134)_
 - ilist _(srfi 116)_
@@ -61,9 +62,12 @@ For now, supported libraries of the *Red edition* are
 For now, supported libraries of the *Tangerine edition* are
 
 - bitwise _(srfi 151)_
+- bytevectors _(scheme bytevector)_- not a SRFI: this one is a chapter from R6RS.
 - division _(srfi 141)_
+- fixnum _(srfi 143)_
 - flonum _(srfi 144)_
 - generator _(srfi 158)_
+- vector @ _(srfi 160)_
 
 ==== The (srfi ...) Libraries
 

--- a/doc/vm/vm.adoc
+++ b/doc/vm/vm.adoc
@@ -1473,7 +1473,7 @@ Continuation is a native type (`tc_continuation`). A continuation object (define
 in `vm.h`) contains pointers to the C stack, the Scheme stack and several other
 data.
 
-Capturing a continuation is carried ou tby the following step (these are
+Capturing a continuation is carried out by the following steps (these are
 the actual comments in the function `STk_make_continuation`):
 
 [arabic]
@@ -1489,5 +1489,5 @@ Restoring is easier:
 . Restore the Scheme stack
 . Restore the C stack
 
-And, when the C stack is restored, the Vm is back to its original state, except
+And, when the C stack is restored, the VM is back to its original state, except
 for the global variables.

--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -947,7 +947,7 @@ doc>
  * are considered as tags and the special form |(-> tag)| is used to
  * transfer execution to the given tag. This is a **very low level**
  * form which is inspired on |tabgody| Common Lisp's form. It can be useful
- * for defining new syntaxes, and should probably not used as is.
+ * for defining new syntaxes, and should probably not be used as is.
  *
  * @lisp
  * (tagbody               ;; an infinite loop
@@ -1108,7 +1108,7 @@ doc>
  *       (call/ec (lambda (return) (list 'a (return 'b) 'c)))
  *       3)        => (1 b 3)
  * @end lisp
- * |call/ec| is cheaper than the full call/cc. It is particularily useful
+ * |call/ec| is cheaper than the full |call/cc|. It is particularily useful
  * when all the power of |call/cc| is not needded.
 doc>
 |#

--- a/lib/callcc.stk
+++ b/lib/callcc.stk
@@ -180,9 +180,9 @@ doc>
   ;; A simple continuation without winding (accepts multiples values)
   (let ((k  (%make-continuation)))
     (if  (%fresh-continuation? k)
-        (proc (lambda v
-                (%restore-continuation k v)))
-        (apply values k))))
+         (proc (lambda v
+                 (%restore-continuation k v)))
+         (apply values k))))
 
 ;(define %dynamic-wind-stack (make-parameter (list #f)))
 

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -79,7 +79,7 @@
                          (cdr            . ,cdr)
                          (null?          . ,null?)
                          (list           . ,list)
-                         (not              . ,not)
+                         (not            . ,not)
                          (vector-ref     . ,vector-ref)
                          (vector-set!    . ,vector-set!)
                          (string-ref     . ,string-ref)

--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -125,7 +125,7 @@ doc>
                                     (if (symbol-mutable? x) "" "im"))))))
      ((keyword? x)      (format port "a keyword"))
      ((pair?    x)      (format port "a non-empty list"))
-     ((string?  x)      (if (eqv? x "")
+     ((string?  x)      (if (zero? (string-length x))
                             (format port "an empty string")
                             (format port "a string of length ~s"
                                     (string-length x))))

--- a/lib/peephole.stk
+++ b/lib/peephole.stk
@@ -220,7 +220,7 @@
                                        ((LOCAL-REF3) 'LOCAL-REF3-PUSH)
                                        ((LOCAL-REF4) 'LOCAL-REF4-PUSH)))))
 
-             ;; [RETURN; RETURN] => [RETURN]
+             ;; [RETURN; RETURN] => RETURN
              ((and (eq? i1 'RETURN) (eq? i2 'RETURN))
               (replace-2-instr code (list 'RETURN)))
 

--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -882,7 +882,7 @@ doc>
 
 #|
 <doc EXT bytevector-u8-set!
- * (bytevector-u8-ref bytevector k byte)
+ * (bytevector-u8-set! bytevector k byte)
  *
  * Stores byte as the k th byte of bytevector. It is an error if |k|
  * is not a valid index of |bytevector|.

--- a/src/boolean.c
+++ b/src/boolean.c
@@ -277,7 +277,7 @@ DEFINE_PRIMITIVE("eqv?", eqv, subr2, (SCM x, SCM y))
  * (eq? :foo :bar)                 =>  #f
  * (eq? '() '())                   =>  #t
  * (eq? 2 2)                       =>  unspecified
- * (eq? #A #A)                     =>  #t (unspecified in r5rs)
+ * (eq? #\A #\A)                   =>  #t (unspecified in r5rs)
  * (eq? car car)                   =>  #t
  * (let ((n (+ 2 3)))
  *   (eq? n n))                    =>  #t (unspecified in r5rs)

--- a/src/char.c
+++ b/src/char.c
@@ -161,7 +161,7 @@ static void error_bad_char(SCM c)
   STk_error("bad char", c);
 }
 
-static Inline int charcomp(SCM c1, SCM c2)
+static inline int charcomp(SCM c1, SCM c2)
 {
   return (CHARACTER_VAL(c1) - CHARACTER_VAL(c2));
 }

--- a/src/env.c
+++ b/src/env.c
@@ -114,7 +114,7 @@ static void register_module(SCM mod)
 }
 
 
-static Inline SCM make_empty_environment(SCM name)
+static inline SCM make_empty_environment(SCM name)
 {
   register SCM z;
 
@@ -130,7 +130,7 @@ static Inline SCM make_empty_environment(SCM name)
 }
 
 
-static Inline SCM make_module(SCM name)
+static inline SCM make_module(SCM name)
 {
   register SCM z = make_empty_environment(name);
 
@@ -590,7 +590,7 @@ DEFINE_PRIMITIVE("symbol-immutable!", symbol_immutable, subr12, (SCM symb, SCM m
 }
 
 /*===========================================================================*/
-static Inline SCM find_symbol_value(SCM symbol, SCM module)
+static inline SCM find_symbol_value(SCM symbol, SCM module)
 {
   SCM res = STk_hash_get_variable(&MODULE_HASH_TABLE(module), symbol);
   if (res)

--- a/src/fport.c
+++ b/src/fport.c
@@ -228,13 +228,13 @@ static int flush_buffer(struct fstream *f)
 /*=============================================================================*/
 
 
-static Inline int Feof(void *stream)
+static inline int Feof(void *stream)
 {
   return PORT_STREAM_FLAGS(stream) & STK_IOEOF;
 }
 
 
-static Inline int Freadyp(void *stream)
+static inline int Freadyp(void *stream)
 {
   if (PORT_CNT(stream) > 0)
     return TRUE;
@@ -250,7 +250,7 @@ static Inline int Freadyp(void *stream)
   }
 }
 
-static Inline int Fgetc(void *stream)
+static inline int Fgetc(void *stream)
 {
   if (PORT_IDLE(stream) != STk_nil) {
     /* There is at least an idle handler */
@@ -272,7 +272,7 @@ static Inline int Fgetc(void *stream)
 }
 
 
-static Inline int Fread(void *stream, void *buff, int count)
+static inline int Fread(void *stream, void *buff, int count)
 {
   int copied, avail;
 
@@ -322,7 +322,7 @@ static off_t Fseek(void *stream, off_t offset, int whence)
 }
 
 
-static Inline int Fputc(int c, void *stream)
+static inline int Fputc(int c, void *stream)
 {
   int ret = c;
 
@@ -346,7 +346,7 @@ static Inline int Fputc(int c, void *stream)
 }
 
 
-static Inline int Fwrite(void *stream, const void *buff, int count)
+static inline int Fwrite(void *stream, const void *buff, int count)
 {
   /* Flush (eventually) chars which are already in the buffer before writing  */
   if (PORT_CNT(stream)) {
@@ -362,7 +362,7 @@ static Inline int Fwrite(void *stream, const void *buff, int count)
 }
 
 
-static Inline int Fnputs(void *stream, const char *s, int len)
+static inline int Fnputs(void *stream, const char *s, int len)
 {
   int res, flush = (PORT_STREAM_FLAGS(stream) & STK_IOLBF);
 
@@ -402,18 +402,18 @@ static Inline int Fnputs(void *stream, const char *s, int len)
 }
 
 
-static Inline int Fputs(const char *s, void *stream)
+static inline int Fputs(const char *s, void *stream)
 {
   return Fnputs(stream, s, strlen(s));
 }
 
-static Inline int Fputstring(SCM s, void *stream)
+static inline int Fputstring(SCM s, void *stream)
 {
   return Fnputs(stream, STRING_CHARS(s), STRING_SIZE(s));
 }
 
 
-static Inline int  Fflush(void *stream)
+static inline int  Fflush(void *stream)
 {
   return flush_buffer(stream);          /* Problem if file opened for reading */
 }

--- a/src/hash.c
+++ b/src/hash.c
@@ -303,7 +303,7 @@ void STk_hashtable_init(struct hash_table_obj *h, int flag)
  *
 \*===========================================================================*/
 
-static Inline SCM hash_get_symbol(struct hash_table_obj *h, const char *s, int *index)
+static inline SCM hash_get_symbol(struct hash_table_obj *h, const char *s, int *index)
 {
   register SCM l;
 
@@ -615,7 +615,7 @@ DEFINE_PRIMITIVE("hash-table-set!", hash_set, subr3, (SCM ht, SCM key, SCM val))
   if (!HASHP(ht)) error_bad_hash_table(ht);
 
   if (HASH_CONSTP(ht)) error_hash_immutable(ht);
-  
+
   switch (HASH_TYPE(ht)) {
     case hash_eqp:
       index = RANDOM_INDEX(ht, key);
@@ -681,7 +681,7 @@ DEFINE_PRIMITIVE("hash-table-set!", hash_set, subr3, (SCM ht, SCM key, SCM val))
  * @end lisp
 doc>
 */
-static Inline SCM hash_table_search(SCM ht, SCM key)
+static inline SCM hash_table_search(SCM ht, SCM key)
 {
   int index = 0;
   SCM func, l = STk_nil;

--- a/src/lib.c
+++ b/src/lib.c
@@ -77,8 +77,6 @@ STk_init_library(int _UNUSED(*argc), char _UNUSED(***argv), int stack_size)
     STk_init_box()                              &&
     STk_init_ffi()                              &&
     STk_init_syntax()                           &&
-#ifdef STK_DEBUG
     STk_init_utf8()                             &&
-#endif
     (STk_library_initialized = TRUE);
 }

--- a/src/mutex-common.c
+++ b/src/mutex-common.c
@@ -159,7 +159,7 @@ DEFINE_PRIMITIVE("mutex-specific-set!", mutex_specific_set, subr2, (SCM mtx, SCM
 
 void STk_error_bad_condv(SCM obj)
 {
-  STk_error("bad confdition variable ~S", obj);
+  STk_error("bad condition variable ~S", obj);
 }
 
 

--- a/src/number.c
+++ b/src/number.c
@@ -2515,10 +2515,7 @@ DEFINE_PRIMITIVE("ceiling", ceiling, subr1, (SCM x))
 DEFINE_PRIMITIVE("truncate", truncate, subr1, (SCM x))
 {
   switch (TYPEOF(x)) {
-    case tc_real:     {
-                        double d = REAL_VAL(x);
-                        return double2real(d < 0.0 ? ceil(d): floor(d));
-                      }
+    case tc_real:     return double2real(trunc(REAL_VAL(x)));
     case tc_rational: return STk_quotient(RATIONAL_NUM(x), RATIONAL_DEN(x));
     case tc_bignum:
     case tc_integer:  return x;

--- a/src/number.c
+++ b/src/number.c
@@ -3642,7 +3642,7 @@ static void deallocate_function(void * ptr, size_t _UNUSED(sz))
 }
 
 /*
- * SRFI 28: NaN procedures
+ * SRFI 208: NaN procedures
  */
 
 static void verify_NaN(SCM n) {

--- a/src/object.c
+++ b/src/object.c
@@ -411,7 +411,7 @@ DEFINE_PRIMITIVE("%method-more-specific?", method_more_specificp, subr3,
  *
 \*===========================================================================*/
 
-static Inline SCM test_change_class(SCM obj)
+static inline SCM test_change_class(SCM obj)
 {
   SCM classe = INST_CLASS_OF(obj);
 
@@ -422,7 +422,7 @@ static Inline SCM test_change_class(SCM obj)
 
 
 
-static Inline SCM get_slot_value(SCM classe, SCM obj, SCM slot_name)
+static inline SCM get_slot_value(SCM classe, SCM obj, SCM slot_name)
 {
   SCM l;
 
@@ -443,7 +443,7 @@ static Inline SCM get_slot_value(SCM classe, SCM obj, SCM slot_name)
   return CALL_GF3("slot-missing", classe, obj, slot_name);
 }
 
-static Inline SCM set_slot_value(SCM classe, SCM obj, SCM slot_name, SCM value)
+static inline SCM set_slot_value(SCM classe, SCM obj, SCM slot_name, SCM value)
 {
   register SCM l;
 
@@ -550,7 +550,7 @@ DEFINE_PRIMITIVE("%slot-ref", undoc_slot_ref, subr2, (SCM obj, SCM slot_name))
  * initialize-object
  *
  ******************************************************************************/
-// static void Inline set_slot_value_if_unbound
+// static void inline set_slot_value_if_unbound
 //                      (SCM classe, SCM obj, SCM slot_name, SCM val)
 // {
 // #ifdef FIXME

--- a/src/print.c
+++ b/src/print.c
@@ -59,7 +59,7 @@ static void printlist(SCM exp, SCM port, int mode)
 }
 
 
-static Inline void printsymbol(SCM symb, SCM port, int mode)
+static inline void printsymbol(SCM symb, SCM port, int mode)
 {
   const char *s = SYMBOL_PNAME(symb);
 
@@ -84,7 +84,7 @@ static Inline void printsymbol(SCM symb, SCM port, int mode)
         STk_putc('\\', port);
         STk_putc(c, port);
       }
-      else 
+      else
         STk_putc(*s, port);
    }
     STk_putc('|', port);
@@ -92,7 +92,7 @@ static Inline void printsymbol(SCM symb, SCM port, int mode)
     STk_puts(s, port);
 }
 
-static Inline void printkeyword(SCM key, SCM port, int mode)
+static inline void printkeyword(SCM key, SCM port, int mode)
 {
   const char *s = KEYWORD_PNAME(key);
 
@@ -108,7 +108,7 @@ static Inline void printkeyword(SCM key, SCM port, int mode)
 }
 
 
-static Inline char printhexa(int x)
+static inline char printhexa(int x)
 {
   return (x >= 10) ? (x - 10 + 'a') : (x + '0');
 }

--- a/src/sport.c
+++ b/src/sport.c
@@ -63,29 +63,29 @@ struct sstream {
 #define PORT_BUFSIZE(x) (((struct sstream *) (x))->bufsize)
 #define PORT_STR(x)     (((struct sstream *) (x))->str)
 
-static Inline int Sgetc(void *stream)
+static inline int Sgetc(void *stream)
 {
   return (PORT_PTR(stream) < PORT_END(stream)) ?
     ((unsigned char) *PORT_PTR(stream)++) : EOF;
 }
 
 
-static Inline int Seof(void * stream)
+static inline int Seof(void * stream)
 {
   return (PORT_PTR(stream) >= PORT_END(stream));
 }
 
-static Inline int Sreadyp(void *stream)
+static inline int Sreadyp(void *stream)
 {
   return !Seof(stream);
 }
 
-static Inline int Sclose(void _UNUSED(*stream))
+static inline int Sclose(void _UNUSED(*stream))
 {
   return 0;
 }
 
-static Inline int Sread(void *stream, void *buffer, int count)
+static inline int Sread(void *stream, void *buffer, int count)
 {
   int avail = PORT_END(stream) - PORT_PTR(stream);
 
@@ -97,7 +97,7 @@ static Inline int Sread(void *stream, void *buffer, int count)
   return count;
 }
 
-static Inline int Sputc(int c, void *stream)
+static inline int Sputc(int c, void *stream)
 {
   register unsigned int tmp;
 
@@ -118,7 +118,7 @@ static Inline int Sputc(int c, void *stream)
 }
 
 
-static Inline int Swrite(void *stream, const void *buffer, int count)
+static inline int Swrite(void *stream, const void *buffer, int count)
 {
   size_t tmp, pos;
   char *right = PORT_PTR(stream) + count;
@@ -140,22 +140,22 @@ static Inline int Swrite(void *stream, const void *buffer, int count)
   return count;
 }
 
-static Inline int Sputs(const char *s, void *stream)
+static inline int Sputs(const char *s, void *stream)
 {
   return Swrite(stream, s, strlen(s));
 }
 
-static Inline int Sputstring(SCM s, void *stream)
+static inline int Sputstring(SCM s, void *stream)
 {
   return Swrite(stream, STRING_CHARS(s), STRING_SIZE(s));
 }
 
-static Inline int Snputs(void *stream, const char *s, int len)
+static inline int Snputs(void *stream, const char *s, int len)
 {
   return Swrite(stream, s, len);
 }
 
-static Inline int Sflush(void _UNUSED(*stream))
+static inline int Sflush(void _UNUSED(*stream))
 {
   return 0;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -1592,7 +1592,7 @@ DEFINE_PRIMITIVE("%seconds->date", seconds2date, subr1, (SCM seconds))
   int overflow;
   SCM argv[12];
   struct tm *t;
-  time_t tt;
+  time_t tt = (time_t) 0L;
   long nsec = 0L;
 
   if (INTP(seconds)) {

--- a/src/system.c
+++ b/src/system.c
@@ -1843,6 +1843,15 @@ DEFINE_PRIMITIVE("hostname", hostname, subr0, (void))
 <doc EXT pause
  * (pause)
  *
+ * Pauses the STklos process untilla a signal is received. This is exactly the
+ * Unix |pause| system function.
+ *
+ * As an example, entering |(pause)| in the REPL makes it unresponsive, because
+ * the whole system is pause -- until a signal is sent to the |stklos| process.
+ * This can be done, for example, by hitting break (ctrl-C) or, on a Unix system,
+ * by sending the |stklos| process a signal using the |kill| program (for example,
+ * |kill -2 nnnnn|, where |nnnnnn| is the proces ID of |stklos|).
+ *
 doc>
 */
 DEFINE_PRIMITIVE("pause", pause, subr0, (void))

--- a/src/uvector.c
+++ b/src/uvector.c
@@ -204,7 +204,7 @@ int STk_uvector_equal(SCM u1, SCM u2)
 
 
 /* Duplicated from number.c: */
-static Inline SCM Cmake_complex(SCM r, SCM i)
+static inline SCM Cmake_complex(SCM r, SCM i)
 {
   SCM z;
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -74,7 +74,7 @@ static int debug_level = 0;     /* 0 is quiet, 1, 2, ... are more verbose */
 
 #define FX(v)                   (STk_fixval(v))
 
-static Inline sigset_t get_signal_mask(void)
+static inline sigset_t get_signal_mask(void)
 {
   sigset_t new, old;
 
@@ -83,7 +83,7 @@ static Inline sigset_t get_signal_mask(void)
   return old;
 }
 
-static Inline void set_signal_mask(sigset_t mask)
+static inline void set_signal_mask(sigset_t mask)
 {
   sigprocmask(SIG_SETMASK, &mask, NULL);
 }
@@ -363,7 +363,7 @@ void STk_print_vm_registers(char *msg, STk_instr *code)
  *   and returns a list with them.  The CAR of the list
  *   will be the element that was deepest on the stack.
  */
-static Inline SCM listify_top(int n, vm_thread_t *vm)
+static inline SCM listify_top(int n, vm_thread_t *vm)
 {
   SCM *p, res = STk_nil;
 
@@ -373,7 +373,7 @@ static Inline SCM listify_top(int n, vm_thread_t *vm)
 }
 
 
-static Inline SCM clone_env(SCM e, vm_thread_t *vm)
+static inline SCM clone_env(SCM e, vm_thread_t *vm)
 {
   /* clone environment til we find one which is in the heap */
   if (IS_IN_STACKP(e))
@@ -434,7 +434,7 @@ static void error_bad_arity(SCM func, int arity, int16_t given_args, vm_thread_t
  *      fixed, and the procedure can take several arguments, but at least
  *      k are mandatory. Then k is returned.
  */
-static Inline int16_t adjust_arity(SCM func, int16_t nargs, vm_thread_t *vm)
+static inline int16_t adjust_arity(SCM func, int16_t nargs, vm_thread_t *vm)
 {
   int16_t arity = CLOSURE_ARITY(func);
 
@@ -2225,7 +2225,7 @@ DEFINE_PRIMITIVE("%dump-code", dump_code, subr2, (SCM f, SCM v))
 }
 
 
-static Inline STk_instr* read_code(SCM f, unsigned int len) /* read a code phrase */
+static inline STk_instr* read_code(SCM f, unsigned int len) /* read a code phrase */
 {
   STk_instr *res, *tmp;
   unsigned int i;

--- a/src/vm.c
+++ b/src/vm.c
@@ -1868,7 +1868,7 @@ FUNCALL:  /* (int nargs, int tailp) */
     case tc_subr2:
       if (nargs == 2) { CALL_PRIM2(vm->val, (vm->sp[1], vm->sp[0]));      break;}
       goto error_invoke;
-  case tc_subr3:
+    case tc_subr3:
       if (nargs == 3) { CALL_PRIM3(vm->val, (vm->sp[2], vm->sp[1],
                                              vm->sp[0]));                 break;}
       goto error_invoke;


### PR DESCRIPTION
The guard is around `STk_init_utf8()`, but that function, in
`utf8.c`, already has the same guard:

```c
int STk_init_utf8(void)
{
 #ifdef STK_DEBUG
  ADD_PRIMITIVE(char_utf8_encoding);
  ADD_PRIMITIVE(dump_string);
 #endif
  return TRUE;
}
```

It seems cleaner to call all init functions in lib.c, and just
include the debug guards around the relevant code chunks, as
is done in `utf8.c`, shown above.

Also fixed a typo in `mutex-common.c`

-----------------

Ok - I also included a lot of small trivial changes after the commit described above...