### PR TITLE
Better use of GMP in `expt` (fixes crash)

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3327,8 +3327,9 @@ static Inline SCM exact_exponent_expt(SCM x, SCM y)
 
       /* Put back the sign, if needed (that is, if sign (of x) < 0 and the exponent is odd): */
       if (sign<0 && ((INT_VAL(y)) & 1UL)) mpz_neg(res,res);
-
-      return bignum2number(res);
+      SCM scm_res = bignum2number(res);
+      mpz_clear(res);
+      return scm_res;
     case tc_bignum:
       mpz_init(res);
       mpz_pow_ui(res, BIGNUM_VAL(x), INT_VAL(y));

--- a/src/number.c
+++ b/src/number.c
@@ -3306,6 +3306,7 @@ doc>
 static Inline SCM exact_exponent_expt(SCM x, SCM y)
 {
   mpz_t res;
+  SCM scm_res;
 
   /* y is already known to be exact; so if it is zero,
      return exact one. */
@@ -3327,13 +3328,15 @@ static Inline SCM exact_exponent_expt(SCM x, SCM y)
 
       /* Put back the sign, if needed (that is, if sign (of x) < 0 and the exponent is odd): */
       if (sign<0 && ((INT_VAL(y)) & 1UL)) mpz_neg(res,res);
-      SCM scm_res = bignum2number(res);
+      scm_res = bignum2number(res);
       mpz_clear(res);
       return scm_res;
     case tc_bignum:
       mpz_init(res);
       mpz_pow_ui(res, BIGNUM_VAL(x), INT_VAL(y));
-      return bignum2number(res);
+      scm_res = bignum2number(res);
+      mpz_clear(res);
+      return scm_res;
     case tc_rational:
       return make_rational(exact_exponent_expt(RATIONAL_NUM(x), y),
                            exact_exponent_expt(RATIONAL_DEN(x), y));

--- a/src/number.c
+++ b/src/number.c
@@ -3318,12 +3318,19 @@ static Inline SCM exact_exponent_expt(SCM x, SCM y)
 
   switch (TYPEOF(x)) {
     case tc_integer:
-      mpz_init_set_si(res, INT_VAL(x));
-      mpz_pow_ui(res, res, INT_VAL(y));
-      SCM scm_res = bignum2number(res);
-      mpz_clear(res);
-      return scm_res;
+      mpz_init(res);
+      /* Take the sign of the base. The GMP computation will be done
+         without it. */
+      long sign = (INT_VAL(x) < 0) ? -1 : +1;
+
+      mpz_ui_pow_ui(res, (unsigned long) (sign*INT_VAL(x)), (unsigned long) INT_VAL(y));
+
+      /* Put back the sign, if needed (that is, if sign (of x) < 0 and the exponent is odd): */
+      if (sign<0 && ((INT_VAL(y)) & 1UL)) mpz_neg(res,res);
+
+      return bignum2number(res);
     case tc_bignum:
+      mpz_init(res);
       mpz_pow_ui(res, BIGNUM_VAL(x), INT_VAL(y));
       return bignum2number(res);
     case tc_rational:

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1103,6 +1103,7 @@
 (test "0^0" 1 (expt 0.0 0))        ;; exact exponent, exact 1
 (test "0^0" 1.0 (expt 0 0.0))      ;; inexact exponent, inexact 1.0
 (test "0^0" 1.0 (expt 0.0 0.0))    ;; inexact exponent, inexact 1.0
+
 (test "complex expt"
       #t
       (let* ((z (expt 2 -3+4i))
@@ -1112,6 +1113,8 @@
              (<  0.045085823 i   0.045085824))))
 (test/error "0^-a+bi" (expt 0   -2+1i))
 (test/error "0^-a+bi" (expt 0.0 -2+1i))
+
+(test "exact expt" 1/1606938044258990275541962092341162602522202993782792835301376 (expt (expt 2 100) -2))
 
 ;;------------------------------------------------------------------
 (test-subsection "sqrt")


### PR DESCRIPTION
### 1. Include missing calls to `mpz_init`
 

In `exact_exponent_expt`, some calls were missing, and STklos would crash on this, for example:

```scheme
(expt (expt 2 100) -2)
```

This patch also includes a test for that.

If an exponent is reeealy too large:
```scheme
(expt fx-greatest 100000)
```

STklos will report a `SIGABRT` from the GMP.

Anyway, when the exponent is too large, several Scheme implementations either crash (Chez, Guile, Sagittarius), or report an error like "our of memory" or "exponent too large" (Gosh, MIT). Kawa and Bigloo return an imprecise infinity -- so the behavior of STklos should be OK.

### 2. Don't create and initialize a new `mpz_t` number unnecessarily 

* Use `mpz_ui_pow_ui` instead of creating and setting the value of a new mpz number to then call `mpz_pow_ui`.

  Since that function only accpets *unsigned* integers, we check the sign, pass the number as unsigned, then if the base was negative *and* the exponent was odd, we multiply by -1.

* Call `mpz_init(res)` for the `tc_bignum` case.

The first change seems to make exponentiation with fixnum base slightly faster:

```scheme
;; fixnum result:
(let ((a 0))
  (time
   (repeat 10000000
     (set! a (expt (expt 2 5) (expt 2 3)))))
  a)
;; 6545.442 => 5446.367
```

```scheme
;; bignum result:
(let ((a 0))
  (time
   (repeat 10000000
     (set! a (expt (expt 2 10) (expt 2 5)))))
  a)
;; 8859.299 => 7478.944
```

(Average of 20 runs)

The sign change didn't make much of a difference in timings (That is, timings seem similar for iterated computation of `(expt -32 9)` and `(expt 32 9)`.

### 3. Call `mpz_clear` before returning from `expt`

This actually makes it faster:

```scheme
(let ((a (* (expt 2 60)))
      (b 30)
      (c #f))
  (time
   (repeat 5_000_000
           (set! c (expt a b))))
  c)
    
4660.171 ms => 2900.074 ms
```

