### PR TITLE
Add `,date` to REPL

### DIFF
--- a/lib/repl.stk
+++ b/lib/repl.stk
@@ -245,6 +245,11 @@ doc>
   (repl-add-command '(shell !)
                     "Run a shell command"
                     (lambda () (system (read-line))))
+
+  ;; ==== date
+  (repl-add-command '(date dt)
+                    "Print the current date and time"
+                    (lambda () (print (date))))
   ;; ==== time
   (repl-add-command '(time t)
                     "Print the time used to run the next expression"


### PR DESCRIPTION
This commit adds a `,date` command to the REPL:

```
stklos> ,date
Wed Aug 14 13:07:26 2024
stklos> ,dt
Wed Aug 14 13:07:27 2024
```

It uses the internal `date` primitive.