### PR TITLE
Compute exact `log` when base is a power of 2 (also faster)

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3603,8 +3603,8 @@ SCM my_log2(SCM x, SCM b) {
         unsigned long pwr = base;
 
         long xx = INT_VAL(x);
-        if (power_of_2_p(xx) && xx < base)
-          return div2(MAKE_INT(1), my_log2(b,x));
+        if (power_of_2_p(xx) && base > 2)
+          return div2(my_log2(x,MAKE_INT(2)), my_log2(b,MAKE_INT(2)));
 
         int pos = (xx > 0);
 

--- a/src/number.c
+++ b/src/number.c
@@ -74,7 +74,8 @@ struct bignum_obj {
 
 /*==============================================================================*/
 
-#define MY_PI           3.1415926535897932384626433832795029L  /* pi */
+//#define MY_PI           3.1415926535897932384626433832795029L  /* pi */
+#define MY_PI      3.1415926535897932384626433832795028841971693993751058209749445923078164062862090L
 
 #define BIGNUM_FITS_INTEGER(_bn) (mpz_cmp_si((_bn), INT_MIN_VAL) >= 0 &&        \
                                   mpz_cmp_si((_bn), INT_MAX_VAL) <= 0)
@@ -222,7 +223,7 @@ int STk_isnan(SCM z) {
 
 double STk_dbl_true_min(void) /* return (or compute) DBL_TRUE_MIN */
 {
-  /* 
+  /*
    This function is used here in order to calculate a rational epsilon (for
    square roots) and also in the (scheme flonum) library.
 
@@ -2279,7 +2280,7 @@ SCM STk_sub2(SCM o1, SCM o2)
   if (INTP(o1)  && INT_VAL(o1)==0 &&
       REALP(o2) && fpclassify(REAL_VAL(o2)) == FP_ZERO)
     return double2real(-REAL_VAL(o2));
-  
+
   switch (convert(&o1, &o2)) {
     case tc_bignum:
       {
@@ -3573,9 +3574,95 @@ transcendental(atanh)
 
 /*=============================================================================*/
 
+SCM my_log2(SCM x, SCM b) {
+  /* my_log2 has fast path for taking logs of fixnums, bignums and
+     exact rationals in base two.  It uses a simple trick to extend
+     this to "base which is power of two". */
+  
+  if (b == MAKE_INT(1)) STk_error("cannot take log in base 1");
+
+  if (INTP(b)) {
+    /* Fast path for base two. When the number is negative, we compute
+       the exact log, and make a complex number with an exact real part,
+       and an inexact imaginary part (equal to pi/log(b) ).    */
+    
+    /* Find if b is a small power of two.
+       By "small" power of two we mean k up to 5 */
+    int power_of_2 = 0;
+    long base = INT_VAL(b);
+    for (int i=1; i <= 5; i++)
+      if (base == (1 << i)) {
+        power_of_2 = 1;
+        break;
+      }
+    
+    if (power_of_2) {
+      switch (TYPEOF(x)) {
+      case tc_integer: {
+        unsigned long pwr = base;
+        long xx = INT_VAL(x);
+        int pos = (xx > 0);
+
+        /* Explicitly check for +-1, so we give an exact result in these cases: */
+        if (xx == 1)  return MAKE_INT(0);
+        if (xx == -1) return Cmake_complex(MAKE_INT(0),double2real(MY_PI/log(base)));
+        
+        xx = labs(xx);
+        if (xx == 0) STk_error("cannot take log of zero");
+        /* Linear search for the wanted power... */
+        for (int i=1; i < INT_LENGTH; i++, pwr *= base) {
+          if (xx == pwr)
+            /* If the number is negative, we return the same
+               result, but with an imaginary part equal to
+               PI/log(base). */
+            return pos
+              ? MAKE_INT(i)
+              : Cmake_complex(MAKE_INT(i),double2real(MY_PI/log(base)));
+        }
+        break;
+      }
+      case tc_bignum: {
+        if (base <= 62) { /* This is a GMP limitation */
+          mpz_t *xx = &BIGNUM_VAL(x);
+          mpz_t r;
+          mpz_init(r);
+          int sgn = mpz_sgn(*xx);
+          /* mpz_sizeinbase returns log(xx) in base two plus one, if it's
+             exact: */
+          unsigned long s = mpz_sizeinbase(*xx,base);
+          if (s != 1) {
+            mpz_ui_pow_ui(r, base, (s-1));
+            /* Now, is s-1 the exact log of xx in base 2 ? */
+            if (!mpz_cmpabs(r,*xx)) {
+              /* If the number is negative, we return the same
+               result, but with an imaginary part equal to
+               PI/log(base). */
+              mpz_clear(r);
+              return (sgn>0)
+                ? MAKE_INT(s-1)
+              : Cmake_complex(MAKE_INT(s-1),double2real(MY_PI/log(base)));
+            }
+          }
+          mpz_clear(r);
+          /* If not, do the floating-point work after the switch... */
+        }
+        break;
+      }
+      case tc_rational:
+        /* Do log(a/b) = log(a)/log(b).
+           This allows us to give exact answers to (log 1/32 2),
+           for example! */
+        return sub2(my_log2(RATIONAL_NUM(x),b),
+                    my_log2(RATIONAL_DEN(x),b));
+      }
+    }
+  }
+  return div2(my_log(x),my_log(b));
+}
+
 DEFINE_PRIMITIVE("log", log, subr12, (SCM x, SCM b))
 {
-    return (b)? div2(my_log(x),my_log(b)) : my_log(x);
+    return (b)? my_log2(x,b) : my_log(x);
 }
 
 

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1558,11 +1558,11 @@
          (/ (log 3) (log 4))))
 
 (test "log 16 2"
-      4.0
+      4
       (log 16 2))
 
 (test "log 1/4 2"
-      -2.0
+      -2
       (log 1/4 2))
 
 (test "log 2 10"
@@ -1570,6 +1570,15 @@
       (< 0.30102000
          (log 2 10)
          0.30103000))
+
+(test "log -64 4 re"
+      3
+      (real-part (log -64 4)))
+(test "log -64 4 im"
+      #t
+      (< 2.26618
+         (imag-part (log -64 4))
+         2.26619))
 
 (test "log 3-5i"
       #t
@@ -1634,9 +1643,12 @@
           (<  2079.44154160000 z 2079.44154170000)))
 
   (test "log_2 2^4000"
-        #t
-        (let ((z (log (expt 2 4000) 2)))
-          (< 3999.9999999 z 4000.0000001)))
+        4000
+        (log (expt 2 4000) 2))
+
+  (test "log_4 4^4000"
+        4000
+        (log (expt 4 4000) 4))
 
   (test "log 10^3000 / 3"
         #t
@@ -1648,6 +1660,12 @@
         (let ((z (log (/ (expt 2 3000) (expt 3 2500)))))
           (<  -667.089180 z -667.089179)))
   )
+
+(dotimes (base 3)
+  (dotimes (x 1000)
+    (test "logs"
+          x
+          (log (expt (expt 2 (+ base 1)) x) (expt 2 (+ base 1))))))
 
 ;; sin, cos
 
@@ -2206,7 +2224,7 @@
 (test "read a 9000 digits bignum (see Issue #592)"
       #t
       (= (with-input-from-string
-             (with-output-to-string 
+             (with-output-to-string
                (lambda () (display (expt 2 30000))))
            (lambda () (read)))
          (expt 2 30000)))


### PR DESCRIPTION
Create a `my_log2` C function, that deals with logs of exact powers of 2. This will give us exact results when the number is exact and the base is a small power of two:

```scheme
(log (expt 8 21) 8) => 21
(log (expt 2 10) 2) => 10
(log 1/4 2)         => -2
(log -4 2)          => 2+4.53236014182719i
```

In the last example, we got an _exact_ real part.

Roughly,
* For fixnums, compare to the known possible powers of two (there are not too many of them anyway)
* For bignums, use `mpz_sizeinbase`
* For rationals, do $\log(x/y) = \log(x) - \log(y)$. This allows us to give exact answers to `(log 1/64 4)`.

But additionally,

* If the base itself is a small power of two, we try to get an exact result anyway: use it in `mpz_sizeinbase` for bignums and use it (the base) to check for known powers for fixnums
* If the number is negative, return a complex with an imaginary part equal to $\pi/\log(base)$

This seems faster than the previous code, in particular when the first argument is a fixnum (but there seems to also be some speedup for bignums). Some timings:

```scheme
(define a  #f)

(define y (expt 4 50))
(time (repeat 50000000 (set! a (log y 4))))
;; current code  7019.777 ms
;; new code      4276.111 ms

(define y (expt 16 100))
(time (repeat 50000000 (set! a (log y 16))))
;; current code 6961.37 ms
;; new code     4384.379 ms

(define y (expt 2 500))
(time (repeat 50000000 (set! a (log y 2))))
;; current code     6929.235 ms
;; new code         4639.744 ms

(define x (expt 4 20))
(time (repeat 50000000 (set! a (log x 4))))
;; current code 6385.002 ms
;; new code     1645.658 ms

(define x (expt 2 50))
(time (repeat 50000000 (set! a (log x 2))))
;; current code 6365.162 ms
;; new code     2401.009 ms
```
