### PR TITLE
Optimize `dotimes`, `repeat`, `while` and `until`, and also do some loop unrolling in `repeat`

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -40,7 +40,7 @@
         hash-table-keys hash-table-values hash-table-fold
         hash-table-merge! hash-table-copy
         fluid-let time tagbody
-        dotimes repeat while until
+        dotimes %repeat repeat while until
         call/ec
         base64-encode-string base64-decode-string
         md5sum-file
@@ -1032,13 +1032,40 @@ doc>
 doc>
 |#
 (define-macro (dotimes bindings . body)
+  ;; In the lambda passed to the apply, below:
+  ;; If count is a number (not a variable), don't include a
+  ;; LET for it -- it won't change anyway!
+  ;;
+  ;; For example:
+  ;; (macro-expand '(dotimes (i MAX) 'work))
+  ;;    => (let ((G77 MAX)) (do ((i 0 (+ i 1))) ((>= i G77) (void)) 'work))
+  ;;
+  ;; (macro-expand '(dotimes2 (i 10) 'work))
+  ;;    => (begin (do ((i 0 (fx+ i 1))) ((fx>= i 10) (void)) 'work))
+  ;;
+  ;; The second case will be faster for nested DOTIMEs, because it
+  ;; avoids access to a local variable *and* entering-and-leaving
+  ;; a LET.
+
+  ;; Also - if count is constant *and* a fixnum, we can use
+  ;; fx- and fx>, even though the speed difference is not
+  ;; that great.
+  ;;
+  ;; When count is not a fixnum, we use + and >= :
+  ;; (macro-expand '(dotimes (i 1180591620717411303424) 'work))
+  ;;   => (begin (do ((i 0 (+ i 1))) ((>= i 1180591620717411303424) (void)) 'work))
+  ;;
   (apply (lambda (var count . result)
-           (let ((limit  (gensym))
-                 (result (if (null? result) (list '(void)) result)))
-             `(let ((,limit ,count))
-                (do ((,var 0 (+ ,var 1)))
-                    ((>= ,var ,limit) ,@result)
-                  ,@body))))
+           (let* ((result (if (null? result) (list '(void)) result))
+                  (limit (if (number? count) count (gensym)))
+                  (head  (if (number? count)
+                             '(begin)
+                             `(let ((,limit ,count)))))
+                  (plus (if (fixnum? count) 'fx+ '+))
+                  (ge   (if (fixnum? count) 'fx>= '>=)))
+             `(,@head (do ((,var 0 (,plus ,var 1)))
+                          ((,ge ,var ,limit) ,@result)
+                        ,@body))))
          bindings))
 
 #|
@@ -1058,15 +1085,51 @@ doc>
  * @end lisp
 doc>
 |#
-(define-macro (repeat expr . body)
-  (let ((var (gensym)))
+
+;; %repeat is an internal macro which does not do loop-unrolling.
+;;
+(define-macro  (%repeat expr . body)
+  ;; If expr is constant *and* a fixnum, we can use
+  ;; fx- and fx>, even though the speed difference is not
+  ;; that great.
+  (let ((var (gensym))
+        (minus (if (fixnum? expr) 'fx- '-))
+        (gt    (if (fixnum? expr) 'fx> '>)))
+
     `(let ((,var ,expr))
        (tagbody
         #:top
-        (when (> ,var 0)
-          (set! ,var (- ,var 1))
+        (when (,gt ,var 0)
+          (set! ,var (,minus ,var 1))
           ,@body
           (-> #:top))))))
+
+;; Multiplies a list...
+;; (%multiply-list '(a b c) 3) => (a b c a b c a b c)
+(define (%multiply-list L k)
+  (cond ((fx=? k 0) '())
+        ((fx=? k 1) (list-copy L))
+        (else (append (list-copy L)
+                      (%multiply-list L (fx- k 1))))))
+
+(define-macro (repeat count . body)
+  (if (fixnum? count)
+      ;; In the unlikely situation when the user requested "one"
+      ;; or "zero" iterations (maybe this is generated code?), we don't
+      ;; even create a let binding...
+      (cond ((fx< count 1) '(void))
+            ((eq? count 1) `(begin ,@body))
+            (else
+             (when (not (and (integer? (compiler:unroll-iterations))
+                             (positive? (compiler:unroll-iterations))))
+               (error "compiler:unroll-iterations must be a positive integer; it is ~S"
+                      (compiler:unroll-iterations)))
+             (let ((q (quotient  count (compiler:unroll-iterations)))
+                   (r (remainder count (compiler:unroll-iterations))))
+               (let ((inside (%multiply-list body (compiler:unroll-iterations))))
+                 `(begin (%repeat ,q ,@inside)
+                         ,@(%multiply-list body r))))))
+      `(%repeat ,count ,@body)))
 
 #|
 <doc EXT-SYNTAX while

--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1140,9 +1140,11 @@ doc>
 doc>
 |#
 (define-macro (while test . body)
-  (let ((lab (gensym)))
-    `(let ,lab ()
-          (when ,test ,@body (,lab)))))
+  `(tagbody
+    #:top
+    (when ,test
+      (begin ,@body
+             (-> #:top)))))
 
 #|
 <doc EXT-SYNTAX until
@@ -1153,10 +1155,11 @@ doc>
 doc>
 |#
 (define-macro (until test . body)
-  (let ((lab (gensym)))
-    `(let ,lab ()
-          (unless ,test ,@body (,lab)))))
-
+  `(tagbody
+    #:top
+    (unless ,test
+      (begin ,@body
+             (-> #:top)))))
 
 #|
 <doc EXT call/ec

--- a/lib/compflags.stk
+++ b/lib/compflags.stk
@@ -149,6 +149,14 @@ doc>
  *        (fib (- n 2)))))
  * @end lisp
 doc>
+<doc EXT compiler:unroll-iterations
+ * (compiler:unroll-iterations)
+ * (compiler:unroll-iterations n)
+ *
+ * This parameter controls the number of iterations to be unrolled in
+ * loops. Currently, only |repeat| loops are unrolled. The argument
+ * |n| must be a positive integer.
+doc>
 |#
 (define compiler:time-display                   (make-parameter #t))
 (define compiler:gen-line-number                (make-parameter #f))
@@ -157,6 +165,7 @@ doc>
 (define compiler:show-assembly-code             (make-parameter #f))
 (define compiler:keep-formals                   (make-parameter #f))
 (define compiler:keep-source                    (make-parameter #f))
+(define compiler:unroll-iterations              (make-parameter 3))
 
 
 

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -36,6 +36,7 @@
           compiler:keep-formals
           compiler:keep-source
           compiler:inline-common-functions
+          compiler:unroll-iterations
 
           %compiler-set-flags
           %grab-file-information

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -374,6 +374,49 @@ b|)
             (repeat 'not-a-number (display "." p)))
 
 ;;----------------------------------------------------------------------
+(test-subsection "while and until")
+
+(test "while.1"
+      10
+      (let ((a 1)) (while (< a 10) (set! a (fx+ 1 a))) a))
+
+(test "while.2"
+      (void)
+      (while #f #f))
+
+(test "while.3"
+      '()
+      (let ((x '(1 2 3)))
+        (while (pair? x) (set! x (cdr x)))
+        x))
+
+(test "while.4"
+      '(3)
+      (let ((x '(1 2 3)))
+        (while (pair? (cdr x)) (set! x (cdr x)))
+        x))
+
+(test "until.1"
+      0
+      (let ((a 10)) (until (= a 0) (set! a (fx- a 1))) a))
+
+(test "until.2"
+      (void)
+      (until #t #f))
+
+(test "until.3"
+      '()
+      (let ((x '(1 2 3)))
+        (until (null? x) (set! x (cdr x)))
+        x))
+
+(test "until.4"
+      '(3)
+      (let ((x '(1 2 3)))
+        (until (null? (cdr x)) (set! x (cdr x)))
+        x))
+
+;;----------------------------------------------------------------------
 (test-subsection "(void)")
 
 (test "void.1" #t (eq? (void) #void))


### PR DESCRIPTION
### 1. DOTIMES

`dotimes` creates a `LET` even when not necessary:

```scheme
(macro-expand '(dotimes (i 10) 'work))
  => (let ((G1 10))
       (do ((i 0 (+ i 1)))
           ((>= i G1)
            (void))
         'work))
```

The new variable `G1` is not necessary -- since 10 is constant, it could have been used in the body instead of `G1`, and the `LET` is superfluous. For nested `dotimes`, this can make a difference.

With this patch we check (at macro expansion time) if `count` is a number, and when it is, we generate a begin instead of a let.

For example:
```scheme
(macro-expand '(dotimes (i MAX) 'work))
    => (let ((G77 MAX)) (do ((i 0 (+ i 1))) ((>= i G77) (void)) 'work))

(macro-expand '(dotimes (i 10) 'work))
    => (begin (do ((i 0 (fx+ i 1))) ((fx>= i 10) (void)) 'work))
```

The second case will be faster for nested `DOTIME`s, because it avoids access to a local variable *and* entering-and-leaving a `LET`.

### 2 REPEAT

We do loop unrolling! For `repeat` this is very easy, since it does not use variables that can be changed by the user.
    
* The parameter `compiler:unroll-iterations` controls the number  of iterations to unroll
* We have an internal function `%multiply-list` that is used to make copies of the body: `(%multiply-list '(x y) 3) => (x y x y x y)`
* `repeat` will divide the repetition count by compiler:unroll-iterations, and produce `(%repeat ,quot ,(multiply-list body))` followed by the remainder times the body:

```scheme
    (macro-expand '(repeat 5 a b c))
    => (begin
         (%repeat 1
           a b c
           a b c
           a b c) ;; 5 / 3 is one, so one iteration of three copies of body
         a b c
         a b c) ;; The remainder of 5 / 3 is two: these are those two copies.
```

**Some timings**. I have ran the following:

```scheme
(compiler:unroll-iterations K)
(let ((a 1))
  (time
    (repeat 1_000_000_000 
      (set! a (+ a 1)))) 
  a)
```

For different `K`, these are the running times:
| K | average time  (ms) |
|-----|---|
| 100 | 9461.12 |
| 10 | 12407.993 |
| 3 | 15015.482 |
| 1 | 26796.797 |

(I also checked the original `repeat`, and the time is similar to unrolling with K=1 -- that is, the new method has no overhead (as expected).

So it looks like it's really worth it.

**Possible issue**: ~we use `list-copy` to make the copies of the body. This *could* maybe have an undesirable effect? Maybe one would expect `(eq? x '(...))` somewhere in the body to be true, and it won't anymore because we copied the literal list? Should we not use `list-copy`?~ Hm, I actually don't think this is an isue...


### 3. REPEAT *and* DOTIMES

In `(repeat N body)` and in `(dotimes (var N) body)`, when `N` is constant *and* a fixnum we can use `fx-` and `fx>`, even though the speed difference is not that great.

### 4. ADDITION (new commits included) -- `while` and `until`

Rewrite while and until using `tagbody`. After that, disassembling  `(while test -1)` we see that the generated code went from 31 instructions to 9 instructions!

Also,

```scheme
(let ((a 1))
  (time
    (while (< a 10_000_000)
      (set! a (fx+ 1 a))))
  a)
```
    
The timing for that code goes from 524.973 ms to 384.457 ms.
