### PR TITLE
`(log -inf.0)` = `+inf + i*pi`

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2915,6 +2915,8 @@ static SCM my_log(SCM z)
                         return double2real(my_bignum_rational_log(z));
     case tc_real:     if ( (REAL_VAL(z) == 0.0) && signbit(REAL_VAL(z)) )
                           return make_complex(double2real(minus_inf), double2real(MY_PI));
+                      else if ( isinf(REAL_VAL(z)) && signbit(REAL_VAL(z)) )
+                          return make_complex(double2real(plus_inf),  double2real(MY_PI));
                       else
                           return double2real(log(REAL_VAL(z)));
     case tc_complex:  return make_complex(my_log(STk_magnitude(z)),

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1453,9 +1453,16 @@
 (test "log -0.0" ;; R7RS says (log -0.0) should be "-inf + i*pi".
       #t
       (let ((z (log -0.0)))
-        (infinite? (real-part z))
-        (negative? (real-part z))
-        (< 3.14159265350 (imag-part z) 3.14159265360)))
+        (and (infinite? (real-part z))
+             (negative? (real-part z))
+             (< 3.14159265350 (imag-part z) 3.14159265360))))
+
+(test "log -inf.0" ;; The limit when x -> -inf is "+inf + i*pi".
+      #t
+      (let ((z (log -inf.0)))
+        (and (infinite? (real-part z))
+             (positive? (real-part z))
+             (< 3.14159265350 (imag-part z) 3.14159265360))))
 
 (test "log 2/3"
       #t


### PR DESCRIPTION
Because the limit when $x \to -\infty$ is actually $+\infty + i\pi$.

Current behavior:

```scheme
(log -0.0)    => -inf.0+3.14159265358979i
(log -10e50)  => 117.431839742696+3.14159265358979i
(log -10e100) => 232.561094392399+3.14159265358979i
(log -10e400) => -nan.0            ;; oops, should be inf + pi.
```

With this patch:

```scheme
(log -10e400) => +inf.0+3.14159265358979i
(log -inf.0)  => +inf.0+3.14159265358979i
```

A test is included.

This patch also corrects the test for `(log -0.0)`, which was ignoring the outcome from two predicates.