### PR TITLE
Enhancement to error message

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1219,15 +1219,18 @@ doc>
 doc>
 |#
 (define (%make-inc-dec-push-body place func val)
-  (if (symbol? place)
-      ;; simple xxx! on a variable
-      `(set! ,place (,func ,val ,place))
-      ;; Generalized xxx!. Do not evaluate arguments two times
-      (let ((vars (map (lambda (x) (list (gensym) x)) place)))
-        `(let ,vars
-           ((setter ,(caar vars))
-            ,@(map car (cdr vars))
-            (,func ,val ,(map car vars)))))))
+  (cond ((symbol? place)
+         ;; simple xxx! on a variable
+         `(set! ,place (,func ,val ,place)))
+         ;; Generalized xxx!. Do not evaluate arguments two times
+        ((list? place)
+         (let ((vars (map (lambda (x) (list (gensym) x)) place)))
+           `(let ,vars
+              ((setter ,(caar vars))
+               ,@(map car (cdr vars))
+               (,func ,val ,(map car vars))))))
+        (else (error "bad place ~w: it is neither a symbol (variable name) nor a list (generalized variable)"
+                     place))))
 
 (define-macro (push! place val)
   (%make-inc-dec-push-body place 'cons val))


### PR DESCRIPTION
Before, we had:

```
stklos> (inc! "abc")
**** Error:
map: malformed list `"abc"'
```

Now we have:

```
stklos> (inc! "abc")
**** Error:
error: bad place "abc": it is neither a symbol (variable name) nor a list (generalized variable)
```

Of course this is not enough to make everything clear all the times, but it's better...