### PR TITLE
configure: report if `asciidoctor` was found

### DIFF
--- a/configure
+++ b/configure
@@ -5072,7 +5072,7 @@ fi
 
 if test "$ASCIIDOCTOR" = "asciidoctor"
 then
-    REPORT_ASCIIDOCTOR="asciidoctor"
+    REPORT_ASCIIDOCTOR="yes"
 else
     REPORT_ASCIIDOCTOR="no (documentation will NOT be rebuilt)"
 fi

--- a/configure
+++ b/configure
@@ -5070,6 +5070,12 @@ printf "%s\n" "no" >&6; }
 fi
 
 
+if test "$ASCIIDOCTOR" = "asciidoctor"
+then
+    REPORT_ASCIIDOCTOR="asciidoctor"
+else
+    REPORT_ASCIIDOCTOR="no (documentation will NOT be rebuilt)"
+fi
 ### Checks for header files.
 
 ac_header= ac_cache=
@@ -9423,10 +9429,10 @@ echo "     Case sensitivity: " $CASE_SENSITIVE '(by default)'
 echo "Control fx parameters: " $CONTROL_FX
 echo "System libraries used: " $SYST_LIBS
 echo "   Compiled libraries: " $COMP_LIBS
+echo "          asciidoctor: " $REPORT_ASCIIDOCTOR
 echo " "
 
 echo "If this is correct, you can just type 'make' now at your shell prompt."
 echo "Otherwise, re-run 'configure' with correct options."
 echo " "
-
 

--- a/configure
+++ b/configure
@@ -9429,7 +9429,7 @@ echo "     Case sensitivity: " $CASE_SENSITIVE '(by default)'
 echo "Control fx parameters: " $CONTROL_FX
 echo "System libraries used: " $SYST_LIBS
 echo "   Compiled libraries: " $COMP_LIBS
-echo "          asciidoctor: " $REPORT_ASCIIDOCTOR
+echo "          Asciidoctor: " $REPORT_ASCIIDOCTOR
 echo " "
 
 echo "If this is correct, you can just type 'make' now at your shell prompt."

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,12 @@ AC_PROG_RANLIB
 AC_PROG_MKDIR_P
 AC_CHECK_PROG(PKGCONFIG, pkg-config, "pkg-config", "false")
 AC_CHECK_PROG(ASCIIDOCTOR, asciidoctor, "asciidoctor", "../adoc-fake.sh")
+if test "$ASCIIDOCTOR" = "asciidoctor"
+then
+    REPORT_ASCIIDOCTOR="asciidoctor"
+else
+    REPORT_ASCIIDOCTOR="no (documentation will NOT be rebuilt)"
+fi
 ### Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h malloc.h memory.h netdb.h netinet/in.h nlist.h stdlib.h string.h strings.h sys/param.h sys/socket.h sys/time.h syslog.h unistd.h execinfo.h])
 
@@ -772,9 +778,9 @@ echo "     Case sensitivity: " $CASE_SENSITIVE '(by default)'
 echo "Control fx parameters: " $CONTROL_FX
 echo "System libraries used: " $SYST_LIBS
 echo "   Compiled libraries: " $COMP_LIBS
+echo "          asciidoctor: " $REPORT_ASCIIDOCTOR
 echo " "
 
 echo "If this is correct, you can just type 'make' now at your shell prompt."
 echo "Otherwise, re-run 'configure' with correct options."
 echo " "
-

--- a/configure.ac
+++ b/configure.ac
@@ -778,7 +778,7 @@ echo "     Case sensitivity: " $CASE_SENSITIVE '(by default)'
 echo "Control fx parameters: " $CONTROL_FX
 echo "System libraries used: " $SYST_LIBS
 echo "   Compiled libraries: " $COMP_LIBS
-echo "          asciidoctor: " $REPORT_ASCIIDOCTOR
+echo "          Asciidoctor: " $REPORT_ASCIIDOCTOR
 echo " "
 
 echo "If this is correct, you can just type 'make' now at your shell prompt."

--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_CHECK_PROG(PKGCONFIG, pkg-config, "pkg-config", "false")
 AC_CHECK_PROG(ASCIIDOCTOR, asciidoctor, "asciidoctor", "../adoc-fake.sh")
 if test "$ASCIIDOCTOR" = "asciidoctor"
 then
-    REPORT_ASCIIDOCTOR="asciidoctor"
+    REPORT_ASCIIDOCTOR="yes"
 else
     REPORT_ASCIIDOCTOR="no (documentation will NOT be rebuilt)"
 fi


### PR DESCRIPTION
Hi @egallesio !
I'm not an expert in autotools, so maybe there's a more elegant way to do this. Anyway, it would be nice to tell the user in the configure summary if `asciidoctor` was not found...

It won't complain or say anything if ruby-rouge is not installed, but it's already better than not saying anything at all...

```
SUMMARY
*******
               System:  Linux-6.5.0-1-amd64
              OS nick:  LINUX_6_5
              OS type:  unix
       Install prefix:  /usr/local
           C compiler:  gcc
    Compilation flags:  -g -O2
               Loader:  ld
       Thread support:  pthreads
     Case sensitivity:  true (by default)
Control fx parameters:  yes
System libraries used:  libffi libpcre2 libgmp libgc
   Compiled libraries:
          asciidoctor:  no (documentation will NOT be rebuilt)
```