### PR TITLE
Be more careful when testing NaNs (and fix a failing test on Android).

### DIFF
--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -431,17 +431,26 @@
 (test-subsection "complex writer syntax")
 
 (test "complex printing"
-      '("+inf.0+inf.0i" "-nan.0+inf.0i" "+inf.0+inf.0i" "-inf.0-inf.0i"
+      '("+inf.0+inf.0i" "+inf.0+inf.0i" "-inf.0-inf.0i"
         "-nan.0-nan.0i" "+nan.0+nan.0i"
         "1+1i" "0+1i"
         "1+0.0i" "1-0.0i"
         "1+1/2i" "2-1/3i")
       (map number->string
-           (list (* 1+1i +inf.0) (* 0+1i +inf.0) (* 2+1i +inf.0) (* -inf.0 1+1i)
+           (list (* 1+1i +inf.0)  (* 2+1i +inf.0) (* -inf.0 1+1i)
                  (* -nan.0 +1i) (* +nan.0 -1i)
                  1+1i 0+1i
                  1+0.0i 1-0.0i
                  1+1/2i 2-1/3i)))
+
+;; (* 0+1i +inf.0) ca be -nan.0+inf.0i (on Linux/amd64 for example)
+;; and also +nan.0+inf.0i (on Android, for example). So we don't
+;; test the sign of the NaN.
+(test "complex printing 2"
+      #t
+      (let ((x (* 0+1i +inf.0)))
+        (and (nan? (real-part x))
+             (infinite? (imag-part x)))))
 
 ;;==================================================================
 ;; Predicates


### PR DESCRIPTION
`(* 0+1i +inf.0)` can be `-nan.0+inf.0i` (on Linux/amd64 for example) and also `+nan.0+inf.0i` (on Android, for example). So we don't test the sign of the NaN.
