### PR TITLE
Small documentation fixes

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1807,13 +1807,13 @@ doc>
  * This form is similar to |define|, except the binding of |<variable>| which
  * is non mutable.
  *
- * @lisp 
+ * @lisp
  * (define-constant a 'hello)
  * (set! a 'goodbye)             => error
  * (define a 2)                  ; is  ok (it's a new binding)
  * (define-constant ((foo a) b)  ; foo is (lambda (a) (lambda (b) ...)))
  *     ...)
- * @end lisp 
+ * @end lisp
 doc>
 |#
 (define-macro (define-constant . args)
@@ -1836,7 +1836,7 @@ doc>
 <doc EXT void?
  * (void? obj)
  *
- * Returns `#t` is |obj| is `#void`, and `#f` otherwise.
+ * Returns `#t` if |obj| is `#void`, and `#f` otherwise.
  * The usual "unspecified" result in Scheme standard and in SRFIs is `#void`
  * in STklos, and it is also returned by the procedure |void|.
  *

--- a/lib/module.stk
+++ b/lib/module.stk
@@ -650,5 +650,5 @@ doc>
 doc>
 |#
 (define (module-list)
-  (filter (lambda(x) (not (library? x)))
+  (filter (lambda (x) (not (library? x)))
           (all-modules)))

--- a/lib/runtime-macros.stk
+++ b/lib/runtime-macros.stk
@@ -53,7 +53,7 @@
 ;;
 ;; %claim-error
 ;;
-;; Permit to claim that a function as detected an error
+;; Permit to claim that a function has detected an error
 ;; For instance
 ;;   (define (change-first-char! str char)
 ;;      (%claim-error 'change-first-char! (string-set! str 0 char)))

--- a/lib/runtime.stk
+++ b/lib/runtime.stk
@@ -58,14 +58,14 @@
 (define cddddr (lambda (x) (%cxr x #:dddd)))
 
 (define (map* fn . l)           ; A map which accepts dotted lists (arg lists
-  (cond                         ; must be "isomorph"
+  (cond                         ; must be "isomorph")
    ((null? (car l)) '())
    ((pair? (car l)) (cons (apply fn      (map car l))
                           (apply map* fn (map cdr l))))
    (else            (apply fn l))))
 
 (define (for-each* fn . l)      ; A for-each which accepts dotted lists (arg lists
-  (cond                         ; must be "isomorph"
+  (cond                         ; must be "isomorph")
    ((null? (car l)) '())
    ((pair? (car l)) (apply fn (map car l)) (apply for-each* fn (map cdr l)))
    (else            (apply fn l))))

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -238,18 +238,18 @@
     ;; 197  Pipeline Operators
     ;; 198  ...... withdrawn
     ;; 199  ....... withdrawn
-    ;; 200  Pattern Matching (draft)
+    ;; 200  ....... withdrawn
     ;; 201  Extensions to the Core Scheme Bindings
     ;; 202  Pattern-matching Variant of the and-let* Form that Supports Multiple Values
     ;; 203  A Simple Picture Language in the Style of SICP
-    ;; 204  Wright-Cartwright-Shinn Pattern Matcher (draft)
-    ;; 205  POSIX Terminal Fundamentals (draft)
+    ;; 204  ....... withdrawn
+    ;; 205  ....... withdrawn
     ;; 206  Auxiliary Syntax Keywords
     (207  "String-notated bytevectors" () "srfi-207")
     (208  "NaN procedures")
     ;; 209  Enumerations and Enum Sets
     ;; 210  Procedures and Syntax for Multiple Values
-    ;; 211  Namespaces for Scheme Macro Systems (draft)
+    ;; 211  Scheme Macro Libraries
     ;; 212  Aliases
     ;; 213  Identifier Properties
     (214  "Flexvectors" () "srfi-214")
@@ -264,7 +264,7 @@
     (223 "Generalized binary search procedures" () "srfi-223")
     (224 "Integer Mappings" () "srfi-224")
     ;; 225 Dictionaries
-    ;; 226 Control Features (draft)
+    ;; 226 Control Features
     (227 "Optional Arguments" () "srfi-227")
     (228 "A further comparator library" () "srfi-228")
     (229 "Tagged Procedures" () "srfi-229")
@@ -275,10 +275,10 @@
     ;; 234 Topological sorting (draft)
     (235 "Combinators" (combinators) "srfi-235")
     (236 "Evaluating expressions in an unspecified order" () "srfi-236")
-    ;; 237 R6RS Records (refined) (draft)
+    ;; 237 R6RS Records (refined)
     (238 "Codesets" () "srfi-238")
     ;; 239 Destructuring lists
-    ;; 240 Reconciled records (draft)
+    ;; 240 Reconciled records
     ;; 241 Match -- Simple Pattern-Matching Syntax to Express Catamorphisms on Scheme Data (drafr)
     ;; 242 The CFG Language (draft)
     ;; 243 Unreadable objects (draft)

--- a/src/misc.c
+++ b/src/misc.c
@@ -93,7 +93,7 @@ SCM STk_read_from_C_string(const char *str)
 
 /*===========================================================================*\
  *
- * Primitives that don't feet anywhere else
+ * Primitives that don't fit anywhere else
  *
 \*===========================================================================*/
 /*
@@ -122,7 +122,7 @@ DEFINE_PRIMITIVE("version", version, subr0, (void))
  * (short-version)
  *
  * Returns a string identifying the current version of the system without
- * its eventual patch number. 
+ * its eventual patch number.
 doc>
 */
 DEFINE_PRIMITIVE("short-version", short_version, subr0, (void))

--- a/src/number.c
+++ b/src/number.c
@@ -2374,7 +2374,7 @@ static void int_divide(SCM x, SCM y, SCM *quotient, SCM* remainder, int exact)
   /* Here, x and y can only be integer or bignum (not real) */
 
   /* NOTE about the remainder: the GMP accepts 'unsigned integers' and
-     als returns 'unsigned integers' for remainders. We can safely use
+     also returns 'unsigned integers' for remainders. We can safely use
      'long' for these remainders, AND these will always fit a fixnum,
      because we'll only receive them when we passed fixnums as arguments,
      and the remainder won't be larger. */
@@ -2410,8 +2410,8 @@ static void int_divide(SCM x, SCM y, SCM *quotient, SCM* remainder, int exact)
       if (quotient) mpz_init(q);
       /* The GMP only returns unsigned remainders, so we need to keep track of the
          sign of x. The easiest way to put back the sign is to initialize rem with
-         it, and multiply by whatever the GPM returns.
-         Also, we need labs so GMP will get the expected ulong. */
+         it, and multiply by whatever the GMP returns.
+         Also, we need 'labs' so the GMP will get the expected ulong. */
       long xsign = mpz_sgn(BIGNUM_VAL(x));
       if (!quotient) rem = xsign * (long) mpz_tdiv_ui(BIGNUM_VAL(x), labs(INT_VAL(y)));
       else rem = xsign * (long) mpz_tdiv_q_ui(q, BIGNUM_VAL(x),
@@ -2595,7 +2595,7 @@ static SCM gcd2(SCM n1, SCM n2)
     else if (BIGNUMP(n1) && BIGNUMP(n2)) /*  n1:BIG n2:BIG */
       mpz_gcd(r, BIGNUM_VAL(n1), BIGNUM_VAL(n2));
 
-    /* NOTE: we are sure to not here a NaN or an infinity since
+    /* NOTE: we are sure to not have here a NaN or an infinity since
      * at most r is equal to n1 or n2, which has been accepted by
      * predicate integer? when entering this function
      */
@@ -2908,7 +2908,7 @@ static double my_bignum_rational_log(SCM z) {
   /* For both the numerator and denominator:
 
      - If it is a bignum AND fits a double, then just
-       converto to double and take the log.
+       convert to double and take the log.
      - If it is a bignum and does NOT fit a double,
        use my_bignum_log.
      - It may be that only one of numerator or denominator

--- a/src/number.c
+++ b/src/number.c
@@ -3320,8 +3320,8 @@ static inline SCM
 acosh_aux(SCM z, double zz) {
     double r = zz*zz - 1;
     if (!isinf(r) && r >= 0) { /* can be too large for a double if
-                                zz is too large; can be negative if
-                                zz is in (0,+1). */
+                                  zz is too large; can be negative if
+                                  zz is in (0,+1). */
         double zzz = sqrt(r) + zz;
         if (!isinf(zzz)) /* did it overflow when we summed zz? */
             return double2real(log(zzz));
@@ -4032,7 +4032,7 @@ DEFINE_PRIMITIVE("encode-float", encode_float, subr3, (SCM significand, SCM expo
   int g = INT_VAL(inexact2exact(sign));
 
   /* #f => NaN,
-     #t =? inf  */
+     #t => inf  */
   if (significand == STk_false) return double2real(make_nan(0,0,0));
   if (significand == STk_true)  return (g >= 0)
                                   ? double2real(plus_inf)
@@ -4230,9 +4230,9 @@ DEFINE_PRIMITIVE("%stklos-has-gmp?", has_gmp, subr0, ())
 int STk_init_number(void)
 {
   /* For systems without these constants, we can do:
-  plus_inf  = 1.0 / 0.0;
-  minus_inf = -plus_inf;
-  STk_NaN   = strtod("NAN", NULL);
+     plus_inf  = 1.0 / 0.0;
+     minus_inf = -plus_inf;
+     STk_NaN   = strtod("NAN", NULL);
   */
 
   /* initialize  special IEEE 754 values */

--- a/src/read.c
+++ b/src/read.c
@@ -260,7 +260,7 @@ static SCM read_list(SCM port, char delim, struct read_context *ctx)
         c = flush_spaces(port, eof_seen, port);
       }
       if (c != delim)
-        error_bad_dotted_list(port, line); // dot not befor last element
+        error_bad_dotted_list(port, line); // dot not before last element
       CDR(last) = cur;
       return start;
     }

--- a/src/signal.c
+++ b/src/signal.c
@@ -319,7 +319,7 @@ int STk_init_signal()
     signals[i] = STk_true;
   }
 
-  // Define the symbols assiocated to signal names
+  // Define the symbols associated to signal names
   for (struct codeset_code *p = STk_signal_names; p->name; p++) {
     STk_define_variable(STk_intern((char *)p->name), MAKE_INT(p->code),
                         STk_STklos_module);

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -154,7 +154,6 @@ DEFINE_PRIMITIVE("symbol->string", symbol2string, subr1, (SCM symbol))
  * because in some implementations of Scheme they cannot be read as themselves.
  *
  * @lisp
- *    (eq? 'mISSISSIppi 'mississippi)                   =>  #t
  *    (string->symbol "mISSISSIppi")                    =>  @pipemISSISSIppi@pipe
  *    (eq? 'bitBlt (string->symbol "bitBlt"))           =>  #f
  *    (eq? 'JollyWog
@@ -163,6 +162,20 @@ DEFINE_PRIMITIVE("symbol->string", symbol2string, subr1, (SCM symbol))
  *    (string=? "K. Harper, M.D."
  *              (symbol->string
  *                (string->symbol "K. Harper, M.D.")))  =>  #t
+ * @end lisp
+ *
+ * If STklos is running in case-sensitive mode (with the `--case-sensitive` command
+ * line option, default) then the behavior is as follows.
+ *
+ * @lisp
+ *    (eq? 'mISSISSIppi 'mississippi)                   =>  #f
+ * @end lisp
+ *
+ * If STklos runs in case-insensitive mode (with the `--case-insensitive` command
+ * line option) then the behavior is different:
+ *
+ * @lisp
+ *    (eq? 'mISSISSIppi 'mississippi)                   =>  #t
  * @end lisp
 doc>
  */

--- a/src/vm.c
+++ b/src/vm.c
@@ -734,7 +734,7 @@ SCM STk_values2vector(SCM obj, SCM vect)
 	STk_error("bad vector ~S", vect);
     if (VECTOR_SIZE(vect) != len)
 	STk_error("expected %d values, but %d were given",
-		  VECTOR_SIZE(vect), len);
+            VECTOR_SIZE(vect), len);
     retval = vect;
   } else {
     /* Allocate a new vector for result */
@@ -1445,14 +1445,14 @@ CASE(ENTER_TAIL_LET) {
       vm->fp = old_fp;
 
       /* Push a new environment on the stack */
-      vm->sp = ((SCM*)vm->env) - nargs-
-                     ((sizeof(struct frame_obj) - sizeof(SCM)) / sizeof(SCM));
+      vm->sp = ((SCM*)vm->env) - nargs -
+               ((sizeof(struct frame_obj) - sizeof(SCM)) / sizeof(SCM));
     }
     else {
       if (nargs) memmove(old_fp-nargs, vm->sp, nargs*sizeof(SCM));
       vm->fp = old_fp;
       vm->sp = vm->fp - nargs -
-                  ((sizeof(struct frame_obj) - sizeof(SCM)) / sizeof(SCM));
+               ((sizeof(struct frame_obj) - sizeof(SCM)) / sizeof(SCM));
     }
 
     PUSH_ENV(nargs, vm->val, vm->env);


### PR DESCRIPTION
One is actually relevant:

The documentation of `string->symbol` assumed that STklos is case-insensitive, but today this is optional (and not default).