### PR TITLE
Add `--without-keep-formals` option to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -481,6 +481,29 @@ else
     CONTROL_FX_PARAMETERS=0
 fi
 
+# -----------------------------------------------------------------------
+# Should the compiler keep the formal parameters of procedures in core
+# and libraries?
+# -----------------------------------------------------------------------
+AC_ARG_WITH(keep-formals,
+       [  --without-keep-formals  don't keep formal parameters of closures when compiling
+                          procedures in core and libraries (this does not affect compilation of closures
+                          done by the user later, the effect is to have them for out-of-the-box STklos
+                          closures. Formal parameters of primitive procedures are never kept, regardless
+                          of this option)],
+       DONT_KEEP_FORMALS="$withval", DONT_KEEP_FORMALS="no")
+
+if test "$DONT_KEEP_FORMALS" = "yes"
+then
+    STR_KEEP_FORMALS="no"    # for output at the end of this script
+    KEEP_FORMALS=0           # for tmpcomp (and in the future, C files)
+    SCM_BOOT_KEEP_FORMALS="" # for the Makefile compiling the boot image
+else
+    STR_KEEP_FORMALS="yes"
+    KEEP_FORMALS=1
+    SCM_BOOT_KEEP_FORMALS="--compiler-flags='+keep-formals'"
+fi
+
 ###
 ### See in what direction the stack grows (code stolen from Sawfish)
 ###
@@ -712,6 +735,8 @@ AC_SUBST(THREADS)
 AC_SUBST(CONF_SUMMARY)
 AC_SUBST(DEFAULT_CS)
 AC_SUBST(CONTROL_FX_PARAMETERS)
+AC_SUBST(KEEP_FORMALS)
+AC_SUBST(SCM_BOOT_KEEP_FORMALS)
 AC_SUBST(DLLIBS)
 AC_SUBST(SYST_LIBS)
 AC_SUBST(COMP_LIBS)
@@ -787,6 +812,7 @@ echo "               Loader: " $LD
 echo "       Thread support: " $THREADS
 echo "     Case sensitivity: " $CASE_SENSITIVE '(by default)'
 echo "Control fx parameters: " $CONTROL_FX
+echo "         Keep formals: " $STR_KEEP_FORMALS
 echo "System libraries used: " $SYST_LIBS
 echo "   Compiled libraries: " $COMP_LIBS
 echo " Documentation update: " $REPORT_ASCIIDOCTOR

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -140,16 +140,16 @@ generate-git-info:
 ../src/boot.img: $(scheme_BOOT)
 	@echo "*** Boot 0"; \
 	(export STKLOS_BUILDING=1; \
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -f bb.stk boot.img0 instr0)
+	$(STKLOS_BINARY) $(STKLOS_FLAGS)  @SCM_BOOT_KEEP_FORMALS@ -f bb.stk boot.img0 instr0)
 	@echo "*** Boot 1"; \
 	(export STKLOS_BUILDING=1; \
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ./boot.img0     -f bb.stk boot.img1 instr1)
+	$(STKLOS_BINARY) $(STKLOS_FLAGS)  @SCM_BOOT_KEEP_FORMALS@ -b ./boot.img0     -f bb.stk boot.img1 instr1)
 	@echo "*** Boot 2"; \
 	(export STKLOS_BUILDING=1; \
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ./boot.img1    -f bb.stk boot.img2 instr2)
+	$(STKLOS_BINARY) $(STKLOS_FLAGS)  @SCM_BOOT_KEEP_FORMALS@ -b ./boot.img1    -f bb.stk boot.img2 instr2)
 	@echo "*** Boot 3"; \
 	(export STKLOS_BUILDING=1; \
-	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ./boot.img2     -f bb.stk boot.img3 instr3)
+	$(STKLOS_BINARY) $(STKLOS_FLAGS)  @SCM_BOOT_KEEP_FORMALS@ -b ./boot.img2     -f bb.stk boot.img3 instr3)
 	@if cmp ./boot.img2 ./boot.img3 ;then                      \
 	   echo "*** New boot file created";                       \
 	   cp ./boot.img3 ../src/boot.img;                         \

--- a/lib/scheme/Makefile.am
+++ b/lib/scheme/Makefile.am
@@ -125,10 +125,10 @@ schemelib_DATA  = $(LARGE_SHOBJ)
 #======================================================================
 SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 .stk.ostk:
-	$(COMP) -o $*.ostk $*.stk
+	KEEP_FORMALS=@KEEP_FORMALS@ $(COMP) -o $*.ostk $*.stk
 
 .stk-incl.c:
-	$(COMP) -C -o $*-incl.c $*.stk
+	KEEP_FORMALS=@KEEP_FORMALS@ $(COMP) -C -o $*-incl.c $*.stk
 
 .c.$(SO) :
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -286,10 +286,10 @@ srfi_sources  = $(SRC_STK)
 SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 
 .stk.ostk:
-	$(COMP) -o $*.ostk $*.stk
+	KEEP_FORMALS=@KEEP_FORMALS@ $(COMP) -o $*.ostk $*.stk
 
 .stk-incl.c:
-	$(COMP) -C -o $*-incl.c $*.stk
+	KEEP_FORMALS=@KEEP_FORMALS@ $(COMP) -C -o $*-incl.c $*.stk
 
 .c.$(SO) :
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \

--- a/lib/stklos/Makefile.am
+++ b/lib/stklos/Makefile.am
@@ -57,10 +57,10 @@ scheme_sources  = $(SRC_STK)
 SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 
 .stk.ostk:
-	$(COMP) -o $*.ostk $*.stk
+	KEEP_FORMALS=@KEEP_FORMALS@ $(COMP) -o $*.ostk $*.stk
 
 .stk-incl.c:
-	$(COMP) -C -o $*-incl.c $*.stk
+	KEEP_FORMALS=@KEEP_FORMALS@ $(COMP) -C -o $*-incl.c $*.stk
 
 .c.$(SO) :
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \

--- a/utils/tmpcomp
+++ b/utils/tmpcomp
@@ -28,6 +28,9 @@
 # system which need compilation. It will not be installed since the
 # user version is the stklos-compile script.
 
+# When the environment variable KEEP_FORMALS is "1", compilation will be done with
+# the flag "keep-formals" turned on.
+
 out="a.out"
 in=""
 Copt=""
@@ -67,8 +70,24 @@ STKLOS_LOAD_PATH=".:../lib:${prefix}/lib:"
 STKLOS_BUILDING=1
 export STKLOS_LOAD_PATH STKLOS_BUILDING
 
-${prefix}/src/stklos -c -q -f ${prefix}/utils/stklos-compile.stk -- \
-     --no-time $Copt --output=$out $in
+# I have tried to use "-F '+keep-formals'" and also "--compiler-flags='+keep-formals'"
+# in $COMP_FLAGS and pass it to stklos-compile here, but neither worked, as for some
+# reason the option ws not recognized. But directly evalauting an expression that sets
+# the keep-formals parameter works, so that's what we do!
+#
+# So -- The Makefiles that cll tmpcomp NEED to set the KEEP_FORMALS vraiable
+# when calling, as in
+#     KEEP_FORMALS=@KEEP_FORMALS@ tmpcomp ...
+#
+# -- jpellegrini
+if test "$KEEP_FORMALS" -eq 1
+then
+    ${prefix}/src/stklos -c -q -f ${prefix}/utils/stklos-compile.stk -- \
+             --no-time $Copt -e '(compiler:keep-formals #t)' --output=$out $in
+else
+    ${prefix}/src/stklos -c -q -f ${prefix}/utils/stklos-compile.stk -- \
+             --no-time $Copt --output=$out $in
+fi
 
 status=$?
 if test "$status" -gt 0


### PR DESCRIPTION
Hi @egallesio !
This PR partially addresses issue #260 . It adds optional formal parameter information for closures in core STklos and provided libraries -- but *not* for primitive procedures.

## Description

This adds a new option ot the configure script.

If the user passes `--without-keep-formals` to configure, then the compiler `keep-formals` parameter will be true when compiling closures in core STklos and all provided libraries.

However, this does not affect primitive procedures, because they are C functions, and having the C compiler include the code to add the formal parameters is, although possible... Tricky, at least.

How it works:

We have three autoconf variables:

```
    STR_KEEP_FORMALS="no"    # for output at the end of this script
    KEEP_FORMALS=0           # for tmpcomp (and in the future, C files)
    SCM_BOOT_KEEP_FORMALS="" # for the Makefile compiling the boot image
```

The tmpcomp file needs to be called in the Makefiles with the shell variable
```
KEEP_FORMALS set:
KEEP_FORMALS=@KEEP_FORMALS@ tmpcomp ...
```

For the boot image, the variable `SCM_BOOT_KEEP_FORMALS` is directly used.

And... Well, autotools is reeeeeally not something I ever got to understand well, so perhaps there are better ways to achieve what I did.

## Future work (primitive procedures)

Since primitives are defined as C functions, this becomes tricky.

The options I thought:

* Do not store the formal parameters of primitives in their property list, but rather keep them as a string in the structure. **Problem**: simple, but would be asymmetric (too different from the way it's done for closures).
* Include the C code to actually set the formals in the property list.  **Problem**: maybe a bit too complex?
* Do not keep formals for primitives. **Problem**: well, we won't have formals for primitives :)
