### PR TITLE
Inform binary and Scheme load paths in configure and SRFI-176

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -818,6 +818,9 @@ echo "Case sensitive symbols: " $CASE_SENSITIVE
 echo " Control fx parameters: " $CONTROL_FX
 echo " System libraries used: " $SYST_LIBS_SHOW
 echo "    Compiled libraries: " $COMP_LIBS_SHOW
+echo "    STklos load prefix: " $PREFIX
+echo "      Binary load path: " $EXECDIR
+echo "      Scheme load path: " $SCMDIR
 echo "  Documentation update: " $REPORT_ASCIIDOCTOR
 echo " "
 

--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -2733,6 +2733,8 @@ doc>
       (install-dir ,(%library-prefix))
       (website "https://stklos.net")
       (scheme.features ,@(features))
+      (stklos.binary-load-path ,(%library-prefix 'lib))
+      (stklos.scheme-load-path ,(%library-prefix 'data))
       (scheme.path ,@(load-path))
       (scheme.srfi ,@srfis)
       (scheme.srfi.count ,(length srfis))


### PR DESCRIPTION
The configure script now tells us the paths. I have actually found one case in which the information was relevant (lib path was set to "/usr/lib/stklos/2.0" but the scheme lib path was set to "/usr/share", and scheme libraries being installed in "/usr/share/stklos/2.0", resulting in a system that cannot load libraries without the need to manually change `load-path`...

```
 System libraries used:  ffi (3.4.6) pcre2 (10.42) gmp (6.3.0) gc (8.2.6)
    Compiled libraries:
    STklos load prefix:  /usr/local
      Binary load path:  /usr/local/lib/stklos/2.00
      Scheme load path:  /usr/local/share/stklos/2.00
  Documentation update:  yes (since Asciidoctor is installed)
```

And `version->alist` will also inform the paths separately:

```
(stklos.binary-load-path "/usr/local/lib/stklos/2.00")
(stklos.scheme-load-path "/usr/local/share/stklos/2.00")
(scheme.load-path "." "/usr/local/lib/stklos/2.00" "/usr/local/share/stklos/2.00")
```