### PR TITLE
Use `~W` for general objects, not `~S`

### DIFF
--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -39,12 +39,12 @@ static void error_fx_at_least_1(void)
 
 static void error_negative_fixnum(SCM obj)
 {
-  STk_error("expected non-negative fixnum, found ~S", obj);
+  STk_error("expected non-negative fixnum, found ~W", obj);
 }
 
 static void error_bad_fxlength(SCM obj)
 {
-    STk_error("bad fixnum length ~S (should be < ~S)", obj, INT_LENGTH);
+    STk_error("bad fixnum length ~W (should be < ~S)", obj, INT_LENGTH);
 }
 
 /* used internally by the fx../carry primitives */
@@ -77,7 +77,7 @@ long exp_2_fxwidth() {
 
 static void error_bad_fixnum1(SCM o1)
 {
-  STk_error("bad fixnum ~S", o1);
+  STk_error("bad fixnum ~W", o1);
 }
 
 static void error_bad_fixnum2(SCM o1, SCM o2)
@@ -399,7 +399,7 @@ DEFINE_PRIMITIVE("fxsqrt", fxsqrt, subr1, (SCM o))
   ensure_fx(o);
   {
     long no = INT_VAL(o);
-    if (no < 0)   STk_error("non negative fixnum expected. It was: ~S", o);
+    if (no < 0)   STk_error("non negative fixnum expected. It was: ~W", o);
     long n1 = (long) sqrt((float)no);
     long n2 = no - (n1*n1);
     return STk_n_values(2,

--- a/src/fport.c
+++ b/src/fport.c
@@ -807,7 +807,7 @@ DEFINE_PRIMITIVE("%port-idle", port_idle, subr12, (SCM port, SCM val))
     /* Set the idle list to the given value. No control on the content of
      * the procedure list (must be done in Scheme)
      */
-    if (STk_int_length(val) < 0) STk_error_bad_io_param("bad list ~S", val);
+    if (STk_int_length(val) < 0) STk_error_bad_io_param("bad list ~W", val);
     PORT_IDLE(PORT_STREAM(port)) = val;
   }
   return  PORT_IDLE(PORT_STREAM(port));

--- a/src/hash.c
+++ b/src/hash.c
@@ -96,7 +96,7 @@ static unsigned long hash_scheme_string(SCM str)
   unsigned long result = 0;
   int i, l;
 
-  if (!STRINGP(str)) STk_error("bad string key ~S", str);
+  if (!STRINGP(str)) STk_error("bad string key ~W", str);
 
   string = STRING_CHARS(str);
   for (i=0, l=STRING_SIZE(str); i < l ; i++) {
@@ -377,7 +377,7 @@ void STk_hash_set_variable(struct hash_table_obj *h, SCM v, SCM value, int defin
     /* Variable already exists. Change its value*/
     if (BOXED_INFO(z) & CONS_CONST)
       if (!define) {
-        STk_error("cannot set or redefine the symbol ~S in ~S",
+        STk_error("cannot set or redefine the symbol ~W in ~S",
                   v, STk_current_module());
       }
     /* It's a redefinition, not a new binding, so we not only allow
@@ -457,7 +457,7 @@ SCM STk_hash_keys(struct hash_table_obj *h)
 \*===========================================================================*/
 static void error_bad_hash_table(SCM obj)
 {
-  STk_error("bad hash table ~S", obj);
+  STk_error("bad hash table ~W", obj);
 }
 
 static void error_hash_immutable(SCM obj)
@@ -467,12 +467,12 @@ static void error_hash_immutable(SCM obj)
 
 static void error_bad_procedure(SCM obj)
 {
-  STk_error("bad procedure ~S", obj);
+  STk_error("bad procedure ~W", obj);
 }
 
 static void error_not_present(SCM key, SCM ht)
 {
-  STk_error("entry not defined for key ~S in table ~S", key, ht);
+  STk_error("entry not defined for key ~W in table ~S", key, ht);
 }
 
 
@@ -482,9 +482,9 @@ DEFINE_PRIMITIVE("%make-hash-table", make_hash, subr2, (SCM compar, SCM hashfct)
   hash_type type = hash_general;
 
   if (STk_procedurep(compar) == STk_false)
-    STk_error("bad comparison function ~S", compar);
+    STk_error("bad comparison function ~W", compar);
   if (STk_procedurep(hashfct) == STk_false)
-    STk_error("bad hash function ~S", hashfct);
+    STk_error("bad hash function ~W", hashfct);
 
   if (BOXED_TYPE(compar) == tc_subr2) {
     /* See if comparison function is 'eq?' or 'string?'.
@@ -969,7 +969,7 @@ DEFINE_PRIMITIVE("hash-table-stats", hash_stats, subr12, (SCM ht, SCM port))
 {
   if(!HASHP(ht)) error_bad_hash_table(ht);
   if (!port) port = STk_current_output_port();
-  else if (!OPORTP(port)) STk_error("bad port ~S", port);
+  else if (!OPORTP(port)) STk_error("bad port ~W", port);
 
   hash_stats((struct hash_table_obj *) ht, port);
   return STk_void;

--- a/src/keyword.c
+++ b/src/keyword.c
@@ -34,17 +34,17 @@ static struct hash_table_obj keyword_table;     /* The keyword "obarray" */
 
 static void error_bad_keyword(SCM obj)
 {
-  STk_error("bad keyword ~S", obj);
+  STk_error("bad keyword ~W", obj);
 }
 
 static void error_bad_list(SCM obj)
 {
-  STk_error("bad list of keywords ~S", obj);
+  STk_error("bad list of keywords ~W", obj);
 }
 
 static void error_const_cell(SCM x)
 {
-  STk_error("changing the constant ~s is not allowed", x);
+  STk_error("changing the constant ~W is not allowed", x);
 }
 
 static SCM make_uninterned_keyword(const char *name)
@@ -99,7 +99,7 @@ DEFINE_PRIMITIVE("make-keyword", make_keyword, subr1, (SCM str))
     s = STRING_CHARS(str);
   else if (SYMBOLP(str))
     s = SYMBOL_PNAME(str);
-  else STk_error("~S is not a string or a symbol", str);
+  else STk_error("~W is not a string or a symbol", str);
 
   return STk_makekey(s);
 }
@@ -117,7 +117,7 @@ DEFINE_PRIMITIVE("make-keyword", make_keyword, subr1, (SCM str))
  * (keyword? '#:foo)   => #t  ; always
  * (keyword? :foo)     => #t  ; depends of keyword-colon-position
  * (keyword? foo:)     => #t  ; depends of keyword-colon-position
- * (keyword? #:foo)    => #t  ; always 
+ * (keyword? #:foo)    => #t  ; always
  * @end lisp
 doc>
  */
@@ -237,7 +237,7 @@ DEFINE_PRIMITIVE("key-set!", key_set, subr3, (SCM l, SCM key, SCM val))
  * |List| must be a list of keywords and their respective values.
  * |key-delete| remove the |key| and its associated value of the keyword
  * list. The key can be absent of the list.
- * 
+ *
  * |key-delete!| does the same job as |key-delete| by physically
  * modifying its |list| argument.
  * @lisp

--- a/src/list.c
+++ b/src/list.c
@@ -49,7 +49,7 @@ static void error_bad_list(SCM x)
 
 static void error_bad_proc(SCM x)
 {
-  STk_error("bad procedure ~S", x);
+  STk_error("bad procedure ~W", x);
 }
 
 static void error_circular_list(SCM x)
@@ -68,7 +68,7 @@ static void error_not_exact_positive(SCM x)
 }
 static void error_bad_comparison_function(SCM x)
 {
-  STk_error("bad comparison function ~S", x);
+  STk_error("bad comparison function ~W", x);
 }
 
 int STk_int_length(SCM l)
@@ -232,7 +232,7 @@ DEFINE_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name))
    * NOTE: using strings (instead of keywords) is less efficient because
    * the char * is at the end of the object. Using symbols is also fast
    * (even a bit faster, don't know why), but it is harder  to detect that
-   * that we can inline when we have (%cxr lst 'daa), because of the quote. 
+   * that we can inline when we have (%cxr lst 'daa), because of the quote.
    */
   if (KEYWORDP(name)) {
     SCM lst   = l;

--- a/src/number.c
+++ b/src/number.c
@@ -129,13 +129,13 @@ static SCM STk_complexp(SCM x);
  ******************************************************************************/
 static void error_bad_number(SCM n)
 {
-  STk_error("~S is a bad number", n);
+  STk_error("~W is a bad number", n);
 }
 
 static void error_not_a_real_number(SCM n)
 {
   if (COMPLEXP(n))
-    STk_error("~S is not a real number", n);
+    STk_error("~W is not a real number", n);
   else
     error_bad_number(n);
 }
@@ -152,27 +152,27 @@ static void error_at_least_1(void)
 
 static void error_cannot_operate(char *operation, SCM o1, SCM o2)
 {
-  STk_error("cannot perform %s on ~S and ~S", operation, o1, o2);
+  STk_error("cannot perform %s on ~W and ~W", operation, o1, o2);
 }
 
 static void error_divide_by_0(SCM n)
 {
-  STk_error("cannot divide ~S by 0", n);
+  STk_error("cannot divide ~W by 0", n);
 }
 
 static void error_incorrect_radix(SCM r)
 {
-  STk_error("base must be 2, 8, 10 or 16. It was ~S", r);
+  STk_error("base must be 2, 8, 10 or 16. It was ~W", r);
 }
 
 static void error_not_an_integer(SCM n)
 {
-  STk_error("exact or inexact integer required, got ~s", n);
+  STk_error("exact or inexact integer required, got ~W", n);
 }
 
 static void error_not_an_exact_integer(SCM n)
 {
-  STk_error("exact integer required, got ~s", n);
+  STk_error("exact integer required, got ~W", n);
 }
 
 union binary64 {


### PR DESCRIPTION
Hi @egallesio !

Error messages do not know what the object is, so they shouldn't assume it's not circular:

```scheme
(define c (list 1 2 3 4))
(set-cdr! (cdddr c) (cdr c))
(+ c)
  => loops
```
