### PR TITLE
Make `expt` work again for inexact exponent + negative base

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3353,7 +3353,7 @@ static SCM my_expt(SCM x, SCM y)
         if (zerop(y)) return double2real(1.0);
         if (zerop(x)) return (x==MAKE_INT(0)) ? x : double2real(0.0);
         if (REALP(y)) {
-          if (REALP(x)) {
+          if (REALP(x) && !negativep(x)) {
             /* real ^ real, see if we can use pow: */
             double r = pow(REAL_VAL(x),REAL_VAL(y));
             if (!isinf(r) || /* no overflow, return r */

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1098,6 +1098,20 @@
 (test "exact expt" -1 (expt -1 720001))
 (test "exact real" 8 (exact (expt 2 3.0))) ;; 3.0 is precisely representable in
                                            ;; the IEEE standards
+(test "expt -2 0.5" #t
+      (complex? (expt -2.0 0.5)))
+(test "expt -2 1/2" #t
+      (complex? (expt -2.0 1/2)))
+
+(test "expt -2 0.5, expt -2 1/2 (imag part)" #t
+      (< (abs (- (imag-part (expt -2.0 0.5))
+                 (imag-part (expt -2.0 1/2))))
+         0.000001))
+(test "expt -2 0.5, expt -2 1/2 (real part)" #t
+      (< (abs (- (real-part (expt -2.0 0.5))
+                 (real-part (expt -2.0 1/2))))
+         0.000001))
+
 (test "0^0" 1 (expt 0 0))          ;; exact exponent, exact 1
 (test "0^0" 1 (expt 0.0 0))        ;; exact exponent, exact 1
 (test "0^0" 1.0 (expt 0 0.0))      ;; inexact exponent, inexact 1.0


### PR DESCRIPTION
```
stklos>  (expt -2.0 0.5)
-nan.0
stklos>  (expt -2.0 1/2)
8.65956056235493e-17+1.41421356237309i
```

Oops. This was my recent PR.

We should not call `pow` for negative base and inexact exponent.
