### PR TITLE
Remove sentence about STklos library from manpage

### DIFF
--- a/doc/stklos.1.in
+++ b/doc/stklos.1.in
@@ -27,9 +27,6 @@ System
 is a free Scheme System (nearly) conforming to R5RS. The aim of this
 implementation is to be fast as well as light. The implementation is
 based on an ad-hoc Virtual Machine.
-.B STklos
-can also be compiled as a library, so that one can easily embed it
-in an application.
 .LP
 The salient points of STklos are:
 .IP "" 4


### PR DESCRIPTION
See 86b6c11c where the same sentence was removed from the README.