### PR TITLE
More documentation to the compiler and `vm.adoc`

### DIFF
--- a/doc/vm/vm.adoc
+++ b/doc/vm/vm.adoc
@@ -350,6 +350,27 @@ DEEP_LOCAL_SET
 DEEP_LOC_REF_PUSH
 ....
 
+STklos organizes local environments as this: each level has a maximum
+of 256 variables. Both the level and the address of local variables
+are encoded in a single 16-bit integer, as "256v1+v2".  For example,
+2*256 + 03 = 0x0203. The first byte, 0x02, identifies the level, and
+the second byte, 0x03, identifies the variable.
+
+The VM will, then, do something like this to access a deep local variable:
+
+[source,c]
+----
+  /* See this is src/vm.c, CASE(DEEP_LOCAL_REF):  */
+  for (level = FIRST_BYTE(info); level; level--)
+    e = (SCM) FRAME_NEXT(e);
+
+  vm->val = FRAME_LOCAL(e, SECOND_BYTE(info));
+----
+
+Here, `info` is the information to access the variable (a `uint16_t`
+number, as every opcode and operand used in the VM).
+`FIRST_BYTE` gets the level; `SECOND_BYTE` gets the var address.
+
 Examples:
 
 [source,scheme]
@@ -396,6 +417,58 @@ comparison opcode `IN-NUMEQ`:
 004:  IN-NUMEQ
 005:  RETURN
 ....
+
+The following example shows a variable in a deeper level.
+
+[source,scheme]
+----
+(disassemble
+  (let ((c 4)
+        (b 3))
+    (lambda ()
+      (let ((a 2))
+        c))))
+----
+
+....
+000:  PREPARE-CALL
+001:  INT-PUSH             2
+003:  ENTER-TAIL-LET       1
+005:  DEEP-LOCAL-REF       513
+007:  RETURN
+....
+
+The number 513 is composed of the bytes 0x02 and 0x01:
+`#x0201 = 513`. This means "the variable of index 1 in
+level 2" (index 1 is for `c`, and index 0 is for `b`).
+
+The code for `(let ((c 4) (b 3)` is not shown, but it can bee seen
+with `disassemble-expr`:
+
+[source,scheme]
+----
+(disassemble-expr
+  '(let ((c 4)
+         (b 3))
+     (lambda ()
+       (let ((a 2))
+         c))) #t)
+----
+
+....
+000:  PREPARE-CALL
+001:  INT-PUSH             4
+003:  INT-PUSH             3
+005:  ENTER-LET            2
+007:  CREATE-CLOSURE       9 0	;; ==> 018
+010:  PREPARE-CALL
+011:  INT-PUSH             2
+013:  ENTER-TAIL-LET       1
+015:  DEEP-LOCAL-REF       513
+017:  RETURN
+018:  LEAVE-LET
+....
+
 
 == Global variables
 

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -376,10 +376,32 @@ doc>
 
 (define (compile-access name env epair ref)
 
+  ;; STklos organizes local environments as this: each level has a
+  ;; maximum of 256 variables. However, the "(+ (* v1 256) v2)"
+  ;; formula here does *not* mean that the variables are stored
+  ;; linearly in frames that are 256 bytes apart.
+  ;; The "256v1+v2" is actually an encoding in two bytes: 2*256 + 03 =
+  ;; 0x0203. The first byte, 0x02, identifies the level, and the second
+  ;; byte, 0x03, identifies the variable.
+  ;; Later, the VM will, for example, do the following to access
+  ;; a local variable in previous levels:
+  ;;
+  ;; for (level = FIRST_BYTE(info); level; level--)
+  ;;   e = (SCM) FRAME_NEXT(e);
+  ;; vm->val = FRAME_LOCAL(e, SECOND_BYTE(info));
+  ;;
+  ;; FIRST_BYTE gets the level; SECOND_BYTE gets the var address.
+  ;;
+  ;; make-word builds a 16-bit word that encodes level v1 and
+  ;; variable v2.
   (define (make-word v1 v2)               ;; FIXME: Add control
     (+ (* v1 256) v2))
 
 
+  ;; The argument 'ref' determines if this is a set or a reference
+  ;; (#f = set, #t = ref). So 'em' is used to simplify emmitting the
+  ;; code: i1 is the instruction for ref, i2 is the instruction for
+  ;; set.
   (define (em i1 i2 . args)
     (apply emit (if ref i1 i2) args))
 

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -260,6 +260,10 @@
       (set! *code-constants* (append! *code-constants* x)))
     (- (length *code-constants*) (length x))))
 
+;; small-integer-constant? checks wether anobject is an exact integer in
+;; a specific range (hardcoded to [ -2^15, 2^15 - 1 ] here). This is because
+;; the STklos VM opcodes are 16-bit wide, so this is the range that fits an
+;; opcode argument.
 (define small-integer-constant?
   (let ((min-int (- (expt 2 15)))
         (max-int (- (expt 2 15) 1)))
@@ -268,6 +272,9 @@
            (exact? v)
            (<= min-int v max-int)))))
 
+;; Generates code for small constants.
+;; v is the constant to be produced;
+;; env and tail? are ignored.
 (define (compile-constant v env tail?)
   (cond
     ((eq? v #t)                        (emit 'IM-TRUE))

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -148,6 +148,10 @@
   mlocals                       ; #t if symbols are macros
   parent)                       ; parent scope
 
+;; find-symbol-in-env will return:
+;; a symbol, if it is a local variable
+;; a syntax object, if the symbol is bound to syntax
+;; #f otherwise
 (define (find-symbol-in-env symb env)
   (let Loop ((env env))
     (cond
@@ -187,6 +191,17 @@
 ;
 ; ======================================================================
 
+;; find-syntax-in-env returns the syntax object to which symb is bound,
+;; or #f
+;; This is *not* to be used when accessing symbol values; it is to be
+;; used when expanding macros -- to expand a form (S ...), we see if
+;; S is syntax; if it's not, we don't bother doing anything else and
+;; return the form as is.
+;;
+;; This is theusual way (almost all Schemes do this):
+;; (define-syntax f (syntax-rules () ((f) -1)))
+;; (let ((f (lambda () 10))) (macro-expand '(f))) => -1
+;; (let ((f (lambda () 10))) (f))                 => 10
 (define (find-syntax-in-env symb env)
   (and (symbol? symb)
        (let ((val (find-symbol-in-env symb env)))         ; local macro?

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1594,6 +1594,18 @@ doc>
 ;;
 ;; DO
 ;;
+;; (do ((a a0 a+)
+;;      (b b0 b+))
+;;     (test fin)
+;;   (body)) =>
+;;
+;; (letrec ((NAME
+;;           (lambda (a b ...)
+;;             (if test
+;;                 (begin fin)
+;;                 (begin body
+;;                        (name a+ b+ ...))))))
+;;  (NAME a0 b0 ...))
 (define (rewrite-do inits test body)
   (let ((loop-name (gensym)))
     `(letrec ((,loop-name
@@ -1615,7 +1627,7 @@ doc>
                                        inits)))))))
        (,loop-name ,@(map cadr inits)))))
 
-
+;; Just calls rewrite-do with tail? = #f
 (define (compile-do e env tail?)
   (if (>= (length e) 3)
       (compile (rewrite-do (cadr e) (caddr e) (cdddr e))

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -263,6 +263,18 @@
 ;
 ; ======================================================================
 
+;; The global variable *code-constants* contains a list of constants for the
+;; code being compiled. Each list in the list is a symbol (and it is searched
+;; with memq).
+;; Why is its index not also kept in the list? Because the index is the position
+;; of the element in the list, and it's calculated when the compiler calls this
+;; function (fetch-constant).
+;;
+;; (define *code-constants* (list-copy '(a b c d e)))
+;; (fetch-constant 'c)  => 2
+;; (fetch-constant 'a)  => 0
+;; (fetch-constant 'x)  => 5   (and x is appended to the end of *code-constants*)
+;;
 (define (fetch-constant c)
   (let ((x (memq c *code-constants*)))
     (unless x

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1932,16 +1932,19 @@ both forms.
      ,@body
      (void)))
 
+;; The expression, 'e', is of the form '(%%label nnnn)',
+;; where nnnn is an integer that describes this label.
 (define (compile-%%label e env tail)
   (if (= (length e) 2)
       (emit-label (cadr e))
       (compiler-error '%%label e "bad usage ~S" e)))
 
+;; The expression, 'e', is something like '(%%goto nnnn)',
+;; where nnnn is a label.
 (define (compile-%%goto e env tail)
   (if (= (length e) 2)
       (emit 'GOTO (cadr e))
       (compiler-error '%%goto e "bad usage ~S" e)))
-
 
 (define (compile-%%source-pos e env tail)
   (compile (if (%epair? e)

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -464,6 +464,16 @@ doc>
 ;;;;
 ;;;; IF
 ;;;;
+;;
+;; (if cond expr1 expr2) =>
+;;
+;; [ cond ]       * tail? = #f
+;; JUMP-FALSE L1
+;; [ expr1 ]
+;; GOTO L2
+;; L1:
+;; [ expr2 ] -or- IM-VOID
+;; L2:
 (define (compile-if args env tail?)
   (let ((len (length (cdr args)))
         (l1  (new-label))

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -625,15 +625,17 @@ doc>
        ((pair? l) (loop (cdr l) (+ n 1)))
        (else      (- (- n) 1)))))
 
+;; (extend-env env '(a b . c))  =>  scope (c b a) '() env)
+;; (extend-env env 'x)          =>  scope (x)     '() env)
 (define (extend-env env formals)
   (letrec ((aux (lambda (l res)
                   (cond
                      ((null? l) res)
                      ((pair? l) (aux (cdr l) (cons (car l) res)))
                      (else      (cons l res))))))
-    (make-scope (aux formals '())
-                '()
-                env)))
+    (make-scope (aux formals '()) ; locals
+                '()               ; mlocals
+                env)))            ; parent
 
 (define (extract-doc-and-name doc name body)
   ;; extract the doc string and and name of the prcedure if present in body

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -419,6 +419,13 @@ doc>
 ;;;; REFERENCES & ASSIGNMENT
 ;;;;
 
+;; compile-access will generate code for references and assignments.
+;; The argments:
+;; name: a symbol, the variable name.
+;; env: the environment to be used.
+;; epair: the extended pair (source s-expression) that originated a
+;;        call to compile-acces.
+;; ref: if #t, then it's a reference; if #f, it's an assignment.
 (define (compile-access name env epair ref)
 
   ;; STklos organizes local environments as this: each level has a
@@ -490,6 +497,18 @@ doc>
 (define (compile-reference name env epair tail?)
   (compile-access name env epair #t))
 
+;; compile-set! will just call compile-access, and when doing so, will
+;; set the 'ref' argument to #f. The 'ref' argument to compile-access
+;; means "this is just a reference, not an assignment".
+;; Before calling compile-access, compile-set! will check the syntac
+;; for set! and also extract the variable name.
+;;
+;; (compile-set! (set! a (+ 2 b)))
+;; will make these two calls:
+;; (compile (+ 2 b) env (set! a + 2 b) #f)
+;; (compile-access 'a env (set! a + 2 b) #f)
+;;
+;; The extended set! is treated separately.
 (define (compile-set! args env tail?)
   (let ((len (length (cdr args))))
     (if (= len 2)

--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -232,6 +232,12 @@
 
 ;; ----------------------------------------------------------------------
 
+
+;; A label is just a number. Each instruction in the list *code-instr*
+;; is either:
+;; - a list (instruction + arguments), or
+;; - a label (an integer number)
+
 (define (new-label)
   (let ((lab *code-labels*))
     (set! *code-labels* (+ *code-labels* 1))
@@ -242,6 +248,11 @@
 (define (emit . args)
   (set! *code-instr* (cons args *code-instr*)))
 
+
+;; emit-label will emit the last generated label, but will *not*
+;; increment it (the same label can be emitted several times).  In
+;; order to create a new label, use %compiler-new-label (or
+;; 'new-label')
 (define (emit-label lab)
   (set! *code-instr* (cons lab *code-instr*)))
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -1173,6 +1173,13 @@ CASE(DEEP_LOCAL_REF) {
   int level, info = fetch_next();
   SCM e = vm->env;
 
+  /* STklos organizes local environments as this: each level has a
+     maximum of 256 variables. Both the level and the address of local
+     variables are encoded in a single 16-bit integer, as "256v1+v2".
+     For example, 2*256 + 03 = 0x0203. The first byte, 0x02,
+     identifies the level, and the second byte, 0x03, identifies the
+     variable.  */
+
   /* Go down in the dynamic environment */
   for (level = FIRST_BYTE(info); level; level--)
     e = (SCM) FRAME_NEXT(e);


### PR DESCRIPTION
Hi @egallesio !
These are mostly patches that add comments to `compiler.stk`, and one which also expands `vm.adoc` a little bit.
