### PR TITLE
Fix `(atan 0.0 0)` => +pi/2

### DIFF
--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1858,6 +1858,22 @@
          (atan 1 1)
          0.7853982000))
 
+(test/error "angle zero, I"  (angle 0))
+
+;; The following tests are borrowed from Gauche:
+(let ((pi 3.141592653589793115997963468544185161590576171875))
+  (test "atan +0.0 +x"    +0.0     (atan 0.0 1))
+  (test "atan -0.0 +x" -0.0        (atan -0.0 1))
+  (test "atan +0.0 -x" pi          (atan +0.0 -1))
+  (test "atan -0.0 -x" (- pi)      (atan -0.0 -1))
+  (test "atan +0.0 +0.0" +0.0      (atan +0.0 +0.0))
+  (test "atan -0.0 +0.0" -0.0      (atan -0.0 +0.0))
+  (test "atan +0.0 -0.0" pi        (atan +0.0 -0.0))
+  (test "atan -0.0 -0.0" (- pi)    (atan -0.0 -0.0))
+  (test "atan +0.0 0" (/ pi 2)     (atan +0.0 0))
+  (test "atan -0.0 0" (- (/ pi 2)) (atan -0.0 0))
+  (test "atan 0 0" #t (nan? (atan 0 0))))
+
 ;; tan, atan
 
 (test "atan tan 2/3"


### PR DESCRIPTION
And also `(atan -0.0 0)` => $-\pi/2$

This is explicitly given as a corner case in R7RS (in the table in the section for trigonometric procedures).

We also make `(angle 0)` trigger an error, since this would have to be exactly the same as `(atan (/ 0 0))`, which can't be computed.

Interestingly, only Chez does trigger the same error (for "`(angle 0)`"), but it is conceptually the right thing to do.

Tests included.