### PR TITLE
Adds a browseable manual from the REPL

### DIFF
--- a/doc/refman/stdproc.adoc
+++ b/doc/refman/stdproc.adoc
@@ -966,6 +966,8 @@ See SRFI document for more information.
 {{insertdoc 'apropos}}
 {{insertdoc 'help}}
 {{insertdoc 'describe}}
+{{insertdoc 'manual}}
+{{insertdoc 'open-in-browser}}
 
 {{insertdoc 'trace}}
 {{insertdoc 'untrace}}

--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -48,6 +48,7 @@
         print printerr eprintf printf fprintf
         declare-new-error
         exec exec-list
+        open-in-browser manual
         apropos die
         decompose-file-name dirname basename file-separator
         make-path file-suffix file-prefix
@@ -1457,6 +1458,58 @@ doc>
 (define (exec-list command)
   (call-with-input-file (string-append "| " command) port->string-list))
 
+#|
+<doc EXT open-in-browser
+ * (open-in-browser url)
+ *
+ * Opens the URL given by the string |url| in the default browser, which is
+ * determined by the string contained in the parameter |default-browser|.
+ *
+ * The parameter |available-browsers| has a list of browsers that will be
+ * searched in the system |PATH|. That parameter can be changed to include
+ * other browsers, or to change the order in which they are tried.
+doc>
+|#
+(define (open-in-browser url)
+  (unless (string? url) (error "bad string ~S" url))
+  (unless (default-browser) (error "the parameter default-browser has not been configured"))
+  (unless (and (string? (default-browser))
+               (file-is-regular? (default-browser))
+               (file-is-executable? (default-browser)))
+    (error "The value of (default-browser) is not an executable: ~S" (default-browser)))
+  ;; FIXME: Unfortunately, this will show the stderr/stdout output of the browser
+  ;; on the REPL. We could redirect, but that would be assuming that we are running
+  ;; on a Unix environment...
+  (system (format #f "~a ~a" (default-browser) url)))
+
+#|
+<doc EXT manual
+ * (manual)
+ *
+ * Opens the STklos manual in a browser.
+ * There are two parameters relevant to this procedure:
+ *
+ * - `default-browser`: this parameter should contain a string
+ *   with the name of the default browser to be used.
+ * - `manual-path`: this parameter should contain a string with
+ *   the path to the STklos manual (the file `stklos-ref.html`).
+ *
+ * STklos tries to set them up automatically, but you may need
+ * to adjust them.
+doc>
+|#
+(define (manual)
+  (unless (manual-path)
+    (error
+     (string-append "Please configure the path to the manual by setting the\n"
+                    "parameter `manual-path`.")))
+  (let ((manual (manual-path)))
+    (unless (and (string? manual)
+                 (file-is-regular? manual)
+                 (file-is-readable? manual))
+      (error "The value of (manual-path) is not a a readable file: ~S" manual))
+    (open-in-browser manual))
+  (void))
 
 
 #|

--- a/lib/boot.stk
+++ b/lib/boot.stk
@@ -246,6 +246,38 @@
 (compiler-current-module (current-module))
 
 ;; ----------------------------------------------------------------------
+;;      Tries to define (default-browser) and (manual-path)
+;; ----------------------------------------------------------------------
+
+(define default-browser (make-parameter #f))
+(define manual-path     (make-parameter #f))
+(define available-browsers (make-parameter
+                            '("lynx"
+                              "links"
+                              "w3m"
+                              "firefox"
+                              "chromium"
+                              "chrome")))
+
+(when (member (os-name) '("Linux")) ; others?
+  (let ((tentative-path (string-append (%library-prefix)
+                                       "/share/doc/stklos/"
+                                       (short-version)
+                                       "/html/stklos-ref.html")))
+    (when (and (file-is-regular? tentative-path)
+               (file-is-readable? tentative-path))
+      (manual-path tentative-path)))
+  (let ((path (string-split (get-environment-variable "PATH") ":")))
+    (call/ec
+     (lambda (out!)
+       (for-each (lambda (browser)
+                   (let ((x (find-path browser path)))
+                     (when x (begin
+                               (default-browser x)
+                               (out!)))))
+                 (available-browsers))))))
+
+;; ----------------------------------------------------------------------
 ;;      option analysis and REPL launching
 ;; ----------------------------------------------------------------------
 (let ((no-init (key-get *%system-state-plist* :no-init-file #f))


### PR DESCRIPTION
Hi @egallesio !

This is probably not good, since it includes some fluff in the boot file, and I have written it without thinking about portability or error handling at all... But it's an idea for the future (post-2.0). :)  Maybe we can enhance this.

Some Scheme implementations (Gauche and Gambit) will call an external pager for the user to read the manual. This patch brings something similar to STklos.

Added parameters:

* `(default-browser)` is a string with the full path of the browser to be used.

* `(available-browsers)` is a list of possible browsers (strings with executable names), that will be searched in the system `PATH` at boot time.

* `(manual-path)` is the full path to the STklos manual. At boot time, this is searched in
```
   (string-append
     (%library-prefix)
     "/share/doc/stklos/"
     (short-version)
     "/html/stklos-ref.html")
```

Two procedures are added in `bonus.stk`:

* `(open-in-browser url)`
Opens the URL given by the string `url` in the default browser, which is determined by the string contained in the parameter `default-browser`.

* `(manual)`
Opens the STklos manual in a browser.
