### PR TITLE
Fix help docs path

### DIFF
--- a/lib/help.stk
+++ b/lib/help.stk
@@ -44,7 +44,7 @@
           '()))))
 
 (define *the-doc*
-  (read-database (make-path (%library-prefix) "share" "stklos" (version) "DOCDB")))
+  (read-database (make-path (%library-prefix) "share" "stklos" (short-version) "DOCDB")))
 
 
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
Don't use `major.minor.PATCH` for looking up the database; it's just `major.minor` (`short-path`).

Otherwise, we get this:
```
stklos> (help memq)
Warning: cannot open "/usr/local/share/stklos/1.70.1153/DOCDB".
```