### PR TITLE
Fix crash in `(scheme bytevector)`, and adjust the procedures to the spec.

### DIFF
--- a/lib/scheme/bytevector.c
+++ b/lib/scheme/bytevector.c
@@ -1065,6 +1065,7 @@ DEFINE_PRIMITIVE("bytevector-ieee-single-native-ref", bytevector_ieee_single_nat
   check_bytevector(b);
   check_integer(i);
   unsigned long idx = INT_VAL(i);
+  if (idx%4) STk_error("index for IEEE single precision bytevector not multiple of 4: ~S", i);
 
   switch (sizeof(float)) {
   case 4: {
@@ -1117,6 +1118,7 @@ DEFINE_PRIMITIVE("bytevector-ieee-double-native-ref", bytevector_ieee_double_nat
   check_bytevector(b);
   check_integer(i);
   unsigned long idx = INT_VAL(i);
+  if (idx%8) STk_error("index for IEEE double precision bytevector not multiple of 8: ~S", i);
 
   switch (sizeof(double)) {
   case 8: {
@@ -1187,6 +1189,7 @@ DEFINE_PRIMITIVE("bytevector-ieee-single-native-set!", bytevector_ieee_single_na
     default:           STk_error("bad real number ~S", val);
   }
   unsigned long idx = INT_VAL(i);
+  if (idx%4) STk_error("index for IEEE single precision bytevector not multiple of 4: ~S", i);
 
   switch (sizeof(float)) {
   case 4: {
@@ -1247,6 +1250,7 @@ DEFINE_PRIMITIVE("bytevector-ieee-double-native-set!", bytevector_ieee_double_na
   check_integer(i);
 
   unsigned long   idx  = INT_VAL(i);
+  if (idx%8) STk_error("index for IEEE double precision bytevector not multiple of 8: ~S", i);
   double valf;
   switch (TYPEOF(val)) {
     case tc_integer:

--- a/lib/scheme/bytevector.c
+++ b/lib/scheme/bytevector.c
@@ -48,6 +48,8 @@ struct bignum_obj {
 
 #define ULONG_FITS_INTEGER(_l)  ((_l) <= ((uint64_t) INT_MAX_VAL))
 
+#define TYPEOF(n)                (INTP(n)? tc_integer: STYPE(n))
+
 /* Reals... */
 static inline SCM double2real(double x)
 {
@@ -1142,8 +1144,16 @@ DEFINE_PRIMITIVE("bytevector-ieee-single-set!", bytevector_ieee_single_set, subr
       end = end_big;
   else STk_error("bad endianness symbol ~S", endianness);
 
+  float valf;
+  switch (TYPEOF(val)) {
+    case tc_integer:
+    case tc_bignum:
+    case tc_rational:
+    case tc_real:     valf = STk_number2double(val);
+                      break;
+    default:          STk_error("bad real number ~S", val);
+  }
   unsigned long idx = INT_VAL(i);
-  float valf = REAL_VAL(val);
 
   switch (sizeof(float)) {
   case 4: {
@@ -1167,8 +1177,16 @@ DEFINE_PRIMITIVE("bytevector-ieee-single-native-set!", bytevector_ieee_single_na
 {
   check_integer(i);
 
+  float valf;
+  switch (TYPEOF(val)) {
+    case tc_integer:
+    case tc_bignum:
+    case tc_rational:
+    case tc_real:      valf = STk_number2double(val);
+                       break;
+    default:           STk_error("bad real number ~S", val);
+  }
   unsigned long idx = INT_VAL(i);
-  float valf = REAL_VAL(val);
 
   switch (sizeof(float)) {
   case 4: {
@@ -1192,6 +1210,16 @@ DEFINE_PRIMITIVE("bytevector-ieee-double-set!", bytevector_ieee_double_set, subr
 {
   check_integer(i);
 
+  double valf;
+  switch (TYPEOF(val)) {
+    case tc_integer:
+    case tc_bignum:
+    case tc_rational:
+    case tc_real:      valf = STk_number2double(val);
+                       break;
+    default:           STk_error("bad real number ~S", val);
+  }
+
   endianness_t end = 0;
   if (endianness == symb_little)
       end = end_little;
@@ -1200,7 +1228,6 @@ DEFINE_PRIMITIVE("bytevector-ieee-double-set!", bytevector_ieee_double_set, subr
   else STk_error("bad endianness symbol ~S", endianness);
 
   unsigned long   idx  = INT_VAL(i);
-  double valf = REAL_VAL(val);
 
   switch (sizeof(double)) {
   case 8: {
@@ -1220,7 +1247,15 @@ DEFINE_PRIMITIVE("bytevector-ieee-double-native-set!", bytevector_ieee_double_na
   check_integer(i);
 
   unsigned long   idx  = INT_VAL(i);
-  double valf = REAL_VAL(val);
+  double valf;
+  switch (TYPEOF(val)) {
+    case tc_integer:
+    case tc_bignum:
+    case tc_rational:
+    case tc_real:      valf = STk_number2double(val);
+                       break;
+    default:           STk_error("bad real number ~S", val);
+  }
 
   switch (sizeof(double)) {
   case 8: {


### PR DESCRIPTION
I've found two bugs in the `(scheme bytevector)` library.

## How the bug was found -- `test/error` was wrong!

I have noticed that the `test/error` macro in `tests/test.stk` doesn't actually do anything: it ignores errors, but doesn't complain when **no** error is produced!   So I fixed it (will include in a later PR), and... Found several problems.

This is one of them -- now the test suite complains that we didn't error when the wrong index (non-aligned) was used. 

Later I'll send a PR with a new test macro, and several fixes in SRFIs, in the core, and in tests.

## 1. Check arguments in `bytevector-ieee-*-set!`

Otherwise STklos crashes!

Also, convert all numbers to imprecise (except complexes) before storing them in the bytevector (only complexes can't be turned into reals -- for bignums, if they don't fit a double, we store an infinity; for rationals, if they're too small, they become zero.)

## 2. Check indices in some of the IEEE bytevector procedures

The spec (the only part of $R^7RS$ Large that was taken from $R^6RS$) says we need to access with proper alignment (multiples of 4 for single precision, and multiples of 8 for double precision). Fixed.


