### PR TITLE
Optimize (inline) the `c_r` aliases to compositions of `car` and `cdr`

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -87,7 +87,35 @@
                          (eq?            . ,eq?)
                          (eqv?           . ,eqv?)
                          (equal?         . ,equal?)
-                         (void           . ,void)))
+                         (void           . ,void)
+                         (caar           . ,caar)
+                         (cdar           . ,cdar)
+                         (cadr           . ,cadr)
+                         (cddr           . ,cddr)
+                         (caaar          . ,caaar)
+                         (cdaar          . ,cdaar)
+                         (cadar          . ,cadar)
+                         (cddar          . ,cddar)
+                         (caadr          . ,caadr)
+                         (cdadr          . ,cdadr)
+                         (caddr          . ,caddr)
+                         (cdddr          . ,cdddr)
+                         (caaaar         . ,caaaar)
+                         (cdaaar         . ,cdaaar)
+                         (cadaar         . ,cadaar)
+                         (cddaar         . ,cddaar)
+                         (caadar         . ,caadar)
+                         (cdadar         . ,cdadar)
+                         (caddar         . ,caddar)
+                         (cdddar         . ,cdddar)
+                         (caaadr         . ,caaadr)
+                         (cdaadr         . ,cdaadr)
+                         (cadadr         . ,cadadr)
+                         (cddadr         . ,cddadr)
+                         (caaddr         . ,caaddr)
+                         (cdaddr         . ,cdaddr)
+                         (cadddr         . ,cadddr)
+                         (cddddr         . ,cddddr)))
 
 (define *inline-symbols* (map car *inline-table*))
 
@@ -1032,7 +1060,24 @@ doc>
                        (compile (caddr actuals) env epair #f)
                        (emit mnemo))
                      (compiler-error fct epair "3 arguments required (~A provided)"
-                                     len)))))
+                                     len))))
+
+        ;; cxr is used to compile the cxr alises to combinations of CAR and CDR.
+        ;; (cxr 'caadr) will emit:
+        ;; IN-CDR
+        ;; IN-CAR
+        ;; IN-CAR
+        (cxr (lambda (f)
+               (let* ((s (symbol->string f))
+                      (i (fx- (string-length s) 1)) ;; last char (=r), will be ignored
+                      (iter (fx- i 1))
+                      (c #f))
+                 (repeat iter
+                         (set! i (fx- i 1))
+                         (set! c (string-ref s i))
+                         (when (eq? #\a c) (emit 'IN-CAR))
+                         (when (eq? #\d c) (emit 'IN-CDR)))))))
+
     (case fct
       ;; Always inlined functions
       ((%%set-current-module)
@@ -1203,6 +1248,15 @@ doc>
                             (emit 'IM-VOID)
                             (compile (append (cons 'begin actuals) (list (void)))
                                      env epair #f)))
+      ;; The cxr closures are very commonly used, and can be optimized.
+      ;; Instead of calling a procedure, we inline the instructions
+      ;; IN-CAR and IN-CDR here.
+      ((caar cdar cadr cddr
+        caaar cdaar cadar cddar caadr cdadr caddr cdddr
+        caaaar cdaaar cadaar cddaar caadar cdadar caddar cdddar
+        caaadr cdaadr cadadr cddadr caaddr cdaddr cadddr cddddr)
+                        (begin (compile (car actuals) env epair #f)
+                               (cxr fct)))
       (else             (panic "unimplemented inline primitive ~S" fct)))))
 
 

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -115,7 +115,8 @@
                          (caaddr         . ,caaddr)
                          (cdaddr         . ,cdaddr)
                          (cadddr         . ,cadddr)
-                         (cddddr         . ,cddddr)))
+                         (cddddr         . ,cddddr)
+                         (list-ref       . ,list-ref)))
 
 (define *inline-symbols* (map car *inline-table*))
 
@@ -1257,6 +1258,12 @@ doc>
         caaadr cdaadr cadadr cddadr caaddr cdaddr cadddr cddddr)
                         (begin (compile (car actuals) env epair #f)
                                (cxr fct)))
+      ((list-ref)       (case (cadr actuals)
+                          ((0) (compile `(car ,(car actuals)) env epair #f))
+                          ((1) (compile `(cadr ,(car actuals)) env epair #f))
+                          ((2) (compile `(caddr ,(car actuals)) env epair #f))
+                          ((3) (compile `(cadddr ,(car actuals)) env epair #f))
+                          (else  (compile-normal-call fct actuals len env epair #f))))
       (else             (panic "unimplemented inline primitive ~S" fct)))))
 
 


### PR DESCRIPTION
## 1. Inline the `cxr` accessors

Currently STklos has all `cxr` aliases implemented as procedures:

```scheme
(disassemble-expr '(caddar x) #t)

000:  PREPARE-CALL
001:  GLOBAL-REF-PUSH      0
003:  GREF-INVOKE          1 1
006:

Constants:
0: x
1: caddar
```

This patch optimizes this, opening their code:

```scheme
(disassemble-expr '(caddar x) #t)

000:  GLOBAL-REF           0
002:  IN-CAR
003:  IN-CDR
004:  IN-CDR
005:  IN-CAR
006:

Constants:
0: x
```

Some timings:

```scheme
(let ((a #f) (L '(a b c d e f g))) (time (repeat 50_000_000 (set! a (cadddr L)))) a)
before patch: 4174.988 ms
after patch:  2786.303 ms
```

```scheme
(let ((a #f) (L '(a b c d e f g))) (time (repeat 50_000_000 (set! a (cadr L)))) a)
before patch: 3703.763 ms
after patch:  2479.088 ms
```

```scheme
(let ((a #f) (L '((((a))) b c d e f g))) (time (repeat 50_000_000 (set! a (caaaar L)))) a)
before patch: 4387.891
after patch:  2802.235
```

Running the STklos tests seems to become *very slightly* faster (around 1%, average of 20 repetitions) - probably the speedup isn't great here because the cxr functions are not used that often in libraries, and also because there are slow tests (such as the Unicode tests) that don't use them.

## 2. Optimize `list-ref` for small constant indices

Since the `cxr` accessors have been optimized, we can use them
to optimize some cases in list-ref. For example,

```scheme
(list-ref L 2) => (caddr L)
```

`list-ref` becomes indeed faster:

```scheme
(let ((a #f) (L '(a b c d e f g))) (time (repeat 50_000_000 (set! a (list-ref L 3)))) a)
before: 3828.612 ms
after:  2836.350 ms

(let ((a #f) (L '(a b c d e f g))) (time (repeat 50_000_000 (set! a (list-ref L 0)))) a)
before: 3562.374 ms
before: 2235.379 ms
```