### PR TITLE
Fix a small glitch in `let-syntax`

### DIFF
--- a/lib/mbe.stk
+++ b/lib/mbe.stk
@@ -131,7 +131,7 @@ doc>
     (error 'letrec-syntax
       "cannot be used here. You must load the file \"full-syntax\" to access it:"
            (cons 'letrec-syntax args)))
-  
+
 
 ;;;
 ;;; Scheme utilities
@@ -625,9 +625,9 @@ doc>
 
 
 ;; find-clause will find the clause to be used in order to expand a macro.
-;; 
+;;
 ;; Example:
-;; 
+;;
 ;; (define-syntax2 f
 ;;   (syntax-rules ()
 ;;     ((f a b)   (+ a b))
@@ -663,21 +663,41 @@ doc>
 
 
 ;;
-;; A very simple implementation of let-syntax. 
+;; A very simple implementation of let-syntax.
 ;; FIXME: Need some work
 ;;
+;; Example (with alternative ellipsis symbol '===):
+;;
+;; (macro-expand '(let-syntax ((f (syntax-rules === () ((f) 10)))) (f)))
+;;
+;; =>
+;; (%let-syntax ((f (lambda args
+;;                    (%find-macro-clause 'f
+;;                                        args
+;;                                        '(f)
+;;                                        '(((f) 10)) '===))))
+;;              (f))
 (define-macro (let-syntax bindings . body)
   `(%let-syntax
     ,(map (lambda (x)
-            (let* ((macro-name (car x))
-                   (syn-rules  (cadr x))
-                   (keywords   (cons macro-name (cadr syn-rules)))
-                   (clauses    (cddr syn-rules)))
-              `(,macro-name (lambda args
-                              (%find-macro-clause ',macro-name
-                                                  args
-                                                  ',keywords
-                                                  ',clauses)))))
+            (let ((macro-name (car x))
+                  (syn-rules  (cadr x)))
+              (let ((alt-ellipsis? (not (list? (cadr syn-rules)))))
+                (let ((ellipsis (if alt-ellipsis?
+                                    (cadr syn-rules)
+                                    '...))
+                      (keywords (if alt-ellipsis?
+                                    (cons macro-name (caddr syn-rules))
+                                    (cons macro-name (cadr syn-rules))))
+                      (clauses  (if alt-ellipsis?
+                                    (cdddr syn-rules)
+                                    (cddr syn-rules))))
+                  `(,macro-name (lambda args
+                                  (%find-macro-clause ',macro-name
+                                                      args
+                                                      ',keywords
+                                                      ',clauses
+                                                      ',ellipsis)))))))
           bindings)
     ,@body))
 
@@ -695,7 +715,7 @@ doc>
 ;;MAC   (if (or (not (pair? syn-rules))
 ;;MAC           (not (eq? (car syn-rules) 'syntax-rules)))
 ;;MAC     (error 'define-syntax "in `~S', bad syntax-rules ~S" macro-name syn-rules)
-;;MAC 
+;;MAC
 ;;MAC     (let ((keywords    (cons macro-name (cadr syn-rules)))
 ;;MAC           (clauses     (cddr syn-rules))
 ;;MAC           (find-clause (symbol-value 'find-clause (find-module 'MBE))))

--- a/tests/test-macros.stk
+++ b/tests/test-macros.stk
@@ -220,6 +220,10 @@
 
 (test-subsection "hygienic macros")
 
+(test "very basic let-syntax"
+      10
+      (let-syntax ((f (syntax-rules === () ((f) 10)))) (f)))
+
 (define-syntax swap!
   (syntax-rules ()
     ((_ a b)


### PR DESCRIPTION
Hi @egallesio 

This is about issue #604 --

The current `let-syntax` implementation doesn't work because it calls `%find-macro-clause` with 4 parameters, and a 5th was added.

```
stklos> (let-syntax ((f (syntax-rules () ((f) 10)))) (f))
**** Error:
find-clause: 5 arguments required in call to `#[closure find-clause]' (4 provided)
```

This patch changes `let-syntax` so it takes into account custom ellipsis symbols.