### PR TITLE
Loading SRFI 169 will automatically turn it on

### DIFF
--- a/lib/srfi/169.stk
+++ b/lib/srfi/169.stk
@@ -26,4 +26,12 @@
 ;;;;
 
 (define-module srfi/169)
+
+;; STklos has this parameter set to #t by default. However...
+;; If the user turned it off, and then decided to "load SRFI 169",
+;; perhaps by the principle of least surprise, we should turn
+;; it back on (because having loaded the SRFI we'd expect it to
+;; work from now on...)
+(accept-srfi-169-numbers #t)
+
 (provide "srfi/169")


### PR DESCRIPTION
Hi @egallesio 

A on-liner patch...

Currently,

```scheme
stklos> (accept-srfi-169-numbers #f)
stklos> 1_2
**** Error:
%execute: symbol `1_2' unbound in module `stklos'

stklos> (import (srfi 169))  ;; This should turn SRFI 196 on...

stklos> 1_2                  ;; But it didn't!
**** Error:
%execute: symbol `1_2' unbound in module `stklos'
```

This adds a line to the SRFI implementation file, that just changes the parameter to #t.