### PR TITLE
Set some procedure names

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1150,7 +1150,10 @@ doc>
                            (get-output-string out))))))
 
   (set! base64-encode-string (encode/decode base64-encode))
-  (set! base64-decode-string (encode/decode base64-decode)))
+  (set! base64-decode-string (encode/decode base64-decode))
+
+  (%set-procedure-name! base64-encode-string 'base64-encode-string)
+  (%set-procedure-name! base64-decode-string 'base64-decode-string))
 
 ;; ======================================================================
 ;;      md5sum ...
@@ -1274,7 +1277,10 @@ doc>
              (Loop (append (car args) (cdr args))
                    str-prev?
                    res))
-          (else (error 'ansi-color "bad command ~S" args)))))))
+          (else (error 'ansi-color "bad command ~S" args))))))
+
+  (%set-procedure-name! ansi-color 'ansi-color)
+  (%set-procedure-name! ansi-color-protect 'ansi-color-protect))
 
 (define do-color
   (let ((term (or (getenv "TERM") "")))

--- a/lib/load.stk
+++ b/lib/load.stk
@@ -287,6 +287,8 @@ doc>
 (set! try-load (lambda (fn)
                  (%try-load fn (load-path) (load-suffixes))))
 
+(%set-procedure-name! try-load 'try-load)
+
 ;=============================================================================
 ;
 ;  Rewriting of the LOAD primitive
@@ -453,8 +455,11 @@ doc>
 
   (set! provided?
     (lambda (what)
-      (and (member what provided) #t))))
+      (and (member what provided) #t)))
 
+  (%set-procedure-name! require/provide 'require/provide)
+  (%set-procedure-name! provide 'provide)
+  (%set-procedure-name! provided? 'provided?))
 
 ;; Overload require with a macro to let the compiler deal with globals
 (define-macro (require what)

--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -339,6 +339,7 @@ doc>
 ;;;; ----------------------------------------------------------------------
 (define equal-simple? equal?)
 (set! equal? %equiv?)   ;; equiv? is defined in equiv.stk
+(%set-procedure-name! equal? 'equal?)
 
 ;;;; ----------------------------------------------------------------------
 ;;;; 6.2 Numbers

--- a/lib/regexp.stk
+++ b/lib/regexp.stk
@@ -137,4 +137,6 @@ doc>
                                                                (string-length str))
                                                     subst))
                             str)))))
-            (regexp-replace-all-r pat str subst)))))
+            (regexp-replace-all-r pat str subst))))
+  (%set-procedure-name! regexp-replace 'regexp-replace)
+  (%set-procedure-name! regexp-replace-all 'regexp-replace-all))


### PR DESCRIPTION
Some procedure are defined inside closures using `set!`. Some of them did not have their names set, and this patch does that.

The procedures are:
`base64-encode-string`, `base64-decode-string`, `ansi-color-protect`, `require/provide`, `provide`, `provided?`, `try-load`, `equal?`.

Also, `ansi-color` had the name of `do-color`.