### PR TITLE
Add optional "name" argument to `error` calls

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1591,7 +1591,7 @@ doc>
         (loop (cons sexp res) (reader p)))))
 
 (define (port->string p)
-  (unless (input-port? p) (error "bad port ~S" p))
+  (unless (input-port? p) (error 'port->string "bad port ~S" p))
   (with-output-to-string
     (lambda () (copy-port p (current-output-port)))))
 
@@ -1983,7 +1983,7 @@ doc>
 (define (error-object-location obj)
   (if (error-object? obj)
       (condition-ref obj 'location)
-      (error "bad error object: ~S" obj)))
+      (error 'error-object-location "bad error object: ~S" obj)))
 
 #|
 <doc EXT define-constant
@@ -2073,9 +2073,9 @@ doc>
 |#
 (define (exact-integer-log n b)
   (unless (and (exact-integer? n) (positive? n))
-    (error "log exponent ~S is not a positive exact integer" n))
+    (error 'exact-integer-log "log exponent ~S is not a positive exact integer" n))
   (unless (and (exact-integer? b) (> b 1))
-    (error "log base ~S is not exact integer greater than one" b))
+    (error 'exact-integer-log "log base ~S is not exact integer greater than one" b))
   ;; This is easier and faster than R7RS exact-integer-sqrt, since:
   ;; * log(n b) = log_2(n) / log_2(b).
   ;; * integer-length(n) = floor(log_2(n)) + 1
@@ -2119,12 +2119,12 @@ doc>
 doc>
 |#
 (define (radians->degrees r)
-  (unless (real? r) (error "bad real number ~S" r))
+  (unless (real? r) (error 'radians->degrees "bad real number ~S" r))
   (/ (* r 180)
      3.141592653589793115997963468544185161590576171875)) ; pi
 
 (define (degrees->radians d)
-  (unless (real? d) (error "bad real number ~S" d))
+  (unless (real? d) (error 'degrees->radians "bad real number ~S" d))
   (* (/ d 180)
      3.141592653589793115997963468544185161590576171875)) ; pi
 
@@ -2532,7 +2532,7 @@ doc>
 |#
 (define (string->keyword str)
   (unless (string? str)
-    (error "bad string ~S" str))
+    (error 'string->keyword "bad string ~S" str))
   (make-keyword str))
 
 ;;

--- a/lib/env.stk
+++ b/lib/env.stk
@@ -1,4 +1,4 @@
-;;;;
+;;;
 ;;;; env.stk                            -- R5RS environments
 ;;;;
 ;;;; Copyright © 2006-2022 Erick Gallesio - I3S-CNRS/ESSI <eg@essi.fr>
@@ -110,7 +110,7 @@ doc>
   (let ((null-env #f))
     (lambda (:optional (version 5))
       (unless (eq? version 5)
-        (error "this version is not supported ~S" version))
+        (error 'null-environment "this version is not supported ~S" version))
       (unless null-env
         (set! null-env (%make-empty-environment))
         (module-immutable! null-env))
@@ -201,7 +201,7 @@ doc>
 |#
 (define (scheme-report-environment :optional (version 5))
   (unless (eq? version 5)
-    (error "this version is not supported ~S" version))
+    (error 'scheme-report-environment "this version is not supported ~S" version))
   (find-module 'R5RS))
 
 

--- a/lib/process.stk
+++ b/lib/process.stk
@@ -85,7 +85,7 @@ doc>
        ((null? l)
         (values (reverse! key) (reverse! other)))
        ((keyword? (car l))
-        (if (null? (cdr l)) (error "value expected after keyword ~S" (car l)))
+        (if (null? (cdr l)) (error 'run-process "value expected after keyword ~S" (car l)))
         (Loop (cddr l) (cons (cadr l) (cons (car l) key)) other))
        (else (Loop (cdr l) key (cons (car l) other))))))
 

--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -498,7 +498,7 @@ doc>
             (loop xn1)))))
 
   (unless (and (exact-integer? k)(>= k 0))
-    (error "non negative integer expected. It was: ~S" k))
+    (error 'exact-integer-sqrt "non negative integer expected. It was: ~S" k))
   (let ((s (if (fixnum? k)
                (let ((v (sqrt k)))
                  (if (exact? v) v (inexact->exact (floor v))))
@@ -730,7 +730,7 @@ doc>
           #:vector->list  ; set procedure name
           (if start?
               (let ((end (if end? end (vector-length v))))
-                (when (< end start) (error "end index ~S < start index ~S" end start))
+                (when (< end start) (error 'vector->list "end index ~S < start index ~S" end start))
                 (%claim-error
                  'vector->list
                  (do ((i (- end 1) (- i 1))
@@ -814,7 +814,7 @@ doc>
 doc>
 |#
 (define (vector->string vect :optional (start 0) (end 0 end?))
-  (unless (vector? vect)    (error "bad vector ~S" vect))
+  (unless (vector? vect)    (error 'vector->string "bad vector ~S" vect))
   (unless end?              (set! end (vector-length vect)))
   (%claim-error
      'vector->string
@@ -824,13 +824,13 @@ doc>
        (if (< start end)
            (let ((c (vector-ref vect start)))
              (unless (char? c)
-               (error "element at index ~S of ~S must be a character" start vect))
+               (error 'vector->string "element at index ~S of ~S must be a character" start vect))
              (string-set! res i c)
              (loop res (+ i 1) (+ start 1)))
            res))))
 
 (define (string->vector str :optional (start 0) (end 0 end?))
-  (unless (string? str)    (error "bad string ~S" str))
+  (unless (string? str)    (error 'string->vector "bad string ~S" str))
   (unless end?             (set! end (string-length str)))
   (%claim-error
      'string->vector
@@ -1168,7 +1168,7 @@ doc>
 (define (error-object-message obj)
   (if (error-object? obj)
       (condition-ref obj 'r7rs-msg)
-      (error "bad error object: ~S" obj)))
+      (error 'error-object-message "bad error object: ~S" obj)))
 
 #|
 <doc R7RS error-object-irritants
@@ -1181,7 +1181,7 @@ doc>
 (define (error-object-irritants obj)
   (if (error-object? obj)
       (condition-ref obj 'r7rs-irritants)
-      (error "bad error object: ~S" obj)))
+      (error 'error-object-irritants "bad error object: ~S" obj)))
 
 #|
 <doc R7RS read-error? file-error?
@@ -1250,12 +1250,12 @@ doc>
 |#
 (define (input-port-open? port)
   (unless (input-port? port)
-    (error "bad input port ~S" port))
+    (error 'input-port-open? "bad input port ~S" port))
   (not (port-closed? port)))
 
 (define (output-port-open? port)
   (unless (output-port? port)
-    (error "bad output port ~S" port))
+    (error 'output-port-open? "bad output port ~S" port))
   (not (port-closed? port)))
 
 
@@ -1275,9 +1275,9 @@ doc>
   (%claim-error
     'read-string
     (unless (positive? k)
-      (error "parameter must be a positive integer. It was: ~S" k))
+      (error 'read-string "parameter must be a positive integer. It was: ~S" k))
     (unless (and (input-port? port) (textual-port? port))
-      (error "bad textual input port ~S" port))
+      (error 'read-string "bad textual input port ~S" port))
 
     (let ((buffer (make-string k)))
       (let Loop ((i 0)
@@ -1310,7 +1310,7 @@ doc>
   (%claim-error
     'read-u8
     (unless (binary-port? port)
-      (error "bad binary port ~S" port))
+      (error 'read-u8 "bad binary port ~S" port))
     (read-byte port)))
 
 #|
@@ -1332,7 +1332,7 @@ doc>
   (%claim-error
     'peek-u8
     (unless (binary-port? port)
-      (error "bad binary port ~S" port))
+      (error 'peek-u8 "bad binary port ~S" port))
     (peek-byte port)))
 
 
@@ -1358,7 +1358,7 @@ doc>
   (%claim-error
    'read-bytevector!
    (unless (bytevector? bv)
-     (error "bad bytevector ~S" bv))
+     (error 'read-bytevector! "bad bytevector ~S" bv))
    (unless end?
      (set! end (bytevector-length bv)))
    (%read-bytevector! bv port start end)))
@@ -1394,7 +1394,7 @@ doc>
   (%claim-error
    'write-u8
    (unless (binary-port? port)
-     (error "bad binary port ~S" port))
+     (error 'write-u8 "bad binary port ~S" port))
    (write-byte byte port)))
 
 #|
@@ -1413,8 +1413,8 @@ doc>
                                        (end -1 end?))
   (%claim-error
    'write-bytevector
-   (unless (bytevector? bv)     (error "bad bytevector ~S" bv))
-   (unless (binary-port? port)  (error "bad binary port ~S" port))
+   (unless (bytevector? bv)     (error 'write-bytevector "bad bytevector ~S" bv))
+   (unless (binary-port? port)  (error 'write-bytevector "bad binary port ~S" port))
    (unless end?                 (set! end (bytevector-length bv)))
 
    (let Loop ((i start))
@@ -1473,7 +1473,7 @@ doc>
                                    err)))
                             (thunk))))
     (if (eq? res err)
-        (error "exception handler returned on non-continuable exception")
+        (error 'with-exception-handler "exception handler returned on non-continuable exception")
         res)))
 
 #|

--- a/lib/srfi-0.stk
+++ b/lib/srfi-0.stk
@@ -104,7 +104,7 @@ doc>
                 ((symbol? feat) feat)
                 ((string? feat) (string->symbol feat))
                 ((integer? feat) (symbol-append 'srfi- feat))
-                (else (error "bad feature" feat))))
+                (else (error 'require-feature "bad feature" feat))))
          (files (srfi-0-feature-implementation-file name)))
     (when files
       (for-each (lambda (x)

--- a/lib/str.stk
+++ b/lib/str.stk
@@ -82,9 +82,9 @@
               (unless (string? str2)
                 (error-bad-string str2))
               (unless (integer? offset)
-                (error "bad offset ~S" offset))
+                (error 'string-blit! "bad offset ~S" offset))
               (unless (string-mutable? str1)
-                (error "changing the constant string ~S is not allowed"))
+                (error 'str1ng-blit! "changing the constant string ~S is not allowed"))
 
               (let ((len1 (string-length str1))
                     (len2 (string-length str2)))
@@ -125,10 +125,10 @@
               (unless (string? str)
                 (error-bad-string  str))
               (unless (integer? start)
-                (error "bad starting index ~S" start))
+                (error 'string-titlecase "bad starting index ~S" start))
               (cond
                 ((not (integer? end))
-                 (error "bad ending index ~S" end))
+                 (error string-titlecase "bad ending index ~S" end))
                 ((= end -1)
                  (set! end (string-length str))))
 
@@ -159,10 +159,10 @@
               (unless (string? str)
                 (error-bad-string str))
               (unless (integer? start)
-                (error "bad starting index ~S" start))
+                (error 'string-titlecase! "bad starting index ~S" start))
               (cond
                 ((not (integer? end))
-                 (error "bad ending index ~S" end))
+                 (error 'string-titlecase! "bad ending index ~S" end))
                 ((= end -1)
                  (set! end (string-length str))))
 
@@ -178,4 +178,3 @@
                                            (else          (char-downcase curr))))
                       (Loop (+ i 1) curr-is-sep?))))))))
     ))
-

--- a/lib/time.stk
+++ b/lib/time.stk
@@ -68,19 +68,19 @@ doc>
          ;; b = nano
          ;; c = sec -> c necessary
          (unless c
-           (error "since first argument is symbol, 3 args (type, nanosecond and second) required, only 2 given"))
+           (error 'make-time "since first argument is symbol, 3 args (type, nanosecond and second) required, only 2 given"))
          (unless (memq a '(time-tai time-utc time-monotonic time-process time-duration))
-           (error "bad time type ~S" a))
-         (unless (integer? b) (error "bad integer ~S" b))
-         (unless (integer? c) (error "bad integer ~S" c))
+           (error 'make-time "bad time type ~S" a))
+         (unless (integer? b) (error 'make-time "bad integer ~S" b))
+         (unless (integer? c) (error 'make-time "bad integer ~S" c))
          (make-struct %time a b c))
         ((integer? a)
          ;; a = nano
          ;; b = sec -> c NOT allowed
-         (when c (error "since first argument is integer, 2 args (nanosecond and second) required, but 3 given"))
-         (unless (integer? b) (error "bad integer ~S" b))
+         (when c (error 'make-time "since first argument is integer, 2 args (nanosecond and second) required, but 3 given"))
+         (unless (integer? b) (error 'make-time "bad integer ~S" b))
          (make-struct %time 'time-utc a b))
-        (else (error "bad symbol or integer ~S" a))))
+        (else (error 'make-time "bad symbol or integer ~S" a))))
 
 #|
 <doc EXT time-type set-time-type! time-second set-time-second! time-nanosecond set-time-nanosecond!
@@ -386,11 +386,11 @@ doc>
   (cond ((or (null? type) (eq? (car type) 'time-utc))
          (%current-time))
         ((> (length type) 1)
-         (error "too many arguments (0 or 1 expected, ~S given)"
+         (error 'current-time "too many arguments (0 or 1 expected, ~S given)"
                 (length type)))
         ((eq? (car type) 'time-tai)
          (time-utc->time-tai (%current-time)))
-        (else (error "unsupported time type ~S" (car type)))))
+        (else (error 'current-time "unsupported time type ~S" (car type)))))
 
 ;;;; ======================================================================
 ;;;;


### PR DESCRIPTION
Not in all of them, but in procedures that are publically visible and where it make ssense to inform who is triggering the error.

Does this make sense, @egallesio ?