### PR TITLE
Detect division by zero when inlining

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1258,6 +1258,9 @@ doc>
                 ((2)  (let ((a (car actuals))
                             (b (cadr actuals)))
                         (cond
+                         ;; it is only an error if b is *exact* zero (not 0.0),
+                         ;; and we can test that with eq? (not NOT with '='):
+                         ((eq? b 0) (compiler-error "division by zero"))
                          ((and (number? a) (number? b))
                           (compile-constant (/ a b) env tail?))
                          ((small-integer-constant? b)
@@ -1275,7 +1278,11 @@ doc>
                                       ((fx+) (fx+ a b))
                                       ((fx-) (fx- a b))
                                       ((fx*) (fx* a b))
-                                      (else  (fxquotient a b)))
+                                      (else
+                                       ;; it is only an error if b is *exact* zero (not 0.0),
+                                       ;; and we can test that with eq? (not NOT with '='):
+                                       (when (eq? b 0) (compiler-error "division by zero"))
+                                       (fxquotient a b)))
                                     env
                                     tail?))
                  ((and (small-integer-constant? a)


### PR DESCRIPTION
These two situations are similar, but one signals a compiler error, and the other signals an error after copilation:

```scheme
stklos> (/)
**** Error:
compiler-error: /: needs at least one argument
	(type ",help" for more information)
stklos> (/ 2 0)
**** Error:
/: cannot make rational with null denominator
	(type ",help" for more information)
```

With this PR, both are treated similarly.