### PR TITLE
Use `if` instead of `do` for multicommand macros (possible fix to #528 -- STklos seems to only compile with `USE_COMPUTED_GOTO`)

### DIFF
--- a/doc/hacking/hacking.adoc
+++ b/doc/hacking/hacking.adoc
@@ -148,6 +148,60 @@ is.
 In order to include Scheme code for execution during STklos startup,
 edit `lib/boot.stk`.
 
+== C style
+
+=== Multicommand macros
+
+It is common practice to use
+
+[source,c]
+----
+#define SOME_MACRO do{ \
+      ... \
+      ... \
+}while(0)
+----
+
+So that `SOME_MACRO` can be used inside `if` and other C commands.
+
+However, this can lead to problems. The following situation actually
+happened in STklos development.
+
+[source,c]
+----
+#define NEXT continue
+ ...
+
+for(;;) {
+    ...
+
+#define LOCK_AND_RESTART                 do{\
+    if (!have_global_lock) {                   \
+      ...                                      \
+      NEXT;                                    \
+    }                                          \
+}while(0)
+...
+
+} /* for(;;) */
+----
+
+The `NEXT` expands into `continue`, which will break out of the `do`,
+and not continue the `for` loop as intended.
+
+For this reason, we use `if(1){ ... }else{}` for multicommand macros,
+as in the following example:
+
+[source,c]
+----
+#define LOCK_AND_RESTART                 if(1){\
+    if (!have_global_lock) {                   \
+      ...                                      \
+      NEXT;                                    \
+    }                                          \
+}else{}
+----
+
 == Adding simple modules and SRFIs
 
 === Adding modules

--- a/src/base64.c
+++ b/src/base64.c
@@ -39,13 +39,13 @@ static char rev_table[128] = {
      41, 42, 43, 44,  45, 46, 47, 48, 49, 50, 51,  0,  0,  0,  0,  0
 };
 
-#define OutChar(c, f) do{           \
+#define OutChar(c, f) if(1){        \
     STk_putc((c), (f));             \
     if (++count>=72) {              \
       STk_putc('\n', (f));          \
       count=0;                      \
     }                               \
-}while(0)
+}else{}
 
 static void error_bad_input_port(SCM obj)
 {

--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -55,25 +55,25 @@ long exp_2_fxwidth() {
 }
 
 #if CONTROL_FX_PARAMETERS == 1
-#define ensure_fx(x) do{      \
+#define ensure_fx(x) if(1){   \
   if (!INTP(x))               \
     error_bad_fixnum1(x);     \
-}while(0)
+}else{}
 
-#define ensure_fx2(x, y) do{    \
+#define ensure_fx2(x, y) if(1){ \
   if (!(INTP(x) && INTP(y)))    \
     error_bad_fixnum2(x, y);    \
-}while(0)
+}else{}
 
-#define ensure_fx3(x, y, z) do{         \
+#define ensure_fx3(x, y, z) if(1){      \
   if (!(INTP(x) && INTP(y) && INTP(z))) \
     error_bad_fixnum3(x, y, z);         \
-}while(0)
+}else{}
 
-#define ensure_fx4(x, y, z, w) do{                 \
+#define ensure_fx4(x, y, z, w) if(1){              \
   if (!(INTP(x) && INTP(y) && INTP(z) && INTP(w))) \
     error_bad_fixnum4(x, y, z, w);                 \
-}while(0)
+}else{}
 
 static void error_bad_fixnum1(SCM o1)
 {

--- a/src/list.c
+++ b/src/list.c
@@ -232,7 +232,7 @@ DEFINE_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name))
    * NOTE: using strings (instead of keywords) is less efficient because
    * the char * is at the end of the object. Using symbols is also fast
    * (even a bit faster, don't know why), but it is harder  to detect that
-   * that we can inline when we have (%cxr lst 'daa), because of the quote. 
+   * that we can inline when we have (%cxr lst 'daa), because of the quote.
    */
   if (KEYWORDP(name)) {
     SCM lst   = l;
@@ -585,7 +585,7 @@ doc>
 
 
 #define LMEMBER(compare)                                        \
-do{                                                             \
+if(1){                                                          \
   register SCM ptr;                                             \
                                                                 \
   if (!CONSP(list) && !NULLP(list)) error_bad_list(list);       \
@@ -599,7 +599,7 @@ do{                                                             \
     if ((ptr=CDR(ptr)) == list) error_circular_list(ptr);       \
   }                                                             \
   return STk_false;                                             \
-}while(0)
+}else{}
 
 
 DEFINE_PRIMITIVE("memq", memq, subr2, (SCM obj, SCM list))
@@ -664,7 +664,7 @@ doc>
  */
 
 #define LASSOC(compare)                                         \
-do{                                                             \
+if(1){                                                          \
   register SCM l,tmp;                                           \
                                                                 \
   for(l=alist; CONSP(l); ) {                                    \
@@ -675,7 +675,7 @@ do{                                                             \
   if (NULLP(l)) return(STk_false);                              \
   STk_error("improper list ~W", alist);                         \
   return STk_void; /* never reached */                          \
-}while(0)
+}else{}
 
 DEFINE_PRIMITIVE("assq", assq, subr2, (SCM obj, SCM alist))
 {

--- a/src/md5.c
+++ b/src/md5.c
@@ -45,20 +45,20 @@ struct md5_context
 
 
 #define GET_UINT32(n,b,i)                                         \
-do{                                                               \
+if(1){                                                            \
     (n) = (uint32) ((uint8 *) (b))[(i)]                           \
       | (((uint32) ((uint8 *) (b))[(i)+1]) <<  8)                 \
       | (((uint32) ((uint8 *) (b))[(i)+2]) << 16)                 \
       | (((uint32) ((uint8 *) (b))[(i)+3]) << 24);                \
-}while(0)
+}else{}
 
 #define PUT_UINT32(n,b,i)                                         \
-do{                                                               \
+if(1){                                                            \
     (((uint8 *) (b))[(i)]  ) = (uint8) (((n)      ) & 0xFF);      \
     (((uint8 *) (b))[(i)+1]) = (uint8) (((n) >>  8) & 0xFF);      \
     (((uint8 *) (b))[(i)+2]) = (uint8) (((n) >> 16) & 0xFF);      \
     (((uint8 *) (b))[(i)+3]) = (uint8) (((n) >> 24) & 0xFF);      \
-}while(0)
+}else{}
 
 static void md5_starts( struct md5_context *ctx )
 {

--- a/src/stklos.c
+++ b/src/stklos.c
@@ -27,27 +27,27 @@
 #include <langinfo.h>
 #include "gnu-getopt.h"
 
-#define ADD_OPTION(o, k)                                     do{\
+#define ADD_OPTION(o, k)                                  if(1){\
   if (*o) options = STk_key_set(options,                        \
                                 STk_makekey(k),                 \
                                 STk_Cstring2string(o));         \
-}while(0)
+}else{}
 
-#define ADD_BOOL_OPTION(o, k)                        do{\
+#define ADD_BOOL_OPTION(o, k)                     if(1){\
   options = STk_key_set(options,                        \
                         STk_makekey(k),                 \
                         MAKE_BOOLEAN(o));               \
-}while(0)
+}else{}
 
-#define ADD_INT_OPTION(o, k)                         do{\
+#define ADD_INT_OPTION(o, k)                      if(1){\
   options = STk_key_set(options,                        \
                         STk_makekey(k),                 \
                         MAKE_INT(o));                   \
-}while(0)
+}else{}
 
-#define ADD_SCM_OPTION(o, k)                         do{\
+#define ADD_SCM_OPTION(o, k)                      if(1){\
   options = STk_key_set(options, STk_makekey(k),o);     \
-}while(0)
+}else{}
 
 /*=============================================================================
  *

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -229,23 +229,23 @@ typedef struct {
 #define STYPE(x)                (BOXED_OBJP(x)? BOXED_TYPE(x): tc_not_boxed)
 
 
-#define NEWCELL(_var, _type)    do{                                             \
+#define NEWCELL(_var, _type)    if(1){                                          \
         _var = (SCM) STk_must_malloc(sizeof(struct CPP_CONCAT(_type,_obj)));    \
         BOXED_TYPE(_var) = CPP_CONCAT(tc_, _type);                              \
         BOXED_INFO(_var) = 0;                                                   \
-        }while(0)
+        }else{}
 
-#define NEWCELL_WITH_LEN(_var, _type, _len)     do{     \
+#define NEWCELL_WITH_LEN(_var, _type, _len)  if(1){     \
         _var = (SCM) STk_must_malloc(_len);             \
         BOXED_TYPE(_var) = CPP_CONCAT(tc_, _type);      \
         BOXED_INFO(_var) = 0;                           \
-        }while(0)
+        }else{}
 
-#define NEWCELL_ATOMIC(_var, _type, _len)       do{     \
+#define NEWCELL_ATOMIC(_var, _type, _len)    if(1){     \
         _var = (SCM) STk_must_malloc_atomic(_len);      \
         BOXED_TYPE(_var) = CPP_CONCAT(tc_, _type);      \
         BOXED_INFO(_var) = 0;                           \
-        }while(0)
+        }else{}
 
   /*
    * PRIMITIVES

--- a/src/system.c
+++ b/src/system.c
@@ -1017,12 +1017,12 @@ DEFINE_PRIMITIVE("glob", glob, vsubr, (int argc, SCM *argv))
  * reasons. ,(index "remove-file")
 doc>
 */
-#define do_remove(filename)                          do{\
+#define do_remove(filename)                      if(1){ \
   if (!STRINGP(filename)) error_bad_string(filename);   \
   if (remove(STRING_CHARS(filename)) != 0)              \
     STk_error_posix(errno, "", filename, NULL);         \
   return STk_void;                                      \
-}while(0)
+}else{}
 DEFINE_PRIMITIVE("delete-file", delete_file, subr1, (SCM filename))
 {
   do_remove(filename);

--- a/src/vm.c
+++ b/src/vm.c
@@ -46,7 +46,6 @@ static int cpt_inst[NB_VM_INSTR];
 static int debug_level = 0;     /* 0 is quiet, 1, 2, ... are more verbose */
 #endif
 
-
 #if defined(__GNUC__) && !defined(DEBUG_VM)
    /* Use computed gotos to have better performance */
 #  define USE_COMPUTED_GOTO
@@ -58,8 +57,8 @@ static int debug_level = 0;     /* 0 is quiet, 1, 2, ... are more verbose */
 #  define NEXT          continue;/* Be sure to not use continue elsewhere */
 #endif
 
-#define NEXT0           do{vm->val = STk_void; vm->valc = 0; NEXT;}while(0)
-#define NEXT1           do{vm->valc = 1; NEXT;}while(0)
+#define NEXT0           if(1){vm->val = STk_void; vm->valc = 0; NEXT;}else{}
+#define NEXT1           if(1){vm->valc = 1; NEXT;}else{}
 
 
 #ifdef sparc
@@ -169,28 +168,28 @@ vm_thread_t *STk_allocate_vm(int stack_size)
 #define VM_STATE_FP(reg)        ((reg)[3])
 #define VM_STATE_JUMP_BUF(reg)  ((reg)[4])
 
-#define SAVE_VM_STATE()               do{               \
+#define SAVE_VM_STATE()               if(1){            \
   vm->sp                   -= VM_STATE_SIZE;            \
   VM_STATE_PC(vm->sp)       = (SCM) vm->pc;             \
   VM_STATE_CST(vm->sp)      = (SCM) vm->constants;      \
   VM_STATE_ENV(vm->sp)      = (SCM) vm->env;            \
   VM_STATE_FP(vm->sp)       = (SCM) vm->fp;             \
   VM_STATE_JUMP_BUF(vm->sp) = (SCM) vm->top_jmp_buf;    \
-}while(0)
+}else{}
 
-#define FULL_RESTORE_VM_STATE(p)      do{                       \
+#define FULL_RESTORE_VM_STATE(p)      if(1){                    \
   vm->pc                     = (STk_instr *) VM_STATE_PC(p);    \
   RESTORE_VM_STATE(p);                                          \
-}while(0)
+}else{}
 
-#define RESTORE_VM_STATE(p)           do{                       \
+#define RESTORE_VM_STATE(p)           if(1){                    \
   /* pc is not restored here. See FULL_RESTORE_VM_STATE */      \
   vm->constants          = (SCM *)  VM_STATE_CST(p);            \
   vm->env                = (SCM)    VM_STATE_ENV(p);            \
   vm->fp                 = (SCM *)  VM_STATE_FP(p);             \
   vm->top_jmp_buf        = (jbuf *) VM_STATE_JUMP_BUF(p);       \
   vm->sp                += VM_STATE_SIZE;                       \
-}while(0)
+}else{}
 
 
 /*
@@ -204,20 +203,20 @@ vm_thread_t *STk_allocate_vm(int stack_size)
 #define HANDLER_PREV(reg)       ((reg)[2])
 
 
-#define SAVE_HANDLER_STATE(proc, addr)  do{             \
+#define SAVE_HANDLER_STATE(proc, addr)  if(1){          \
   vm->sp                   -= EXCEPTION_HANDLER_SIZE;   \
   HANDLER_PROC(vm->sp)  =  (SCM) (proc);                \
   HANDLER_END(vm->sp)   =  (SCM) (addr);                \
   HANDLER_PREV(vm->sp)  =  (SCM) vm->handlers;          \
   vm->handlers          = vm->sp;                       \
-}while(0)
+}else{}
 
-#define UNSAVE_HANDLER_STATE()  do{                     \
+#define UNSAVE_HANDLER_STATE()  if(1){                  \
   SCM *old = vm->handlers;                              \
                                                         \
   vm->handlers = (SCM *) HANDLER_PREV(vm->handlers);    \
   vm->sp       = old + EXCEPTION_HANDLER_SIZE;          \
-}while(0)
+}else{}
 
 
 /*===========================================================================*\
@@ -226,7 +225,7 @@ vm_thread_t *STk_allocate_vm(int stack_size)
  *
 \*===========================================================================*/
 
-#define PREP_CALL() do{                                 \
+#define PREP_CALL() if(1){                              \
   SCM fp_save = (SCM)(vm->fp);                          \
                                                         \
   /* Push an activation record on the stack */          \
@@ -236,16 +235,16 @@ vm_thread_t *STk_allocate_vm(int stack_size)
   ACT_SAVE_PROC(vm->fp) = STk_false;                    \
   ACT_SAVE_INFO(vm->fp) = STk_false;                    \
   /* Other fields will be initialized later */          \
-}while(0)
+}else{}
 
 
-#define RET_CALL() do{                                  \
+#define RET_CALL() if(1){                               \
   vm->sp        = vm->fp + ACT_RECORD_SIZE;             \
   vm->env       = ACT_SAVE_ENV(vm->fp);                 \
   vm->pc        = ACT_SAVE_PC(vm->fp);                  \
   vm->constants = ACT_SAVE_CST(vm->fp);                 \
   vm->fp        = ACT_SAVE_FP(vm->fp);                  \
-}while(0)
+}else{}
 
 
 /*
@@ -266,18 +265,18 @@ MUT_DECL(global_lock);          /* the lock to access checked_globals */
 
 
 
-#define PUSH_ENV(nargs, func, next_env)  do{    \
+#define PUSH_ENV(nargs, func, next_env)  if(1){ \
     BOXED_TYPE(vm->sp)   = tc_frame;            \
     FRAME_LENGTH(vm->sp) = nargs;               \
     FRAME_NEXT(vm->sp)   = next_env;            \
     FRAME_OWNER(vm->sp)  = func;                \
-}while(0)
+}else{}
 
-#define CALL_CLOSURE(func) do{                  \
+#define CALL_CLOSURE(func) if(1){               \
     vm->pc        = CLOSURE_BCODE(func);        \
     vm->constants = CLOSURE_CONST(func);        \
     vm->env       = (SCM) vm->sp;               \
-}while(0)
+}else{}
 
 
 
@@ -290,17 +289,17 @@ typedef SCM (*prim5)(SCM,SCM,SCM,SCM,SCM);
 typedef SCM (*primv)(int,SCM*);
 
 
-#define CALL_PRIM(v, args) do{                  \
+#define CALL_PRIM(v, args) if(1){               \
     ACT_SAVE_PROC(vm->fp) = v;                  \
     v = PRIMITIVE_FUNC(v)args;                  \
-}while(0)
+}else{}
 
 
 
-#define CALL_PRIMITIVE(type, v, args) do{       \
+#define CALL_PRIMITIVE(type, v, args) if(1){    \
     ACT_SAVE_PROC(vm->fp) = v;                  \
     v = (* (type) PRIMITIVE_FUNC(v))args;       \
-}while(0)
+}else{}
 
 #define CALL_PRIM0(v, args) CALL_PRIMITIVE(prim0, v, args)
 #define CALL_PRIM1(v, args) CALL_PRIMITIVE(prim1, v, args)
@@ -313,16 +312,16 @@ typedef SCM (*primv)(int,SCM*);
 
 
 
-#define REG_CALL_PRIM(name) do{                           \
+#define REG_CALL_PRIM(name) if(1){                        \
   extern struct primitive_obj CPP_CONCAT(STk_o_, name);   \
   ACT_SAVE_PROC(vm->fp) = &CPP_CONCAT(STk_o_, name);      \
-}while(0)
+}else{}
 
 
-#define RETURN_FROM_PRIMITIVE() do{             \
+#define RETURN_FROM_PRIMITIVE() if(1){          \
     vm->sp = vm->fp + ACT_RECORD_SIZE;          \
     vm->fp = (SCM *) ACT_SAVE_FP(vm->fp);       \
-}while(0)
+}else{}
 
 static void run_vm(vm_thread_t *vm);
 
@@ -910,26 +909,24 @@ DEFINE_PRIMITIVE("%vm", set_vm_debug, vsubr, (int _UNUSED(argc), SCM _UNUSED(*ar
  *      operand at [n+1]
  *   4) Thread A resumes, updates operand at [n+1], releases lock
  */
-#define LOCK_AND_RESTART                     do{\
+#define LOCK_AND_RESTART                  if(1){\
   if (!have_global_lock) {                      \
     MUT_LOCK(global_lock);                      \
     have_global_lock=1;                         \
     (vm->pc)--;                                 \
     NEXT;                                       \
   }                                             \
-}while(0)
-#define RELEASE_LOCK                         do{\
-   {                                            \
+}else{}
+#define RELEASE_LOCK                      if(1){\
     MUT_UNLOCK(global_lock);                    \
     have_global_lock=0;                         \
-   }                                            \
-}while(0)
-#define RELEASE_POSSIBLE_LOCK                do{\
+}else{}
+#define RELEASE_POSSIBLE_LOCK             if(1){\
   if (have_global_lock) {                       \
     MUT_UNLOCK(global_lock);                    \
     have_global_lock=0;                         \
   }                                             \
-}while(0)
+}else{}
 
 static void run_vm(vm_thread_t *vm)
 {
@@ -1547,7 +1544,7 @@ CASE(INSCHEME) {
   NEXT1;
  }
 
- 
+
 CASE(END_OF_CODE) {
    return;
  }
@@ -1709,7 +1706,7 @@ CASE(IN_CXR) {
   vm->val= STk_cxr(vm->val, fetch_const());
   NEXT1;
  }
- 
+
 CASE(IN_APPLY)   {
   STk_panic("INSTRUCTION IN-APPLY!!!!!!!!!!!!!!!!!!!!!!!");
   NEXT;


### PR DESCRIPTION
Hi @egallesio !

This seems to fix #528 ... I'm not sure it's the best way, but it was easy to implement, so here it is.

The commit message:

It is common practice to use

```c
 #define SOME_MACRO do{ \
  ... \
  ... \
}while(0)
```

so that SOME_MACRO can be used inside `if`s and other C commands.

However, this can lead to problems:

```c
 #define NEXT continue
...
...
for(;;) {
...
 #define LOCK_AND_RESTART                 do{\
  if (!have_global_lock) {                   \
    ...                                      \
    NEXT;                                    \
  }                                          \
}while(0)
...
} /* for(;;) */
```

The `NEXT` expands into `continue`, which will break out of the `do`, and not continue the `for` loop as intended.

So we insteda use `if(1){ ... }else{}` for all multi-command macros.