### PR TITLE
Fix an `sqrt` crash, make it faster and more precise

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3497,23 +3497,26 @@ DEFINE_PRIMITIVE("sqrt", sqrt, subr1, (SCM z))
       SCM a = COMPLEX_REAL(z);
       SCM b = COMPLEX_IMAG(z);
 
-      /* The square root of a complex number,
+      /* Given a, b we will compute A, B such that the square root of
+         the complex number a+bi is
+
          sqrt(a+bi) = A+Bi
 
+         The algorithm:
+
          if a < 0:
-             B := sqrt( (|z|-a) /2) * sign(b)
-             A := b/(2*B).
+             B := sqrt( (|z|-a) / 2) * sign(b)
+             A := b / (2*B).
 
          if a >= 0:
-             A := sqrt( (|z|+a) /2)
+             A := sqrt( (|z|+a) / 2)
              if A != 0:
                  B := (b / (2*A))
              else:
-                 B = 0.0
-      */
+                 B = 0.0                        */
 
       if (negativep(a) ||  /* a < 0 */
-          REALP(a) && signbit(REAL_VAL(a))) { /* negaivep(-0.0) won't work... */
+          REALP(a) && signbit(REAL_VAL(a))) { /* negativep(-0.0) won't work... */
         bb = STk_sqrt(div2(sub2(STk_magnitude(z),a), MAKE_INT(2)));
 
         if (negativep(b) ||

--- a/src/number.c
+++ b/src/number.c
@@ -3492,20 +3492,45 @@ DEFINE_PRIMITIVE("sqrt", sqrt, subr1, (SCM z))
                         return Cmake_complex(MAKE_INT(0),
                                              double2real(sqrt(-REAL_VAL(z))));
                       return double2real(sqrt(REAL_VAL(z)));
-    case tc_complex:  if (zerop(COMPLEX_IMAG(z))) {
-                        // Special cases: (sqrt -1+0.0i) => +i
-                        //                (sqrt -1-0.0i) => -i
-                        SCM im = COMPLEX_IMAG(z);
-                        SCM tmp =  STk_ex2inex(STk_sqrt(COMPLEX_REAL(z)));
+    case tc_complex: {
+      SCM aa, bb;
+      SCM a = COMPLEX_REAL(z);
+      SCM b = COMPLEX_IMAG(z);
 
-                        if (REALP(im) && signbit(REAL_VAL(im))) {
-                          COMPLEX_IMAG(tmp) = double2real(-REAL_VAL(COMPLEX_IMAG(tmp)));
-                        }
-                        return tmp;
-                      } else
-                        return make_polar(STk_sqrt(STk_magnitude(z)),
-                                          div2(STk_angle(z), MAKE_INT(2)));
+      /* The square root of a complex number,
+         sqrt(a+bi) = A+Bi
 
+         if a < 0:
+             B := sqrt( (|z|-a) /2) * sign(b)
+             A := b/(2*B).
+
+         if a >= 0:
+             A := sqrt( (|z|+a) /2)
+             if A != 0:
+                 B := (b / (2*A))
+             else:
+                 B = 0.0
+      */
+
+      if (negativep(a) ||  /* a < 0 */
+          REALP(a) && signbit(REAL_VAL(a))) { /* negaivep(-0.0) won't work... */
+        bb = STk_sqrt(div2(sub2(STk_magnitude(z),a), MAKE_INT(2)));
+
+        if (negativep(b) ||
+            REALP(b) && signbit(REAL_VAL(b)))
+          bb = mul2(bb,MAKE_INT(-1));
+
+        aa = div2(b,mul2(bb, MAKE_INT(2)));
+      }
+      else {  /* a >= 0 */
+        aa = STk_sqrt(div2(add2(a, STk_magnitude(z)), MAKE_INT(2)));
+        if (zerop(aa))
+          bb = double2real(0.0);
+        else
+          bb = div2(b,mul2(aa,MAKE_INT(2)));
+      }
+      return make_complex(aa, bb);
+    }
     default:          error_bad_number(z);
   }
   return STk_void; /* never reached */


### PR DESCRIPTION
Hello @egallesio !

Currently, STklos crashes on this input: `(sqrt 1-0.0i)`.

Looking at the algorithm used, it seems that we can both fix this crash and also make it a bit more precise.

With this PR, we calculate the square root of coplexes as this (same algorithm that Clisp uses):

```
sqrt(a+bi) = A+Bi

   if a < 0:
       B := sqrt( (|z|-a) /2) * sign(b)
       A := b/(2*B).

   if a >= 0:
       A := sqrt( (|z|+a) /2)
       if A != 0:
           B := (b / (2*A))
       else:
           B = 0.0
```

So we don't use `ex2inex`, `angle` (and consequently `atan`) anymore, only two square roots and one inversion (and it seems to be more precise - see below).

A tricky part is to test "a < 0" for negative zero (because -0.0 < 0 won't work, we need to get the `REAL_PART` and use `signbit()` to test it)

Looking at the limiting process, we see that

```scheme
(sqrt -1) = i.
```

Then, `(sqrt -1 + tiny*i)` should get be very close to i.

Current algorithm:

```scheme
(import (srfi 144))
(sqrt (+ -1 (* fl-least +i))) => 6.12323399573677e-17+1.0i
```

With this patch:

```scheme
(sqrt (+ -1 (* fl-least +i))) => 0.0+1.0i
```

So we go from `6e-17` to `0.0` (great!)

We are also closer to the values of Clisp, Gambit, Guile, SBCL for complex square roots...

And... It seems faster!

```scheme
(time
 (let ((x 2000-3000i))
   (dotimes (i 3000000)
     (when (= (modulo i 100)) (set! x 2000-3000i))
     (set! x (sqrt x)))
   x))

Old code: 3623.08 ms
New code: 3002.49 ms
```