### PR TITLE
Small enhancement to message

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -911,7 +911,7 @@ doc>
            (eprintf ";    Elapsed time: ~S ms\n"
                     (/ (- (exact-clock) ,time-start) 1000.0))
            (eprintf ";    Allocations: ~S byte~A in ~S allocation call~A (GC: ~A)\n"
-                    ,bytes (if (> ,bytes 1) "s" "") ,allocs (if (> ,allocs 1) "s" "")
+                    ,bytes (if (= ,bytes 1) "" "s") ,allocs (if (= ,allocs 1) "" "s")
                     (- (key-get (%gc-stats) #:gc-no 0) ,gc-no))
            (%count-allocations ,counting?)       ;; restore save state
            ,res)))))                             ;; return computed result


### PR DESCRIPTION
Now we also use plural for zero: "zero bytes" and "zero allocation calls"...

```
stklos> (time 1)
;    Elapsed time: 0.016 ms
;    Allocations: 0 bytes in 0 allocation calls (GC: 0)
1
stklos> (time (list 1 2 3 4))
;    Elapsed time: 0.007 ms
;    Allocations: 96 bytes in 4 allocation calls (GC: 0)
(1 2 3 4)
stklos> (time (list 1))
;    Elapsed time: 0.004 ms
;    Allocations: 24 bytes in 1 allocation call (GC: 0)
(1)
```

But we use singular for one, as in the last example (one "allocation call").