### PR TITLE
Make `(acos 1)` return exact zero

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3270,8 +3270,7 @@ static SCM acos_real(double d)
 static SCM my_acos(SCM z)
 {
   switch (TYPEOF(z)) {
-    case tc_integer:  if (z == MAKE_INT(0)) return div2(double2real(MY_PI),
-                                                        MAKE_INT(2));
+   case tc_integer:   if (z == MAKE_INT(1)) return MAKE_INT(0);
                       return acos_real(INT_VAL(z));
     case tc_bignum:   return acos_real(scheme_bignum2double(z));
     case tc_rational: return acos_real(rational2double(z));

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1806,7 +1806,7 @@
          (sin (asin 2/3))))
 
 (test "cos-acos 1"
-      1.0
+      1
       (cos (acos 1)))
 
 (test "cos-acos 2/3"


### PR DESCRIPTION
Previously we had

```
stklos> (acos 1)
0.0
stklos> (asin 0)
0
```

Hm, we have anice precise result for `(asin 0)`, why not for
`(acos 1)`?   It's because for asin, we have:

```
    case tc_integer:  if (z == MAKE_INT(0)) return MAKE_INT(0);
                      return asin_real(INT_VAL(z));
```

and for acos, we were also testing for exact zero, and then we returned inexact pi/2:

```
    case tc_integer:  if (z == MAKE_INT(0)) return div2(double2real(MY_PI),
                                                        MAKE_INT(2));
```

But that's not necessary, because `acos_real` will do that anyway. And we were not testing for the nice case of `(acos 1)`. Now we do that.

One test was also adjusted.