### PR TITLE
Make `abs` work for complexes

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2284,6 +2284,8 @@ DEFINE_PRIMITIVE("/", division, vsubr, (int argc, SCM *argv))
  * @lisp
  * (abs -7)                =>  7
  * (abs -inf.0)            => +inf.0
+ * (abs -3+4i)             => 5
+ * (abs -3.0-4i)           => 5.0
  * @end lisp
 doc>
  */
@@ -2305,6 +2307,8 @@ DEFINE_PRIMITIVE("abs", abs, subr1, (SCM x))
     case tc_real:     return (REAL_VAL(x) < 0.0) ? double2real(-REAL_VAL(x)) : x;
     case tc_rational: return make_rational(absolute(RATIONAL_NUM(x)),
                                            RATIONAL_DEN(x));
+    case tc_complex:  return STk_sqrt(add2(mul2(COMPLEX_REAL(x),COMPLEX_REAL(x)),
+                                           mul2(COMPLEX_IMAG(x),COMPLEX_IMAG(x))));
     default:          error_not_a_real_number(x);
   }
   return STk_void;      /* never reached */

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -2066,4 +2066,29 @@
            (radians->degrees (/ pi 5))
            36.00001)))
 
+(test "abs complex"
+      5
+      (abs -3-4i))
+
+(test "abs complex"
+      5.0
+      (abs -3.0-4i))
+
+(test "abs complex"
+      #t
+      (infinite? (abs -inf.0+4i)))
+
+(test "abs complex"
+      #t
+      (infinite? (abs 2-inf.0i)))
+
+(test "abs complex"
+      #t
+      (nan? (abs -nan.0+4i)))
+
+(test "abs complex"
+      #t
+      (nan? (abs 1-nan.0i)))
+
+
 (test-section-end)


### PR DESCRIPTION
R7RS says it "computes the absolute value of its argument", but doesn't imply it should be real...
So we do compute the norm,
` (abs a+bi)` $`= \sqrt{a^2+b^2} `$
as usual.

A very small patch... :)

```
(abs -3+4i)             => 5
(abs -3.0-4i)           => 5.0
```

Here's a list of how other lisps deal with `(abs -3-4i)`:


| System      | result       | remark           |
|-------------|--------------|------------------|
| Bigloo      | no complexes |                  |
| Biwa        | no complexes |                  |
| Chez        | error        |                  |
| Chibi       | -3-4i        | leaves unchanged |
| Chicken     | error        |                  |
| Cyclone     | error          |  |
| Gambit      | error        |                  |
| Gauche      | 5.0          |                  |
| Guile       | error        |                  |
| Kawa        | 5.0          |                  |
| LIPS        | error        |                  |
| MIT         | error        |                  |
| Racket      | error        |                  |
| Sagittarius | 5            | keeps exactness  |
| STklos      | error        |                  |
| Unsyntax    | -3-4i        | leaves unchanged |
|             |              |                  |
| ABCL        | 5.0          |                  |
| CCL         | 5            | keeps exactness  |
| Clisp       | 5            | keeps exactness  |
| ECL         | 5.0          |                  |
| GCL         | 5.0          |                  |
| SBCL        | 5.0          |                  |

