### PR TITLE
Respect LDFLAGS

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -193,12 +193,6 @@ lib/stklos: lib
 lib/streams: lib
 lib/srfi: lib/scheme lib/stklos lib/streams
 
-readline-complete.@SH_SUFFIX@: readline-complete.c
-	@CC@ @CFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ -I../src @GCINC@ \
-	-c -o $*.o $*.c
-	@SH_LOADER@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@ @RDLINE@
-	/bin/rm -f $*.o
-
 #
 # SRFIs support
 #


### PR DESCRIPTION
The Makefile has a rule for `.c.@SH_SUFFIX@`, which includes `@LDFLAGS@`.