### PR TITLE
Report C compiler version in configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -781,7 +781,8 @@ echo "               System: " $BUILD_OS
 echo "              OS nick: " $OS_NAME_VERSION
 echo "              OS type: " $OS_FLAVOUR
 echo "       Install prefix: " $prefix
-echo "           C compiler: " $CC
+echo "    C compiler binary: " $CC
+echo "   C compiler version: " $C_VERSION
 echo "    Compilation flags: " $CFLAGS
 echo "               Loader: " $LD
 echo "       Thread support: " $THREADS


### PR DESCRIPTION
It may be useful to immediately see if we're using gcc version 14 instead of 13, for example.

So now there are two lines:
* one for the compiler binary
* one for the version string (1st line reported by the compiler when called with `--version`)
