### PR TITLE
Compute (log -0.0) as per R7RS

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2627,7 +2627,11 @@ static SCM my_log(SCM z)
                       return double2real(log((double) INT_VAL(z)));
     case tc_bignum:   return double2real(log(scheme_bignum2double(z)));
     case tc_rational: return double2real(log(rational2double(z)));
-    case tc_real:     return double2real(log(REAL_VAL(z)));
+        
+    case tc_real:     if ( (REAL_VAL(z) == 0.0) && signbit(REAL_VAL(z)) )
+                          return make_complex(double2real(minus_inf), double2real(MY_PI));
+                      else
+                          return double2real(log(REAL_VAL(z)));
     case tc_complex:  return make_complex(my_log(STk_magnitude(z)),
                                           STk_angle(z));
     default:          error_bad_number(z);

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1426,6 +1426,17 @@
       0.0
       (log 1.0))
 
+(test "log 0.0"
+      -inf.0
+      (log 0.0))
+
+(test "log -0.0" ;; R7RS says (log -0.0) should be "-inf + i*pi".
+      #t
+      (let ((z (log -0.0)))
+        (infinite? (real-part z))
+        (negative? (real-part z))
+        (< 3.14159265350 (imag-part z) 3.14159265360)))
+
 (test "log 2/3"
       #t
       (< -0.4055000


### PR DESCRIPTION
R7RS requires that

```scheme
(log  0.0) => -inf.0
(log -0.0) => -inf.0+(PI)i
```

STklos was returning `-inf.0` for both cases. This patch corrects that.