### PR TITLE
Add `improper-list?`

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -25,6 +25,7 @@
 
 (export read-chars read-chars! display-shared gensym
         macro-expand macro-expand*
+        improper-list?
         remove remove! delete delete!
         every any
         call-with-input-string call-with-output-string
@@ -156,6 +157,32 @@ doc>
     (if (equal? new exp)
         exp
         (macro-expand* new))))
+
+;;;
+;;; List functions
+;;;
+
+#|
+<doc EXT improper-list?
+ * (improper-list? obj)
+ *
+ * Returns false if and only if |obj| is an improper list.
+ * @lisp
+ * (improper-list? 2)            => #f
+ * (improper-list? '())          => #f
+ * (improper-list? '(1 2 3))     => #f
+ * (improper-list? '(1 2 . 3))   => #t
+ * (improper-list? (cons 'a 'b)) => #t
+ * (improper-list? (list 1 2))   => #f
+ * (improper-list? #void)        => #f
+ * @end lisp
+doc>
+|#
+
+(define (improper-list? lst)
+  (and (pair? lst)
+       (not (list? lst))))
+
 
 #|
 <doc EXT remove remove!

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -89,6 +89,10 @@ b|)
 ;;----------------------------------------------------------------------
 (test-subsection "bonus.stk")
 
+(test "improper-list?"
+      '(#f #f #f #t #t #f #f)
+      (map improper-list? (list 2 '() '(1 2 3) '(1 2 . 3) (cons 'a 'b) (list 1 2) #void)))
+
 (let ((fct  (lambda (x y) (and (even? x) (even? y) (+ x y)))))
   (test "every.1"
         1
@@ -495,7 +499,7 @@ b|)
           (begin (inc! (car l) 42) vec))
     (test "generalized dec!.4" #(-1 2 (45 4))
           (begin (dec! (vector-ref vec 0) 2) vec))))
- 
+
 ;;----------------------------------------------------------------------
 (test-subsection "dolist")
 


### PR DESCRIPTION
Not sure if this reeeealy is interesting, but here it is: it can be useful to make code clearer -- instead of

```scheme
(and (pair? x) (not (list? x)))
```

we can write

```scheme
(improper-list? x)
```