### PR TITLE
Customize `class-of` and `describe` for bitvectors

### DIFF
--- a/lib/srfi/178.stk
+++ b/lib/srfi/178.stk
@@ -109,6 +109,18 @@
                       list->bitvector
                       reverse-list->bitvector)
 
+;; Customize "describe"
+(%user-type-proc-set! 'bitvector 'describe
+                      (lambda (x port)
+                        (format port "a bitvector of length ~A"
+                                (bitvector-length x))))
+;; Customize "class-of"
+(define-class <bitvector> (<top>) ())
+(export <bitvector>)
+
+
+(%user-type-proc-set! 'bitvector 'class-of <bitvector>)
+
 (define (bitvector . args)
   (list->bitvector args))
 

--- a/tests/srfis/178.stk
+++ b/tests/srfis/178.stk
@@ -908,7 +908,31 @@
 
 )
 
+;; EXTRA TESTS
+;; -- jpellegrini
 
+(define (extra-tests)
+  (print-header "Extra bitvector type tests...")
+  ;; class-of should not segfault, and the class of all bitvectors
+  ;; should be the same
+  (test "class-of.1"
+        #t
+        (eq?  (class-of (read-from-string "#*"))
+              (class-of (read-from-string "#*1"))))
+  (test "class-of.2"
+        #t
+        (eq?  (class-of (read-from-string "#*0"))
+              (class-of (bitvector #t #t))))
+  (test "class-of.3"
+        #t
+        (eq?  (class-of (read-from-string "#*"))
+              (class-of (read-from-string "#*1"))))
+
+  ;; describe should not segfault
+  (test "describe"
+        #t
+        (string? (with-output-to-string
+                   (lambda () (describe (read-from-string "#*")))))))
 
 ;;;;;;;;;;;;
 ;;  TEST  ;;
@@ -926,7 +950,8 @@
   (check-bitwise-operations)
   (check-quasi-integer-operations)
   (check-bit-field-operations)
-  (check-sharp-reader))
+  (check-sharp-reader)
+  (extra-tests))
 )
 
 (select-module test-srfi-178)


### PR DESCRIPTION
```
stklos> (import (srfi 178))
stklos> #*11
stklos> (class-of #*11)

Program received signal SIGSEGV, Segmentation fault.
```

This is because `#*11` is of a type which is only defined in `srfi-178.c`, and `object.c` can't tell what it is.

We do as we did in SRFI 25, and customize `class-of` and `describe` for bitvectors.