### PR TITLE
Fix `lset=` in SRFI 1 / `(scheme list)` (small issue, side-effects only)

### DIFF
--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -1579,15 +1579,18 @@ FILTER an FILTER! are primitives in STklos
 
 (define (%lset2<= = lis1 lis2) (every (lambda (x) (member x lis2 =)) lis1))
 
-(define (lset<= = . lists)
-  (check-arg procedure? = lset<=)
+(define (lset= = . lists)
+  (define (flip proc) (lambda (x y) (proc y x)))
+  (check-arg procedure? = lset=)
   (or (not (pair? lists)) ; 0-ary case
       (let lp ((s1 (car lists)) (rest (cdr lists)))
-    (or (not (pair? rest))
-        (let ((s2 (car rest))  (rest (cdr rest)))
-          (and (or (eq? s2 s1)  ; Fast path
-               (%lset2<= = s1 s2)) ; Real test
-           (lp s2 rest)))))))
+        (or (not (pair? rest))
+            (let ((s2   (car rest))
+                  (rest (cdr rest)))
+              (and (or (eq? s1 s2)            ; Fast path
+                       (and (%lset2<= = s1 s2) ; Real test
+                            (%lset2<= (flip =) s2 s1)))
+                   (lp s2 rest)))))))
 
 (define (lset= = . lists)
   (check-arg procedure? = lset=)

--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -1579,6 +1579,16 @@ FILTER an FILTER! are primitives in STklos
 
 (define (%lset2<= = lis1 lis2) (every (lambda (x) (member x lis2 =)) lis1))
 
+(define (lset<= = . lists)
+  (check-arg procedure? = lset<=)
+  (or (not (pair? lists)) ; 0-ary case
+      (let lp ((s1 (car lists)) (rest (cdr lists)))
+	(or (not (pair? rest))
+	    (let ((s2 (car rest))  (rest (cdr rest)))
+	      (and (or (eq? s2 s1)	; Fast path
+		       (%lset2<= = s1 s2)) ; Real test
+		   (lp s2 rest)))))))
+
 (define (lset= = . lists)
   (define (flip proc) (lambda (x y) (proc y x)))
   (check-arg procedure? = lset=)
@@ -1591,18 +1601,6 @@ FILTER an FILTER! are primitives in STklos
                        (and (%lset2<= = s1 s2) ; Real test
                             (%lset2<= (flip =) s2 s1)))
                    (lp s2 rest)))))))
-
-(define (lset= = . lists)
-  (check-arg procedure? = lset=)
-  (or (not (pair? lists)) ; 0-ary case
-      (let lp ((s1 (car lists)) (rest (cdr lists)))
-    (or (not (pair? rest))
-        (let ((s2   (car rest))
-          (rest (cdr rest)))
-          (and (or (eq? s1 s2)  ; Fast path
-               (and (%lset2<= = s1 s2) (%lset2<= = s2 s1))) ; Real test
-           (lp s2 rest)))))))
-
 
 (define (lset-adjoin = lis . elts)
   (check-arg procedure? = lset-adjoin)


### PR DESCRIPTION
The reference (sample) implementation had a bug that reversed the arguments to =. The implementation has been corrected to match the SRFI text, and we do so in STklos also.

See:
https://srfi.schemers.org/srfi-1/srfi-1.html#lset%3D-element-equality-order

The difference in behavior is only for side-effects. It can be seen in this example:

```
;; OLD version of lset=
scheme/list> (lset= (lambda (x y) (print x) (= x y)) '(1 2 ) '(1 2 ))
1
2
2
1
2      ;; <= HERE!
2

;; NEW version of lset=
scheme/list> (lset=-new (lambda (x y) (print x) (= x y)) '(1 2 ) '(1 2 ))
1
2
2
1
1      ;; <= HERE!
2
```