### PR TITLE
Fix behavior of `vector-copy` in SRFI 43

### DIFF
--- a/lib/srfi/43.stk
+++ b/lib/srfi/43.stk
@@ -22,7 +22,7 @@
    vector?
    vector-empty?
    vector=
-   
+
    ;;; Selectors
    vector-ref
    vector-length
@@ -38,7 +38,7 @@
    vector-index-right              vector-skip-right
    vector-binary-search
    vector-any                      vector-every
-   
+
    ;;; Mutators
    vector-set!
    vector-swap!
@@ -120,7 +120,7 @@
                                   length)
                              callee)))))
     loop))
-    
+
 ;; Constructors
 
 (from-scheme make-vector)
@@ -129,9 +129,9 @@
 (from-133    vector-unfold-right)
 
 (define r7rs-vector-copy (symbol-value 'vector-copy scheme))
-(define (vector-copy v :optional (start 0) stop (fill #f fill?))
+(define (vector-copy v :optional (start 0) stop (fill #void fill?))
   (let ((stop (if stop stop (vector-length v))))
-    (if (not fill?)
+    (if (<= stop (vector-length v))
         (r7rs-vector-copy v start stop)
         (let ((w (make-vector (- stop start))))
           (dotimes (i (- (vector-length v) start))
@@ -140,7 +140,6 @@
             (vector-set! w (+ i (- (vector-length v) start))  fill))
           w))))
 
-      
 
 (from-133    vector-reverse-copy)
 (from-scheme vector-append)

--- a/tests/srfis/43.stk
+++ b/tests/srfis/43.stk
@@ -696,6 +696,11 @@
                 (reverse-list->vector '(0 1 2 3) 2 1))
   ))
 
+(test "vector-copy, no fill"
+      #(-1 -1 -1 -1 -1 #void #void #void)
+      (let ((v (make-vector 5 -1)))
+        (vector-copy v 0 8)))
+
 ) ;; run-srfi-43-test
 
 ) ;; module


### PR DESCRIPTION
The procedure should augment the vector as necessary, even if there's no fill argument...

```scheme
(define v (make-vector 5 -1))
v => #(-1 -1 -1 -1 -1)

(vector-copy v 0 8)
```

The above currently triggers an error, but SRFI 43 says it should augment the vector with an unspecified argument...

This patch fixes this:

```scheme
(vector-copy v 0 8) => #(-1 -1 -1 -1 -1 #void #void #void)
```