### PR TITLE
(tiny fix) set names of two procedures

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1183,7 +1183,12 @@ doc>
   (set! base64-encode-string
         (encode/decode base64-encode 'base64-encode-string))
   (set! base64-decode-string
-        (encode/decode base64-decode 'base64-decode-string)))
+        (encode/decode base64-decode 'base64-decode-string))
+  ;; Can't use the keyword inside lambda to set the procedure names, because
+  ;; it's a single lambda for both procedures, so we force it here with
+  ;; %set-procedure-name!
+  (%set-procedure-name! base64-encode-string 'base64-encode-string)
+  (%set-procedure-name! base64-decode-string 'base64-decode-string))
 
 ;; ======================================================================
 ;;      md5sum ...


### PR DESCRIPTION
`base64-decode-string` and `base64-encode-string` had no names.  We can't use the `(lambda (...) #:name ...)` method, since it's a single lambda defining both procedures, so we force the name with `%set-procedure-name!`.