### PR TITLE
Clean up STk_errno_names

### DIFF
--- a/src/signal.c
+++ b/src/signal.c
@@ -145,7 +145,7 @@ static void sigint(int _UNUSED(i))
 static void sigsegv(int _UNUSED(i))
 {
   fprintf(stderr,
-      "Received a SIGSGV signal.\n"
+      "Received a SIGSEGV signal.\n"
       "Try to augment stack size (--stack-size option).\n"
       "If the problem persists, send a mail to <bugs@stklos.net>\n");
   fflush(stderr);

--- a/src/system.c
+++ b/src/system.c
@@ -262,6 +262,9 @@ struct codeset_code STk_errno_names[] = {
 #ifdef EDEADLK
     CODESET_ERRNO(EDEADLK)
 #endif
+#ifdef EDEADLOCK
+    CODESET_ERRNO(EDEADLOCK)
+#endif
 #ifdef EDESTADDRREQ
     CODESET_ERRNO(EDESTADDRREQ)
 #endif
@@ -343,14 +346,14 @@ struct codeset_code STk_errno_names[] = {
 #ifdef ELIBBAD
     CODESET_ERRNO(ELIBBAD)
 #endif
+#ifdef ELIBEXEC
+    CODESET_ERRNO(ELIBEXEC)
+#endif
 #ifdef ELIBMAX
     CODESET_ERRNO(ELIBMAX)
 #endif
 #ifdef ELIBSCN
     CODESET_ERRNO(ELIBSCN)
-#endif
-#ifdef ELIBEXEC
-    CODESET_ERRNO(ELIBEXEC)
 #endif
 #ifdef ELNRANGE
     CODESET_ERRNO(ELNRANGE)
@@ -475,6 +478,9 @@ struct codeset_code STk_errno_names[] = {
 #ifdef ENXIO
     CODESET_ERRNO(ENXIO)
 #endif
+#ifdef EOPNOTSUPP
+    CODESET_ERRNO(EOPNOTSUPP)
+#endif
 #ifdef EOVERFLOW
     CODESET_ERRNO(EOVERFLOW)
 #endif
@@ -523,11 +529,11 @@ struct codeset_code STk_errno_names[] = {
 #ifdef ESHUTDOWN
     CODESET_ERRNO(ESHUTDOWN)
 #endif
-#ifdef ESPIPE
-    CODESET_ERRNO(ESPIPE)
-#endif
 #ifdef ESOCKTNOSUPPORT
     CODESET_ERRNO(ESOCKTNOSUPPORT)
+#endif
+#ifdef ESPIPE
+    CODESET_ERRNO(ESPIPE)
 #endif
 #ifdef ESRCH
     CODESET_ERRNO(ESRCH)
@@ -559,35 +565,14 @@ struct codeset_code STk_errno_names[] = {
 #ifdef EUSERS
     CODESET_ERRNO(EUSERS)
 #endif
+#ifdef EWOULDBLOCK
+    CODESET_ERRNO(EWOULDBLOCK)
+#endif
 #ifdef EXDEV
     CODESET_ERRNO(EXDEV)
 #endif
 #ifdef EXFULL
     CODESET_ERRNO(EXFULL)
-#endif
-
-
-#ifdef EOPNOTSUPP
-    CODESET_ERRNO(EOPNOTSUPP)
-#endif
-#ifdef ENOTSUP
-    CODESET_ERRNO(EOPNOTSUPP)
-#endif
-
-
-#ifdef EWOULDBLOCK
-    CODESET_ERRNO(EWOULDBLOCK)
-#endif
-#ifdef EAGAIN
-    CODESET_ERRNO(EAGAIN)
-#endif
-
-
-#ifdef EDEADLOCK
-    CODESET_ERRNO(EDEADLOCK)
-#endif
-#ifdef EDEADLK
-    CODESET_ERRNO(EDEADLK)
 #endif
     {NULL, 0}
 };


### PR DESCRIPTION
- Sort in alphabetical order.

- EAGAIN and EDEADLK were listed twice.

- The following entry was incorrect:

    #ifdef ENOTSUP
        CODESET_ERRNO(EOPNOTSUPP)
    #endif

- Note: EOPNOTSUPP and ENOTSUP are sometimes the same number, sometimes different. We should list both names.