### PR TITLE
Use git information to show stable versions in banner

### DIFF
--- a/lib/repl.stk
+++ b/lib/repl.stk
@@ -330,7 +330,10 @@ doc>
       (repl-theme 'classic))
     ;; Show banner
     (let* ((utf8?  (key-get *%system-state-plist* :use-utf8 #f))
-           (line1   (format "STklos version ~A  (Id: ~A)\n" (version) (%push-id)))
+           (version-string (if (stklos-stable?)
+                               (format "version ~a" (version))
+                               (format "version post-~a (git commit ~A)" (version) (%push-id))))
+           (line1   (format "STklos ~a\n" version-string))
            (line2  "Copyright (C) 1999-2023 Erick Gallesio <eg@stklos.net>\n")
            (line3 (format "[~a/~a/~a/~a]\n"
                           (machine-type)

--- a/lib/runtime.stk
+++ b/lib/runtime.stk
@@ -235,3 +235,22 @@ doc>
     (newline out)))
 
 
+;; ----------------------------------------------------------------------
+;; ----------------------------------------------------------------------
+
+#|
+<doc stklos-stable?
+ * (stklos-stable?)
+ *
+ * Returns `#t` if the running STklos installation was compiled from a stable
+ * release, and `#f` otherwise.
+doc>
+|#
+(define (stklos-stable?)
+  ;; Checking if the source wqas mdified is a bit tricky:
+  ;; Usually the Makefile.in files *will* be modified by
+  ;; autotools. We can enhance this later.
+  (let ((info (%stklos-git)))
+    (if (null? info)
+        #t
+        (not (zero? (string-length (key-get info #:stable 2)))))))

--- a/utils/generate-git-info
+++ b/utils/generate-git-info
@@ -1,22 +1,31 @@
 #!/bin/sh
 
-# detect git tag, branch, commit, and wether the repository is dirty
-# when not in a git repository, all the strings will be empty,
-# and STklos will be able to detect this.
-git_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
-git_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-git_commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
-git_modified="$(git diff-index --name-only HEAD 2>/dev/null |  xargs -n 1 printf ' \\"%s\\"')"
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]
+then
+    # detect git tag, branch, commit, and wether the repository is dirty
+    # when not in a git repository, all the strings will be empty,
+    # and STklos will be able to detect this.
+    git_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+    git_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    git_commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
+    git_modified="$(git diff-index --name-only HEAD 2>/dev/null |  xargs -n 1 printf ' \\"%s\\"')"
+    git_stable="$(git tag --contains $git_commit)"
 
-cat > new-git-info.h <<EOF
-#define GIT_SUMMARY  "(#:branch \"$git_branch\" #:commit \"$git_commit\" #:tag \"$git_tag\" #:modified ($git_modified))"
+    cat > new-git-info.h <<EOF
+#define GIT_SUMMARY  "(#:branch \"$git_branch\" #:commit \"$git_commit\" #:tag \"$git_tag\" #:modified ($git_modified) #:stable \"$git_stable\")"
 EOF
 
-if cmp --quiet new-git-info.h git-info.h 2>/dev/null
-then
-     rm new-git-info.h
+    if cmp --quiet new-git-info.h git-info.h 2>/dev/null
+    then
+        rm new-git-info.h
+    else
+        echo "*** Updating git-info.h"
+        mv new-git-info.h git-info.h
+    fi
 else
-    echo "*** Updating git-info.h"
-    mv new-git-info.h git-info.h
+    echo "*** Not inside a checkout from git"
+    cat > git-info.h <<EOF
+#define GIT_SUMMARY  "()"
+EOF
 fi
 


### PR DESCRIPTION
See issue #515 

* When compiling from a git checkout, a stable version will be detected and included in `git-info.h`
* In `runtime.stk` there is a new procedure, `stklos-stable?`, that will tell if this STklos binary was compiled from a stable release
* In `repl.stk`, we use this to make the banner more informative: After creating a "10.1" tag for the current commit and reconfiguring and compiling STklos, we have:

```
  \    STklos version 10.1
   \   Copyright (C) 1999-2023 Erick Gallesio <eg@stklos.net>
  / \  [Linux-6.1.0-5-amd64-x86_64/pthreads/readline/utf8]
 /   \ Type ',h' for help
```

If we delete the tag, reconfigure and compile again,

```
  \    STklos version post-1.70 (git commit fefabbde)
   \   Copyright (C) 1999-2023 Erick Gallesio <eg@stklos.net>
  / \  [Linux-6.1.0-5-amd64-x86_64/pthreads/readline/utf8]
 /   \ Type ',h' for help
```