### PR TITLE
Add SRFI 232 - Flexible Curried Procedures

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -133,6 +133,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-228: A further comparator library
     - SRFI-229: Tagged Procedures
     - SRFI-230: Atomic Operations
+    - SRFI-232: Flexible Curried Procedures
     - SRFI-233: INI files
     - SRFI-235: Combinators
     - SRFI-236: Evaluating expressions in an unspecified order

--- a/lib/srfi/232.stk
+++ b/lib/srfi/232.stk
@@ -1,0 +1,108 @@
+;;;; 232.stk         -- SRFI 232 Flexible curried procedures.
+;;;;                    Adapted for STklos
+;;;;
+;;;; Copyright © 2023 Jeronimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 2 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jeronimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date: 01-Sep-2023 18:05
+;;;;
+;;;; This program uses the reference implementation of the SRFI by
+;;;; Wolfgang Corcoran-Mathe, which is copyrighted as:
+;;;;
+;;;
+;;; (C) 2022 Wolfgang Corcoran-Mathe
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation files
+;;; (the "Software"), to deal in the Software without restriction,
+;;; including without limitation the rights to use, copy, modify, merge,
+;;; publish, distribute, sublicense, and/or sell copies of the Software,
+;;; and to permit persons to whom the Software is furnished to do so,
+;;; subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice (including the
+;;; next paragraph) shall be included in all copies or substantial
+;;; portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;;; SOFTWARE.
+
+
+(define-module (srfi 232)
+  (export curried
+          curried-1
+          one-or-more
+          rest-args
+          define-curried
+          more-args)
+   (import (scheme base)
+           (scheme case-lambda))
+
+(define-syntax curried
+  (syntax-rules ()
+    ((curried formals exp ...)
+     (curried-1 formals (begin exp ...)))))
+
+(define-syntax curried-1
+  (syntax-rules ()
+    ((curried-1 () exp) exp)
+    ((curried-1 (arg0 arg1 ...) exp)
+     (one-or-more (arg0 arg1 ...) exp))
+    ((curried-1 (arg0 arg1 ... . rest) exp)
+     (rest-args (arg0 arg1 ... . rest) exp))
+    ((curried-1 args exp) (lambda args exp))))
+
+(define-syntax one-or-more
+  (syntax-rules ()
+    ((one-or-more (arg0 arg1 ...) exp)
+     (letrec
+      ((f (case-lambda
+            (() f)       ; app. to no args -> original function
+            ((arg0 arg1 ...) exp)
+            ((arg0 arg1 ... . rest)
+             (apply (f arg0 arg1 ...) rest))
+            (args (more-args f args)))))
+       f))))
+
+(define-syntax rest-args
+  (syntax-rules ()
+    ((rest-args (arg0 arg1 ... . rest) exp)
+     (letrec ((f (case-lambda
+                   (() f)
+                   ((arg0 arg1 ... . rest) exp)
+                   (args (more-args f args)))))
+       f))))
+
+(define (more-args f current)
+  (lambda args (apply f (append current args))))
+
+(define-syntax define-curried
+  (syntax-rules ()
+    ((define-curried (var . formals) exp ...)
+     (define var
+       (curried formals exp ...)))))
+)
+
+(provide "srfi-232")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -140,6 +140,7 @@ SRC_STK   = 1.stk   \
             228.stk \
             229.stk \
             230.stk \
+            232.stk \
             233.stk \
             235.stk \
             236.stk \
@@ -252,6 +253,7 @@ SRC_OSTK =  1.ostk   \
             228.ostk \
             229.ostk \
             230.ostk \
+            232.ostk \
             233.ostk \
             235.ostk \
             236.ostk \

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -504,6 +504,7 @@ SRC_STK = 1.stk   \
             228.stk \
             229.stk \
             230.stk \
+            232.stk \
             233.stk \
             235.stk \
             236.stk \
@@ -616,6 +617,7 @@ SRC_OSTK = 1.ostk   \
             228.ostk \
             229.ostk \
             230.ostk \
+            232.ostk \
             233.ostk \
             235.ostk \
             236.ostk \

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -270,7 +270,7 @@
     (229 "Tagged Procedures" () "srfi-229")
     (230 "Atomic Operations" () "srfi-230")
     ;; 231 Intervals and Generalized Arrays (Updated^2)
-    ;; 232 Flexible Curried Procedures
+    (232 "Flexible Curried Procedures" () "srfi-232")
     (233 "INI files" (ini-files) "srfi-233")
     ;; 234 Topological sorting (draft)
     (235 "Combinators" (combinators) "srfi-235")

--- a/tests/srfis/232.stk
+++ b/tests/srfis/232.stk
@@ -1,0 +1,41 @@
+;; "Simple currying"
+  (test "srfi-232.1" 5 ((curried (x y) (+ x y)) 2 3))
+  (test "srfi-232.2" 5 (((curried (x y) (+ x y)) 2) 3))
+  (test "srfi-232.3" 5 ((curried (w x y z) (+ w x y z)) 1 1 1 2))
+  (test "srfi-232.4" 5 ((((curried (w x y z) (+ w x y z)) 1) 1) 1 2))
+  (test "srfi-232.5" 5 (((curried (w x y z) (+ w x y z)) 1) 1 1 2))
+  (test "srfi-232.6" 5 (((curried (w x y z) (+ w x y z)) 1 1) 1 2))
+  (test "srfi-232.7" 5 (((curried (w x y z) (+ w x y z)) 1 1 1) 2))
+  (test "srfi-232.8" 5 (((((curried (w x y z) (+ w x y z)) 1) 1) 1) 2))
+
+
+;; "Variadic"
+  (test "srfi-232.9"
+        '(3 (3 4))
+        ((curried (a b . rest) (list (+ a b) rest)) 1 2 3 4))
+  (test "srfi-232.10"
+        '(3 (3 4))
+        (((curried (a b . rest) (list (+ a b) rest)) 1) 2 3 4))
+  (test  "srfi-232.11"
+        '(3 ())
+        ((curried (a b . rest) (list (+ a b) rest)) 1 2))
+
+
+;; "Nullary"
+  (test "srfi-232.12" 3 ((curried () (curried (x y) (+ x y))) 1 2))
+  (test "srfi-232.13" 3 (((curried () (curried (x y) (+ x y))) 1) 2))
+
+  ;; "... while these behaviors are decidedly not wrong, they are
+  ;;  perhaps mildly unsettling."
+  (test "srfi-232.14"
+        2
+        ((curried (a)
+           (curried ()
+             (curried ()
+               (curried (b) b)))) 1 2))
+  (test "srfi-232.15" 4 (((((((((curried (a b c) 4)))))))) 1 2 3))
+
+
+;; "Extra arguments"
+  (test "srfi-232.16" 20 ((curried (x y) (curried (z) (* z (+ x y)))) 2 3 4))
+  (test "srfi-232.16" 20 (((curried (x y) (curried (z) (* z (+ x y)))) 2) 3 4))


### PR DESCRIPTION
Hi @egallesio !
As I mentioned in PR #602, with a simple modification in `syntax-rules`, the reference implementation of SRFI-232 works!
Passes all tests!

*** This is based on my other branch, from #602, so it's easier to see the changes there first, I suppose.

It exports all its symbols, but currently that's the only thing we can do with macros. 
(In the future, when we make macros reference variables in their defining environment, not their expansion environment, then we could only export the right symbols)
