### PR TITLE
`(- 0.0)` should be `-0.0`

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2157,6 +2157,12 @@ doc>
  */
 SCM STk_sub2(SCM o1, SCM o2)
 {
+  /* Special case:
+     (- 0.0) is calculated as (- 0 0.0)
+     which in turn should result in -0.0. */
+  if (INTP(o1)  && INT_VAL(o1)==0 &&
+      REALP(o2) && FP_ZERO == fpclassify(REAL_VAL(o2)))
+    return double2real(-REAL_VAL(o2));
   switch (convert(&o1, &o2)) {
     case tc_bignum:
       {

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -533,6 +533,7 @@
 (test "zero?" #t (zero? 0+0i))
 (test "zero?" #f (zero? 1.0))
 (test "zero?" #f (zero? +5i))
+(test "zero?" #t (zero? -0.0))
 (test "positive?" #t (positive? 1))
 (test "positive?" #f (positive? -1))
 (test "positive?" #t (positive? 3.1416))
@@ -590,6 +591,14 @@
       (- xx y))
 (test "-bignum - -bignum" #x-fffffffd00000000fffffffd00000000
       (- xx yy))
+
+(test "minus-zero"
+      -0.0
+      (- 0.0))
+
+(test "minus zero"
+      0.0
+      (- 0.0 0.0))
 
 ;;------------------------------------------------------------------
 (test-subsection "small immediate integer constants")


### PR DESCRIPTION
Hi @egallesio !

Because of the way subtraction is performed, the expression `(- 0.0)` turns out to evaluate as `0.0`, because

* `(- 0.0)` becomes `(- 0 0.0)` in `"-"`
* `(- 0 0.0` becomes `(- 0.0 0.0)` in `convert`
* the result is `0.0`

This patch fixes this, so `(- 0.0)` is now `-0.0` (as all Schemes do)