### PR TITLE
Fix typo in `gcd2` which was allowing arbitrary types (not just integer numbers) as arguments. (One-liner)

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2351,7 +2351,7 @@ static SCM gcd2(SCM n1, SCM n2)
   int exactp = 1;
 
   if (STk_integerp(n1) == STk_false) error_not_an_integer(n1);
-  if (STk_integerp(n1) == STk_false) error_not_an_integer(n2);
+  if (STk_integerp(n2) == STk_false) error_not_an_integer(n2);
 
   if (REALP(n1)) {
     n1 = inexact2exact(n1);


### PR DESCRIPTION
Hi @egallesio !

```
stklos> (gcd 10 'a)
0
stklos> (gcd 'a 10)
**** Error:
gcd: exact or inexact integer required, got a
```

Oh, that is because:

```c
  if (STk_integerp(n1) == STk_false) error_not_an_integer(n1);
  if (STk_integerp(n1) == STk_false) error_not_an_integer(n2);
                   ^^
                   ^^
```

Oops.. Fixed!