### PR TITLE
Redefining a symbol should clear its immutbale bit

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -375,10 +375,14 @@ void STk_hash_set_variable(struct hash_table_obj *h, SCM v, SCM value, int defin
 
   if (z) {
     /* Variable already exists. Change its value*/
-    if (BOXED_INFO(z) & CONS_CONST && !define) {
-      STk_error("cannot set or redefine the symbol ~S in ~S",
-                v, STk_current_module());
-    }
+    if (BOXED_INFO(z) & CONS_CONST)
+      if (!define) {
+        STk_error("cannot set or redefine the symbol ~S in ~S",
+                  v, STk_current_module());
+      }
+    /* It's a redefinition, not a new binding, so we not only allow
+       it, but also clear the CONST bit: */
+    BOXED_INFO(z) &= (~CONS_CONST);
     *BOX_VALUES(CDR(z)) = value;
   } else {
     SCM z;
@@ -615,7 +619,7 @@ DEFINE_PRIMITIVE("hash-table-set!", hash_set, subr3, (SCM ht, SCM key, SCM val))
   if (!HASHP(ht)) error_bad_hash_table(ht);
 
   if (HASH_CONSTP(ht)) error_hash_immutable(ht);
-  
+
   switch (HASH_TYPE(ht)) {
     case hash_eqp:
       index = RANDOM_INDEX(ht, key);

--- a/tests/test-unmutable-bindings.stk
+++ b/tests/test-unmutable-bindings.stk
@@ -107,5 +107,15 @@
   (test "define-constant.1" 1 cst)
   (test "define-constant.2" #f (symbol-mutable? 'cst)))
 
+(define-constant %%%___unmutable 10)
+
+(test "unmutable value" 10 %%%___unmutable)
+(test/error "set! unmutable" (set! %%%___unmutable 20))
+
+(define %%%___unmutable 20)
+(test "unmutable value" 20 %%%___unmutable)
+(set! %%%___unmutable -1)
+(test "unmutable / new value" -1 %%%___unmutable)
+
 
 (test-section-end)


### PR DESCRIPTION
`set!` is not allowed on a mutable binding; but a 'define' would actually redefine the binding, so we should clear the immutability bit.
In order to forbid `define`s, one should make the *module* immutable (not the symbol) -- which is already possible using `module-immutable!`. Right?