### PR TITLE
Enhancements and optimizations for SRFI-1

### DIFF
--- a/lib/scheme/Makefile.am
+++ b/lib/scheme/Makefile.am
@@ -70,8 +70,7 @@ R7_OBJS =  base.ostk            \
 # ----------------------------------------------------------------------
 # R7RS Large Support
 # ----------------------------------------------------------------------
-LARGE_STK  = list.stk       \
-             charset.stk    \
+LARGE_STK  = charset.stk    \
              stream.stk     \
              box.stk        \
              set.stk        \
@@ -86,8 +85,7 @@ LARGE_STK  = list.stk       \
              bitwise.stk
 
 
-LARGE_OBJS = list.ostk       \
-             charset.ostk    \
+LARGE_OBJS = charset.ostk    \
              stream.ostk     \
              box.ostk        \
              set.ostk        \
@@ -101,9 +99,9 @@ LARGE_OBJS = list.ostk       \
              division.ostk   \
              bitwise.ostk
 
-LARGE_C     = ilist.c     flonum.c     sort.c     vector.c     bytevector.c
-LARGE_C_STK = ilist.stk   flonum.stk   sort.stk   vector.stk   bytevector.stk
-LARGE_SHOBJ = ilist.$(SO) flonum.$(SO) sort.$(SO) vector.$(SO) bytevector.$(SO)
+LARGE_C     = list.c      ilist.c     flonum.c     sort.c     vector.c     bytevector.c
+LARGE_C_STK = list.stk    ilist.stk   flonum.stk   sort.stk   vector.stk   bytevector.stk
+LARGE_SHOBJ = list.$(SO)  ilist.$(SO) flonum.$(SO) sort.$(SO) vector.$(SO) bytevector.$(SO)
 
 
 #----------------------------------------------------------------------
@@ -163,6 +161,9 @@ set.ostk: ../srfi/9.ostk ../srfi/69.ostk comparator.ostk
 	(cd ../srfi; $(MAKE) 60.ostk)
 
 bytevector.$(SO): bytevector-incl.c bytevector.c
+
+list.$(SO): list-incl.c
+list-incl.c: list.stk
 
 ilist.$(SO): ilist-incl.c
 ilist-incl.c: comparator.ostk

--- a/lib/scheme/list.c
+++ b/lib/scheme/list.c
@@ -1,0 +1,103 @@
+/*
+ *  list.c         -- Partial implementation of (scheme list) aka SRFI-1
+ *
+ *  Copyright © 2023 Jeronimo Pellegrini - <j_p@aleph0.info>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ *            Author: Jeronimo Pellegrini [j_p@aleph0.info]
+ *     Creation date: 18-Apr-2023 14:21 (jpellegrini)
+ *
+ */
+
+#include <stklos.h>
+
+#include "list-incl.c"
+
+/* cars_cdrs is the heart of the CAR/CDR extracting internal utilities
+   for SRFI-1. THe parameters are:
+   cars_final       = element to use after the last one in the CAR list.
+                      If null, none is added
+   do_cars, co_cdrs = which lists should be computed? cars, cdrs, or both?
+   test             = if one of the lists is null, return NIL (test=1) or
+                      error (test=0)                                        */
+static inline SCM cars_cdrs(SCM lists, SCM cars_final, int do_cars, int do_cdrs, int test) {
+  SCM cars = STk_nil;
+  SCM cdrs = STk_nil;
+
+  if (!(CONSP(lists) || NULLP(lists)))
+    STk_error("bad list ~S", lists);
+
+  while(CONSP(lists)) {
+    if (NULLP(CAR(lists))) {
+      if (test) return (!do_cars || !do_cdrs)
+                  ? STk_nil
+                  : STk_n_values(2, STk_nil, STk_nil);
+      else
+        STk_error("empty list");
+    }
+
+    if (CONSP(CAR(lists))) {
+      if (do_cars) cars = STk_cons(CAR(CAR(lists)), cars);
+      if (do_cdrs) cdrs = STk_cons(CDR(CAR(lists)), cdrs);
+      lists = CDR(lists);
+    } else break;
+  }
+  if (!do_cars) return STk_reverse(cdrs);
+  if (cars_final) cars = STk_cons(cars_final, cars);
+  if (!do_cdrs) return STk_reverse(cars);
+  return STk_n_values(2, STk_reverse(cars), STk_reverse(cdrs));
+}
+
+DEFINE_PRIMITIVE("%cars+", cars, subr2, (SCM lists, SCM fin)) {
+  return cars_cdrs(lists, fin, 1, 0, 1);
+}
+
+DEFINE_PRIMITIVE("%cdrs", cdrs, subr1, (SCM lists)) {
+  return cars_cdrs(lists, NULL, 0, 1, 1);
+}
+
+DEFINE_PRIMITIVE("%cars+cdrs", cars_cdrs, subr1, (SCM lists)) {
+  return cars_cdrs(lists, NULL, 1, 1, 1);
+}
+
+DEFINE_PRIMITIVE("%cars+cdrs+", cars_cdrs_fin, subr2, (SCM lists, SCM fin)) {
+  return cars_cdrs(lists, fin, 1, 1, 1);
+}
+
+DEFINE_PRIMITIVE("%cars+cdrs/notest", cars_cdrs_notest, subr1, (SCM lists)) {
+  return cars_cdrs(lists, NULL, 1, 1, 0);
+}
+
+MODULE_ENTRY_START("scheme/list")
+{
+  SCM module =  STk_create_module(STk_intern("scheme/list"));
+
+  ADD_PRIMITIVE_IN_MODULE(cars, module);
+  ADD_PRIMITIVE_IN_MODULE(cdrs, module);
+  ADD_PRIMITIVE_IN_MODULE(cars_cdrs, module);
+  ADD_PRIMITIVE_IN_MODULE(cars_cdrs_fin, module);
+  ADD_PRIMITIVE_IN_MODULE(cars_cdrs_notest, module);
+
+  STk_export_all_symbols(module);
+
+  /* Execute Scheme code */
+  STk_execute_C_bytecode(__module_consts, __module_code);
+}
+MODULE_ENTRY_END
+
+DEFINE_MODULE_INFO

--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -960,18 +960,40 @@ written in C, in STklos core!
         (lp (cdr lis) (kons (car lis) ans))))))
 
 
+;; FOLD-RIGHT: the single list case has been changed:
+;; to avoid exhausting the stack AND to obtain better
+;; performance, instead of a recursive procedure we
+;; call list->vector and process the vector from the
+;; end towards the beginning.
+;; This avoids wrong results due to stack overflow
+;; in the following case:
+;; (define L (iota 1_000_000))
+;; (fold - 0 L)
+;; (With the default STklos stack size)
+;;
+;; This is a big less efficient for the N-ary cse, since
+;; we'd have to compute the minimum size of all lists
+;; (or vectors), potentially traversing the larger list
+;; (that could perhaps be a million times larger than the
+;; others). It would also probably require some more uses
+;; of apply.
 (define (fold-right kons knil lis1 . lists)
   (check-arg procedure? kons fold-right)
   (if (pair? lists)
       (let recur ((lists (cons lis1 lists)))        ; N-ary case
-    (let ((cdrs (%cdrs lists)))
-      (if (null? cdrs) knil
-          (apply kons (%cars+ lists (recur cdrs))))))
+        (let ((cdrs (%cdrs lists)))
+          (if (null? cdrs) knil
+              (apply kons (%cars+ lists (recur cdrs))))))
 
-      (let recur ((lis lis1))               ; Fast path
-    (if (null-list? lis) knil
-        (let ((head (car lis)))
-          (kons head (recur (cdr lis))))))))
+      (if (null-list? lis1) knil                    ; Fast path
+          (let* ((V (list->vector lis1))
+                 (n (- (vector-length V) 1))
+                 (x (kons (vector-ref V n) knil))
+                 (i (- n 1)))
+            (repeat n
+                    (set! x (kons (vector-ref V i) x))
+                    (set! i (- i 1)))
+            x))))
 
 
 (define (pair-fold-right f zero lis1 . lists)

--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -831,6 +831,11 @@
 
 ;;; Return (map cdr lists).
 ;;; However, if any element of LISTS is empty, just abort and return '().
+
+#|
+%cars+, %cdrs, %cars+cdrs, %cars+cdrs+, %cars+cdrs/no-test are primitives
+written in C, in STklos core!
+
 (define (%cdrs lists)
   (call/ec
     (lambda (abort)
@@ -884,6 +889,7 @@
         (receive (cars cdrs) (recur other-lists)
           (values (cons a cars) (cons d cdrs)))))
     (values '() '()))))
+|#
 
 ;;; count
 ;;;;;;;;;
@@ -1483,7 +1489,7 @@ FILTER an FILTER! are primitives in STklos
                          (cons (car lis) (Loop (cdr lis))))
                   ;; found (hash table returned mark), ignore it
                   (Loop (cdr lis)))
-              lis))))) 
+              lis)))))
 
 ;; The reference implementation had duplicated code for these two procedures.
 ;; We can just make on alias to the other.

--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -430,16 +430,19 @@
 ;;; Note that this definition rules out circular lists -- and this
 ;;; function is required to detect this case and return false.
 
-(define (proper-list? x)
-  (let lp ((x x) (lag x))
-    (if (pair? x)
-    (let ((x (cdr x)))
-      (if (pair? x)
-          (let ((x   (cdr x))
-            (lag (cdr lag)))
-        (and (not (eq? x lag)) (lp x lag)))
-          (null? x)))
-    (null? x))))
+;; The primitive list? does exactly the same.
+(define proper-list? (in-module SCHEME list?))
+
+;; (define (proper-list? x)
+;;   (let lp ((x x) (lag x))
+;;     (if (pair? x)
+;;     (let ((x (cdr x)))
+;;       (if (pair? x)
+;;           (let ((x   (cdr x))
+;;             (lag (cdr lag)))
+;;         (and (not (eq? x lag)) (lp x lag)))
+;;           (null? x)))
+;;     (null? x))))
 
 
 ;;; A dotted list is a finite list (possibly of length 0) terminated
@@ -1722,7 +1725,7 @@ FILTER an FILTER! are primitives in STklos
 ;;; file. However, in order to keep a list of exported symbol which is coherent
 ;;; with the text of the SRFI
 (define-macro (redefine symb)
-  `(define ,symb (in-module |STklos| ,symb)))
+  `(define ,symb (in-module SCHEME ,symb)))
 
 (redefine every)
 (redefine any)


### PR DESCRIPTION
Hi @egallesio !

Last one today, I promise :)

There are three commits in this PR:

## 1. ~Inline~ Make `%car+cdrs` and friends primitives

The reference implementation of SRFI-1 recommends that the following procedures be inlined:

```
%cars+, %cdrs, %cars+cdrs, %cars+cdrs+, %cars+cdrs/no-test
```

~We just did that.~ -- (actually, we made them primitives. We *could* inline them, but then we'd need to get them into the core, and make the compiler inline even more primitives...)

There is one single C function `cars_cdrs` that does all the work, and five new internal Scheme primitives.

All procedures in the `fold` family are faster now.

## 2. Other general enhancements

* In `redefine`, get the standard procedures from module `SCHEME`, not `STklos`.
* Don't define `proper-list?`, just make it an alias to `list?`, since they do the same thing, and `list?` is a fast primitive already in STklos core.

## 3.  Optimize `fold-right`

The single list case has been changed: to avoid exhausting the stack *AND* to obtain better performance, instead of a recursive procedure we call list->vector and process the vector from the end towards the beginning.

This avoids wrong results due to stack overflow in the following case:

```scheme
(define L (iota 1_000_000))
(fold - 0 L)
```
With the default STklos stack size it would overwrite local variables and signal an error. With this patch, it works (because the stack does not grow at all, and all work is done inside a single vector).

It also makes `fold-right` faster:

```scheme
(let ((L (iota 1_000))
      (a 0))
  (time
   (repeat  30000
     (set! a (fold-right - 0 L))))
  a)
previous version: 5527.42 ms
new version:      3996.49 ms
```

We only change the case of one single list -- this optimization would be less efficient for the N-ary cse, since we'd have to compute the minimum size of all lists (or vectors), potentially traversing the larger list (that could perhaps be a million times larger than the others). It would also probably require some more uses of apply.