### PR TITLE
Make `(log 1 x)` return exact zero

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3620,6 +3620,10 @@ SCM my_log2(SCM x, SCM b) {
      this to "base which is power of two". */
 
   if (b == MAKE_INT(1)) STk_error("cannot take log in base 1");
+  if (b == MAKE_INT(0)) STk_error("cannot take log in base 0");
+  /* And now that we checked that the base is neither 0 nor 1: */
+  if (x == MAKE_INT(1))  return MAKE_INT(0);
+
   long base = INT_VAL(b);
 
   if (INTP(b)) {

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1680,6 +1680,26 @@
                      (> (expt B (+ 1 l)) N))))))))
 
 
+(test "log 1" 0 (log 1 2))
+(test "log 1" 0 (log 1 3))
+(test "log 1" 0 (log 1 -2))
+(test "log 1" 0 (log 1 -3))
+(test "log 1" 0 (log 1 (expt 2 300)))
+(test "log 1" 0 (log 1 (- (expt 2 300))))
+(test "log 1" 0 (log 1 (inexact (expt 2 300))))
+(test "log 1" 0 (log 1 (inexact (- (expt 2 300)))))
+(test "log 1" 0 (log 1 2.0))
+(test "log 1" 0 (log 1 3.0))
+(test "log 1" 0 (log 1 -2.0))
+(test "log 1" 0 (log 1 -3.0))
+(test "log 1" 0 (log 1 (/ 1 (expt 2 300))))
+(test "log 1" 0 (log 1 (/ 1 (- (expt 2 300)))))
+(test "log 1" 0 (log 1 (inexact (/ 1 (expt 2 300)))))
+(test "log 1" 0 (log 1 (inexact (/ 1 (- (expt 2 300))))))
+
+(test/error "log 1 0" (log 1 0))
+(test/error "log 1 1" (log 1 1))
+
 ;; exp, log
 
 (test "exp log 1.0"


### PR DESCRIPTION
Hi @egallesio !
One more small change:  for `(log 1 x)`, if x is neither 0 nor 1, we could just return exact zero...