### PR TITLE
Allow STklos to compile without the FFI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,7 +440,7 @@ echo "*****"
 # *** If it's set to "no", then the --with-provided-ffi won't even be
 #     verified.
 AC_ARG_WITH(ffi,
-       [  --without-ffi don't include FFI code ],
+       [  --without-ffi           don't include FFI code ],
        AVOID_FFI="yes", AVOID_FFI="no")
 
 if test "$AVOID_FFI" = "no"

--- a/configure.ac
+++ b/configure.ac
@@ -434,46 +434,64 @@ echo "*****"
 echo "***** FFI support"
 echo "*****"
 
-# Try to determine if libffi is installed
-if ${PKGCONFIG} --exists libffi ;then
-   HAVE_FFI="yes"
-else
-  AC_CHECK_LIB(ffi, ffi_prep_cif, HAVE_FFI="yes", HAVE_FFI="no", $LIBS)
-fi
+# Check if the user wants FFI included or not.
+# The autoconf variable AVOID_FFI will be set here to either "yes"
+# or "no".
+# *** If it's set to "no", then the --with-provided-ffi won't even be
+#     verified.
+AC_ARG_WITH(ffi,
+       [  --without-ffi don't include FFI code ],
+       AVOID_FFI="yes", AVOID_FFI="no")
 
-# Test if the user wants to force the use of our FFI lib
-AC_ARG_WITH(provided-ffi,
-       [  --with-provided-ffi     use the provided FFI library],
-       PROV_FFI="$withval", PROV_FFI="no")
-
-if test "$HAVE_FFI" = "no" -o "$PROV_FFI" = "yes"
+if test "$AVOID_FFI" = "no"
 then
-     echo "... Configuring libffi"
-     (cd ffi; ./configure --disable-structs --disable-raw-api --disable-shared \
-           --prefix=$prefix) || { echo "Cannot configure libffi"; exit; }
-     FFI="ffi"
-     FFIINC="-I../ffi/$(./config.guess)/include"
-     FFILIB="../ffi/$(./config.guess)/.libs/libffi.a"
-     COMP_LIBS="libffi $COMP_LIBS"
-else
-     echo "... Using system libffi library"
-     FFI=""
-     if $PKGCONFIG --exists libffi ;then
-       FFIINC=$($PKGCONFIG libffi --cflags)
-       FFILIB=$($PKGCONFIG libffi --libs)
-       FFIVER=$($PKGCONFIG --modversion libffi)
-     else
-       FFIINC="-I/usr/include/ffi"
-       FFILIB="-lffi"
-       DLLIBS="$DLLIBS $FFILIB"
-     fi
-     DLLIBS="$DLLIBS $FFILIB"
-     SYST_LIBS="libffi $SYST_LIBS"
-     SYST_LIBS_SHOW="ffi ($FFIVER) $SYST_LIBS_SHOW"
-fi
-# We always want FFI. Should be modifiable in the future
-AC_DEFINE(HAVE_FFI, 1, [System provides FFI])
+  # Try to determine if libffi is installed
+  if ${PKGCONFIG} --exists libffi ;then
+     HAVE_FFI="yes"
+  else
+    AC_CHECK_LIB(ffi, ffi_prep_cif, HAVE_FFI="yes", HAVE_FFI="no", $LIBS)
+  fi
 
+  # Test if the user wants to force the use of our FFI lib
+  AC_ARG_WITH(provided-ffi,
+         [  --with-provided-ffi     use the provided FFI library],
+         PROV_FFI="$withval", PROV_FFI="no")
+
+  if test "$HAVE_FFI" = "no" -o "$PROV_FFI" = "yes"
+  then
+       echo "... Configuring libffi"
+       (cd ffi; ./configure --disable-structs --disable-raw-api --disable-shared \
+             --prefix=$prefix) || { echo "Cannot configure libffi"; exit; }
+       FFI="ffi"
+       FFIINC="-I../ffi/$(./config.guess)/include"
+       FFILIB="../ffi/$(./config.guess)/.libs/libffi.a"
+       COMP_LIBS="libffi $COMP_LIBS"
+       STR_FFI="provided"
+  else
+       echo "... Using system libffi library"
+       FFI=""
+       if $PKGCONFIG --exists libffi ;then
+         FFIINC=$($PKGCONFIG libffi --cflags)
+         FFILIB=$($PKGCONFIG libffi --libs)
+         FFIVER=$($PKGCONFIG --modversion libffi)
+       else
+         FFIINC="-I/usr/include/ffi"
+         FFILIB="-lffi"
+         DLLIBS="$DLLIBS $FFILIB"
+       fi
+       DLLIBS="$DLLIBS $FFILIB"
+       SYST_LIBS="libffi $SYST_LIBS"
+       SYST_LIBS_SHOW="ffi ($FFIVER) $SYST_LIBS_SHOW"
+       STR_FFI="system"
+  fi
+
+  # The following "HAVE_FFI" is defined so the compiler will actually
+  # compile the code for it.
+  AC_DEFINE(HAVE_FFI, 1, [System provides FFI])
+else
+  echo "... NOT using FFI"
+  STR_FFI="none"
+fi
 
 # ----------------------------------------------------------------------
 # Control fixnum and flonum parameters
@@ -800,6 +818,7 @@ echo "     Case sensitivity: " $CASE_SENSITIVE '(by default)'
 echo "Control fx parameters: " $CONTROL_FX
 echo "System libraries used: " $SYST_LIBS_SHOW
 echo "   Compiled libraries: " $COMP_LIBS_SHOW
+echo "                  FFI: " $STR_FFI
 echo " Documentation update: " $REPORT_ASCIIDOCTOR
 echo " "
 

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -496,7 +496,7 @@ static int exec_callback(SCM callback, ...)
  * it is used in the gtk-gtklos-base ScmPkg (a callback can be called
  * with one or two pointers. Hopefully, callbacks were not documened
  * in previous versions of STklos ;-)
- * 
+ *
  * 2021/06/09: This code was used before for GTk support. It doesn't
  * seem useful anymore. It is kept here for reference
  */
@@ -703,7 +703,7 @@ DEFINE_PRIMITIVE("%make-ext-func", make_ext_func, subr4,
                  (SCM p1, SCM p2, SCM p3, SCM p4))
 { error_no_ffi(); return STk_void;}
 
-DEFINE_PRIMITIVE("make-callback", make_callback, subr3, (SCM p1, SCM p2, SCM p3))
+DEFINE_PRIMITIVE("%make-callback", make_callback, subr3, (SCM p1, SCM p2, SCM p3))
 { error_no_ffi(); return STk_void;}
 
 DEFINE_PRIMITIVE("%exec-callback-address", exec_cb_addr, subr0, (void))
@@ -729,9 +729,11 @@ DEFINE_PRIMITIVE("%set-typed-ext-var!", set_typed_ext_var, subr3,
  * ====================================================================== */
 int STk_init_ffi(void)
 {
+  #ifdef HAVE_FFI
   pointer_on_exec_callback = STk_make_Cpointer(exec_callback,
                                                STk_void,
                                                STk_false);
+  #endif
 
   ADD_PRIMITIVE(make_ext_func);
   ADD_PRIMITIVE(make_callback);

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -698,7 +698,6 @@ static void error_no_ffi(void)
   STk_error("current system does not support FFI");
 }
 
-
 DEFINE_PRIMITIVE("%make-ext-func", make_ext_func, subr4,
                  (SCM p1, SCM p2, SCM p3, SCM p4))
 { error_no_ffi(); return STk_void;}
@@ -724,6 +723,16 @@ DEFINE_PRIMITIVE("%set-typed-ext-var!", set_typed_ext_var, subr3,
 
 #endif
 
+DEFINE_PRIMITIVE("%stklos-has-ffi?", has_ffi, subr0, ())
+{
+#ifdef HAVE_FFI
+  return STk_true;
+#else
+  return STk_false;
+#endif
+}
+
+
 /* ======================================================================
  *      INIT  ...
  * ====================================================================== */
@@ -742,5 +751,7 @@ int STk_init_ffi(void)
   ADD_PRIMITIVE(get_symbol_address);
   ADD_PRIMITIVE(get_typed_ext_var);
   ADD_PRIMITIVE(set_typed_ext_var);
+
+  ADD_PRIMITIVE(has_ffi);
   return TRUE;
 }

--- a/tests/do-test.stk
+++ b/tests/do-test.stk
@@ -43,7 +43,7 @@
   (load "test-base64.stk")
   (load "test-box.stk")
   (load "test-regexp.stk")
-  (load "test-ffi.stk")
+  (when (%stklos-has-ffi?) (load "test-ffi.stk"))
   (load "test-r5.stk")
   (load "test-r7rs.stk")
   (load "test-r7rs-lib.stk")


### PR DESCRIPTION
Hi @egallesio !

This PR changes `ffi.c`, `configure.ac` and `do-test.stk` to allow STklos to be compiled without the FFI.

I did this because the FFI lib may not be available in some environments, and also because it may be interesting to have STklos running without the 47k taken by the libffi shared object file...
In particular, I couldn't compile STklos with musl libc in order to run on my wireless router (it used to be possible, but now for some reason it complains about the FFI -- but I don't need it in that context anyway).