### PR TITLE
Allow for `(expt -1 bignum)`

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -4020,9 +4020,20 @@ static SCM my_expt(SCM x, SCM y)
 
 DEFINE_PRIMITIVE("expt", expt, subr2, (SCM x, SCM y))
 {
-  if (!COMPLEXP(y) && negativep(y))
-    return div2(MAKE_INT(1),
-                my_expt(x, sub2(MAKE_INT(0), y)));
+    /* We specifically check for -1 here because if y is a bignum,
+       it will be rejected later -- but we know that if x is -1,
+       then the result only depends on the parity of y. */
+    if (x == MAKE_INT(-1) &&
+        ((TYPEOF(y) == tc_integer) ||
+         (TYPEOF(y) == tc_bignum)))
+        return (number_parity(y) < 0)
+            ? MAKE_INT(-1)
+            : MAKE_INT(+1);
+
+    if (!COMPLEXP(y) && negativep(y)) {
+        return div2(MAKE_INT(1),
+                    my_expt(x, sub2(MAKE_INT(0), y)));
+    }
   return my_expt(x, y);
 }
 

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -628,7 +628,7 @@
       (equal? -0.0 -0.0))
 
 
-;; Note: We have a special case: (- 0+0.0i 0.0) is "0.0+0.0i" and not 
+;; Note: We have a special case: (- 0+0.0i 0.0) is "0.0+0.0i" and not
 ;; "-0.0+0.0i"
 (test "minus zero in a complex"
       "0.0+0.0i"
@@ -1286,6 +1286,22 @@
 (test/error "0^-a+bi" (expt 0.0 -2+1i))
 
 (test "exact expt" 1/1606938044258990275541962092341162602522202993782792835301376 (expt (expt 2 100) -2))
+
+(test "expt big exponent.1"
+      1
+      (expt 1 132897461238946918327469812213123215555532132133764))
+
+(test "expt big exponent.2"
+      1
+      (expt 1 132897461238946918327469812213123215555532132133763))
+
+(test "expt big exponent.3"
+      1
+      (expt -1 132897461238946918327469812213123215555532132133764))
+
+(test "expt big exponent.4"
+      -1
+      (expt -1 132897461238946918327469812213123215555532132133763))
 
 ;;------------------------------------------------------------------
 (test-subsection "sqrt")


### PR DESCRIPTION
Currently we always reject bignum exponents, except for when the base is +1.

Before: 

```
stklos> (expt -1 12676506002282294232132132123213213213015)
**** Error:
expt: exponent too big: '12676506002282294232132132123213213213015'
	(type ",help" for more information)
stklos> (expt 1 12676506002282294232132132123213213213015)
1
```

Now:
```
stklos> (expt -1 12676506002282294232132132123213213213015)
-1
stklos> (expt 1 12676506002282294232132132123213213213015)
1
```
