### PR TITLE
Use two-level namespace for bundles on macOS

### DIFF
--- a/utils/shlib-options
+++ b/utils/shlib-options
@@ -21,7 +21,7 @@
 #
 #           Author: Erick Gallesio [eg@unice.fr]
 #    Creation date: 27-Jul-2000 12:21 (eg)
-# Last file update:  7-Mar-2023 07:55 (ryandesign)
+# Last file update: 16-Mar-2023 22:28 (ryandesign)
 
 
 #
@@ -161,7 +161,7 @@ case $os in
   Darwin*)
       OS=DARWIN;
       SH_COMP_FLAGS="-fPIC -fno-common"
-      SH_LOAD_FLAGS='-bundle -flat_namespace -undefined suppress'
+      SH_LOAD_FLAGS='-bundle -undefined dynamic_lookup'
       SH_LOADER="$CC"
       SH_SUFFIX='so'
       SH_LIB_SUFFIX='dylib'


### PR DESCRIPTION
Use the two-level namespace for loadable modules on macOS instead of the flat namespace. The flat namespace is a relic from Mac OS X 10.0 (2001). The two-level namespace was introduced in Mac OS X 10.1 (2001) and the ability to resolve undefined symbols at runtime in the two-level namespace was added in Mac OS X 10.3 (2003). There's no reason to use the flat namespace anymore today.

For more info about the differences between the two types of namespaces and why the two-level namespace is better:

https://web.archive.org/web/20030604123710/http://developer.apple.com/techpubs/macosx/ReleaseNotes/TwoLevelNamespaces.html

I'm linking to an archived copy of that page because Apple has removed it from their site or at least moved it somewhere I could not find it, and it is outdated. For example it states that you cannot have any undefined symbols in the two-level namespace, but that limitation was removed in Mac OS X 10.3 with the introduction of `-undefined dynamic_lookup`.