### PR TITLE
Don't define `__NO_MATH_INLINES`

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -25,13 +25,6 @@
  */
 
 
-/* workaround for bad optimisations done in glibc2.1. Thanks to  Andreas Jaeger
- * <aj@suse.de> for it
- */
-#ifndef __NO_MATH_INLINES
-#  define __NO_MATH_INLINES
-#endif
-
 #include <math.h>
 #include <ctype.h>
 #include <locale.h>


### PR DESCRIPTION
There doesn't seem to be any difference in using this or not -- all tests pass and the average performance seems the same in both cases.