### PR TITLE
Make `expt` more precise

### DIFF
--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1096,10 +1096,12 @@
 (test "exact expt" 1 (expt 1 720000))
 (test "exact expt" 1 (expt -1 720000))
 (test "exact expt" -1 (expt -1 720001))
-(test "0^0" 1 (expt 0 0))        ; exact exponent, exact 1
-(test "0^0" 1 (expt 0.0 0))      ; exact exponent, exact 1
-(test "0^0" 1.0 (expt 0 0.0))    ; inexact exponent, inexact 1.0
-(test "0^0" 1.0 (expt 0.0 0.0))  ; inexact exponent, inexact 1.0
+(test "exact real" 8 (exact (expt 2 3.0))) ;; 3.0 is precisely representable in
+                                           ;; the IEEE standards
+(test "0^0" 1 (expt 0 0))          ;; exact exponent, exact 1
+(test "0^0" 1 (expt 0.0 0))        ;; exact exponent, exact 1
+(test "0^0" 1.0 (expt 0 0.0))      ;; inexact exponent, inexact 1.0
+(test "0^0" 1.0 (expt 0.0 0.0))    ;; inexact exponent, inexact 1.0
 (test "complex expt"
       #t
       (let* ((z (expt 2 -3+4i))


### PR DESCRIPTION
If the exponent is a floating point number that happens to represent an integer precisely (that is, with fractinal part equal to exactly zero), turn it into exact, perform the operation, then turn it back into inexact.

Before this patch:

```scheme
stklos> (real-precision 50)
stklos> (expt 2 3.0)
7.9999999999999982236431605997495353221893310546875
stklos> (exact (expt 2 3.0))
4503599627370495/562949953421312
```

After this patch:

```scheme
stklos> (real-precision 50)
stklos> (expt 2 3.0)
8.0
stklos> (exact (expt 2 3.0))
8
```