### PR TITLE
Make `expt` work with complex exponents, and adjust to one R7RS requirement

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3181,10 +3181,10 @@ static Inline SCM exact_exponent_expt(SCM x, SCM y)
 {
   mpz_t res;
 
-  if (zerop(y))
-      return (isexactp(x) && isexactp(y))
-          ? MAKE_INT(1)
-          : double2real(1.0);
+  /* y is already known to be exact; so if it is zero,
+     return exact one. */
+  if (zerop(y)) return MAKE_INT(1);
+
   if (zerop(x) || (x == MAKE_INT(1))) return x;
 
   if (TYPEOF(y) == tc_bignum)

--- a/tests/srfis/70.stk
+++ b/tests/srfis/70.stk
@@ -58,8 +58,6 @@
 (test "expr.1" 1.0    (expt 10 0.0))
 (test "expr.2" 1      (expt 10 0))
 (test "expr.3" 1.0    (expt (sqrt 2) 0.0))
-(test "expr.4" 1      (expt (sqrt 3) 0))
+(test "expr.4" 1.0    (expt (sqrt 3) 0)) ; because sqrt(3) is inexact
+(test "expr.5" 1      (expt (sqrt 4) 0)) ; because sqrt(4) is exact
 (test "expt.5" +inf.0 (expt 0.0 -4))
-
-
-

--- a/tests/srfis/70.stk
+++ b/tests/srfis/70.stk
@@ -58,6 +58,7 @@
 (test "expr.1" 1.0    (expt 10 0.0))
 (test "expr.2" 1      (expt 10 0))
 (test "expr.3" 1.0    (expt (sqrt 2) 0.0))
-(test "expr.4" 1.0    (expt (sqrt 3) 0)) ; because sqrt(3) is inexact
-(test "expr.5" 1      (expt (sqrt 4) 0)) ; because sqrt(4) is exact
+(test "expr.4" 1      (expt (sqrt 3) 0)) ; sqrt(3) is inexact, but exponent exact
+(test "expr.5" 1      (expt (sqrt 4) 0)) ; sqrt(4) is exact, but exponent exact
+(test "expr.5" 1      (expt +inf.0 0))   ; all Schemes do compute ∞^0 = one...
 (test "expt.5" +inf.0 (expt 0.0 -4))

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1096,7 +1096,19 @@
 (test "exact expt" 1 (expt 1 720000))
 (test "exact expt" 1 (expt -1 720000))
 (test "exact expt" -1 (expt -1 720001))
-
+(test "0^0" 1 (expt 0 0))
+(test "0^0" 1.0 (expt 0.0 0))
+(test "0^0" 1.0 (expt 0 0.0))
+(test "0^0" 1.0 (expt 0.0 0.0))
+(test "complex expt"
+      #t
+      (let* ((z (expt 2 -3+4i))
+             (r (real-part z))
+             (i (imag-part z)))
+        (and (< -0.116585885  r -0.116585884)
+             (<  0.045085823 i   0.045085824))))
+(test/error "0^-a+bi" (expt 0   -2+1i))
+(test/error "0^-a+bi" (expt 0.0 -2+1i))
 
 ;;------------------------------------------------------------------
 (test-subsection "sqrt")

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1096,10 +1096,10 @@
 (test "exact expt" 1 (expt 1 720000))
 (test "exact expt" 1 (expt -1 720000))
 (test "exact expt" -1 (expt -1 720001))
-(test "0^0" 1 (expt 0 0))
-(test "0^0" 1.0 (expt 0.0 0))
-(test "0^0" 1.0 (expt 0 0.0))
-(test "0^0" 1.0 (expt 0.0 0.0))
+(test "0^0" 1 (expt 0 0))        ; exact exponent, exact 1
+(test "0^0" 1 (expt 0.0 0))      ; exact exponent, exact 1
+(test "0^0" 1.0 (expt 0 0.0))    ; inexact exponent, inexact 1.0
+(test "0^0" 1.0 (expt 0.0 0.0))  ; inexact exponent, inexact 1.0
 (test "complex expt"
       #t
       (let* ((z (expt 2 -3+4i))


### PR DESCRIPTION
The following condition in the primitive definition for `expt`:
```c
  if (negativep(y))
    return div2(MAKE_INT(1),
                my_expt(x, sub2(MAKE_INT(0), y)));
```
was preventing it from working with complex exponents, because `negativep` will trigger an error for complexes. Adding `!COMPLEXP(y)` fixes it.

However, there is another issue that we also fix with this PR: R7RS says that

> "The value of $0^z$ is $1$ if `(zero? z)`, $0$ if `(real-part z)` is positive, and an error otherwise.  Similarly for $0.0^z$, with inexact results."

But the current code would not do the "zero when (real-part z) is positive", so we also fix this in `my_expt`.

Then, we add some tests. And adjust one test from SRFI 70:

```scheme
(test "expr.4" 1    (expt (sqrt 3) 0))
```

This won't work with R7RS, because `(sqrt 3)` is inexact, and then `expt` is *required* to return an inexact number. So we do this instead:

```scheme
(test "expr.4" 1.0    (expt (sqrt 3) 0)) ; because sqrt(3) is inexact
(test "expr.5" 1      (expt (sqrt 4) 0)) ; because sqrt(4) is exact
```

(And actually, as far as I can see, SRFI 70 doesn't really require that the result from `(expt (sqrt 3) 0)` be exact).