### PR TITLE
Add `exact-integer-log` (similar to R7RS `exact-integer-sqrt`)

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -58,6 +58,7 @@
         define-constant
         void?
         default-browser open-in-browser manual man
+        exact-integer-log
         receive case-lambda
         radians->degrees degrees->radians
 
@@ -1850,6 +1851,58 @@ doc>
 doc>
 |#
 (define (void? obj) (eq? obj #void))
+
+#|
+
+<doc exact-integer-log
+ * (exact-integer-log n b)
+ *
+ * |Exact-integer-log| is to |log| what |exact-integer-sqrt| is to |sqrt|.
+ *
+ * Returns two values: the first value is the largest integer number less
+ * than or equal to the logarithm of |n| in base |b|. The second value is
+ * the difference between |n| and |(expt b k)|, where |k| is the first value.
+ *
+ * Both arguments must be exact, and the resulting values are exact integers.
+ * Also, both arguments are mandatory, since it is no meaningful in this context
+ * to use base *e*.
+ *
+ * @lisp
+ * (exact-integer-log 8 2)  => 3,0
+ * (exact-integer-log 11 2) => 3,3
+ * (exact-integer-log
+ *          (expt 3 5)
+ *          (expt 3 4))     => 1, 162
+ * (exact-integer-log 16 2) => 4, 0
+ * (exact-integer-log 19 1) => 4, 3
+ * (exact-integer-log
+ *          (expt 6 10000)
+ *          (expt 6 1000)) => 10, 0
+ * (exact-integer-log 2 1) => error
+ * (exact-integer-log 0 5) => error
+ * (exact-integer-log 0 0) => error
+ * @end lisp
+doc>
+|#
+(define (exact-integer-log n b)
+  (unless (and (exact-integer? n) (positive? n))
+    (error "log exponent ~S is not a positive exact integer" n))
+  (unless (and (exact-integer? b) (> b 1))
+    (error "log base ~S is not exact integer greater than one" b))
+  ;; This is easier and faster than R7RS exact-integer-sqrt, since:
+  ;; * log(n b) = log_2(n) / log_2(b).
+  ;; * integer-length(n) = floor(log_2(n)) + 1
+  ;; We just put it all together.
+  (let ((log2-n (- (integer-length n) 1))
+        (log2-b (- (integer-length b) 1)))
+    (let ((L (quotient log2-n log2-b)))
+      ;; Ok, so FLOOR(a/b) can be smaller than FLOOR(a)/FLOOR(b).
+      ;; That means we may have overestimated L -- but we should be
+      ;; close. If we overestimated, then (expt b L) will be larger
+      ;; than n, and we can subtract from it until we find the correct
+      ;; number.
+      (while (> (expt b L) n) (set! L (- L 1)))
+      (values L (- n (expt b L))))))
 
 #|
 <doc EXT radians->degrees degrees->radians

--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1895,13 +1895,31 @@ doc>
   ;; We just put it all together.
   (let ((log2-n (- (integer-length n) 1))
         (log2-b (- (integer-length b) 1)))
-    (let ((L (quotient log2-n log2-b)))
+    (let ((L (quotient log2-n log2-b))
+          (step 1))
       ;; Ok, so FLOOR(a/b) can be smaller than FLOOR(a)/FLOOR(b).
       ;; That means we may have overestimated L -- but we should be
       ;; close. If we overestimated, then (expt b L) will be larger
       ;; than n, and we can subtract from it until we find the correct
       ;; number.
-      (while (> (expt b L) n) (set! L (- L 1)))
+      ;; We do increase the step at each iteration in order to speed
+      ;; up the process. If we go too far, we correct it later. This is
+      ;; fast.
+      (while (> (expt b L) n)
+        (set! L (- L step))
+        (set! step (+ step 2)))
+
+      ;; If we overestimated, then we had to walk down from L.
+      ;; In this case, since we added 2 to the step at each
+      ;; iteration, we may now have UNDERestimated. But then,
+      ;; we undo the last iteration (the "go back" line below),
+      ;; and start walking again, this time with a fixed step
+      ;; equal to 1.
+      (when (> step 1)            ; did we need to walk?
+        (set! L (+ L step -2))    ; go back...
+        (while (> (expt b L) n)
+          (set! L (- L 1))))      ; don't grow the step this time!
+
       (values L (- n (expt b L))))))
 
 #|

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1579,6 +1579,28 @@
         (and (<  1.7631802000 r  1.7631803000)
              (< -1.0303769000 i -1.0303768000))))
 
+;; exact-integer-log
+
+(dotimes (n 100)
+  (dotimes (b 100)
+    (when (and (positive? n) (> b 1))
+      (receive (l r)
+          (exact-integer-log n b)
+        (test "exact-integer-log.1" n (+ (expt b l) r))
+        (test "exact-integer-log.2" #t (> (expt b (+ 1 l)) n))))))
+
+(dotimes (n 100)
+  (dotimes (b 100)
+    (when (and (positive? n) (> b 1))
+      (let ((N (+ 500 (expt 11 n)))
+            (B (* 3 (expt 7 b))))
+        (receive (l r)
+            (exact-integer-log N B)
+          (test "exact-integer-log.3" N (+ (expt B l) r))
+          (test "exact-integer-log.4" #t (> (expt B (+ 1 l)) N)))))))
+
+
+
 ;; exp, log
 
 (test "exp log 1.0"


### PR DESCRIPTION
`exact-integer-log` is to log what `exact-integer-sqrt` is to `sqrt`.
It is actually easy to implement, since

* $\log_b(n) = \log_2(n) / \log_2(b)$.
* `(integer-length n)` $= \lfloor \log_2(n)\rfloor + 1$

We just need to put everything together, noting that $\log_b(n) = \log_2(n)/\log_2(b)$. Actually, we need a small adjustment, since 
```math
\lfloor \log_r(s)\rfloor / \lfloor \log_y(x)\rfloor
 \geq
\lfloor \log_r(s) / \log_y(x)\rfloor
```
(That is, it's not always an equality) - but that's easy to do.

Then we'll have this:

```scheme
stklos> (exact-integer-log (+ (expt 7 20000) 5) 49)
10000
5
```
