### PR TITLE
Optimize `in-module` for `SCHEME`

### DIFF
--- a/lib/module.stk
+++ b/lib/module.stk
@@ -634,7 +634,10 @@ doc>
 doc>
 |#
 (define-macro (in-module mod symb . default)
-  `(apply symbol-value* ',symb (find-module ',mod) ',default))
+  (if (and (eq? mod 'SCHEME)
+           (null? default))
+      `(%%in-scheme ',symb)
+      `(apply symbol-value* ',symb (find-module ',mod) ',default)))
 
 
 ;;=============================================================================

--- a/lib/module.stk
+++ b/lib/module.stk
@@ -634,6 +634,18 @@ doc>
 doc>
 |#
 (define-macro (in-module mod symb . default)
+  ;; If mod is the symbol SCHEME we know the user wants the SCHEME module.
+  ;; This is because:
+  ;;
+  ;; 1. That module cannot be renamed.
+  ;; 2. This is a macro, and we don't need to (and cannot!) evaluate its
+  ;;    arguments.
+  ;;
+  ;; So, in that case we can call the `%%in-scheme` primitive, which is
+  ;; much faster than using apply and symbol-value*.
+  ;; however, if the user wanted a default value, we revert to applying
+  ;; symbol-value*, because we'd need a handler around %%in-scheme, which
+  ;; becomes terribly slow.
   (if (and (eq? mod 'SCHEME)
            (null? default))
       `(%%in-scheme ',symb)


### PR DESCRIPTION
`(in-module mod symb . default)` will now use `%%in-scheme` when `mod` is `SCHEME`.

```scheme
(macro-expand '(in-module SCHEME list))

=> (apply symbol-value* 'list (find-module 'SCHEME) '())

stklos> (disassemble-expr '(in-module SCHEME list))

000:  PREPARE-CALL
001:  GLOBAL-REF-PUSH      0
003:  CONSTANT-PUSH        1
005:  PREPARE-CALL
006:  CONSTANT-PUSH        2
008:  GREF-INVOKE          3 1
011:  PUSH
012:  NIL-PUSH
013:  GREF-INVOKE          4 4
016:
```

The new code:

```scheme
(macro-expand '(in-module SCHEME list))

=> (%%in-scheme 'list)

stklos> (disassemble-expr '(in-module SCHEME list))

000:  CONSTANT             0
002:  INSCHEME
003:
```

Following is an illustration of the speedup.

```scheme
(time
  (let ((a #f))
    (repeat 10_000_000
      (set! a (in-module SCHEME list))) a))
```

Old code: around 1200 ms
New code: around  300 ms

However, this optimization is only done when there is no default passed to `in-module`, because using `with-handler` around `%%in-scheme` resulted in a huge slowdown.

If there is a way to call %%in-scheme and trap its result without using `with-handler`, maybe it could be added later.
