### PR TITLE
Do `(cd DIR && rm ...) || true`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,15 +70,15 @@ SUPPORTED-SRFIS: lib/srfis.stk
 	mv -f  $@.tmp $@
 
 clean-am:
-	for i in doc tests utils extensions;do (cd $$i; $(MAKE) clean) ;done
+	for i in doc tests utils extensions;do (cd $$i && $(MAKE) clean) ;done
 	rm -f SUPPORTED-SRFIS.tmp
 
 distclean: clean
-	for i in $(SUBDIRS) extensions ;do (cd $$i; $(MAKE) distclean); done
+	for i in $(SUBDIRS) extensions ;do (cd $$i && $(MAKE) distclean); done
 	rm -rf Makefile config.log config.status autom4te.cache
 
 test tests: all
-	(cd tests; $(MAKE) test)
+	(cd tests && $(MAKE) test)
 
 uninstall-hook:
 	rmdir $(schemeprefix) $(schemelibprefix) || true

--- a/doc/pp/Makefile.am
+++ b/doc/pp/Makefile.am
@@ -28,7 +28,7 @@ extradoc: pdf
 ../HTML/$(SAMPLE): Resources/mymd-prelude.templ  Resources/mymd-postlude.templ \
                    Resources/pp-demo.md
 	mkdir -p ../HTML
-	(cd Resources; ./build-pp-demo.sh)
+	(cd Resources && ./build-pp-demo.sh)
 
 # ----------------------------------------------------------------------
 ../PDF/$(PDF): tmp-pdf.txt

--- a/doc/refman/Makefile.am
+++ b/doc/refman/Makefile.am
@@ -96,7 +96,7 @@ tmp-pdf.txt: $(SOURCES) $(DOCDB)
 	$(SPP) -D "doc-fmt: pdf" stklos.adoc > $@
 # ----------------------------------------------------------------------
 $(DOCDB):
-	(cd ..; $(MAKE) docdb)
+	(cd .. && $(MAKE) docdb)
 
 clean:
 	rm -f  tmp-html.txt tmp-pdf.txt stklos-ref-multi.txt tmp.pdf *~

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -8,7 +8,7 @@
 #
 
 
-subdirs= curl fuse gtklos 
+subdirs= curl fuse gtklos
 
 all:
 	@echo "***"
@@ -16,9 +16,9 @@ all:
 	@echo "***"
 
 clean-am:
-	for d in $(subdirs) ;do (cd $$d; $(MAKE) $@) ;done
+	for d in $(subdirs) ;do (cd $$d && $(MAKE) $@) ;done
 	rm -f *~
 
 distclean-am:
-	for d in $(subdirs) ;do (cd $$d; $(MAKE) $@) ;done
+	for d in $(subdirs) ;do (cd $$d && $(MAKE) $@) ;done
 	rm -f Makefile

--- a/extensions/curl/Makefile.am
+++ b/extensions/curl/Makefile.am
@@ -13,5 +13,5 @@ clean-am:
 	rm -f *~
 
 distclean-am: clean-am
-	(cd demos; make distclean)
+	(cd demos && make distclean)
 	rm -f Makefile

--- a/extensions/fuse/Makefile.am
+++ b/extensions/fuse/Makefile.am
@@ -13,5 +13,5 @@ clean-am:
 	rm -f *~
 
 distclean-am: clean-am
-	(cd demos; make distclean)
+	(cd demos && make distclean)
 	rm -f Makefile

--- a/extensions/gtklos/Makefile.am
+++ b/extensions/gtklos/Makefile.am
@@ -10,7 +10,7 @@
 SUBDIRS=lib/stklos demos
 
 clean-am:
-	(cd demos; make clean)
+	(cd demos && make clean)
 	rm -f *~
 
 distclean-am:

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -159,7 +159,7 @@ generate-git-info:
 		$(STKLOS_BINARY) $(STKLOS_FLAGS) -b ../src/boot.img    \
 		-f make-C-boot.stk -- boot.img3 ../src/boot.c);        \
 	   echo "*** Recompile STklos";                            \
-	   (cd ../src; $(MAKE) stklos);                            \
+	   (cd ../src && $(MAKE) stklos);                            \
 	   echo "*** Cleaning useless images";                     \
 	   /bin/rm boot.img[0-3] instr[0-3];                       \
 	else                                                       \
@@ -170,7 +170,7 @@ generate-git-info:
 # Installation of *.stk files
 install-sources:
 	@for i in $(SUBDIRS) ;do \
-	   (cd $$i; $(MAKE) install-sources)\
+	   (cd $$i && $(MAKE) install-sources)\
 	done
 	cp $(SRC_STK) $(scheme_BOOT) $(DESTDIR)$(schemedir)
 
@@ -202,11 +202,11 @@ srfis-data.scm: srfis.stk getopt.ostk
 	$(STKLOS_BINARY) -q -l srfis.stk \
 	                 -f ../utils/update-srfi-list.stk \
                      -- --internal > $@
-	(cd ..; $(MAKE) SUPPORTED-SRFIS)
+	(cd .. && $(MAKE) SUPPORTED-SRFIS)
 
 doc: $(DOCDB)
 	@for i in $(SUBDIRS) ;do \
-	   (cd $$i; $(MAKE) doc)\
+	   (cd $$i && $(MAKE) doc)\
 	done
 
 
@@ -216,18 +216,18 @@ $(DOCDB): $(scheme_sources)
 clean:
 	/bin/rm -f $(scheme_OBJS) $(scheme_SOLIBS) ./srfis-data.scm
 	@for i in $(SUBDIRS) ;do \
-	   (cd $$i; $(MAKE) clean)\
+	   (cd $$i && $(MAKE) clean)\
 	done
 
 distclean: clean
 	/bin/rm -f Makefile
 	touch boot.stk
 	@for i in $(SUBDIRS) ;do \
-	   (cd $$i; $(MAKE) distclean)\
+	   (cd $$i && $(MAKE) distclean)\
 	done
 
 uninstall-hook:
-	(cd $(schemedir) && rm -f $(DOCDB) $(scheme_sources))
+	(cd $(schemedir) && rm -f $(DOCDB) $(scheme_sources)) || true
 	rmdir $(schemedir) $(schemelibdir) || true
 
 

--- a/lib/SILex.d/Makefile.am
+++ b/lib/SILex.d/Makefile.am
@@ -30,6 +30,6 @@ install-sources:
 
 
 uninstall-hook:
-	(cd $(DESTDIR)$(schemedir) && rm -f $(SRC))
+	(cd $(DESTDIR)$(schemedir) && rm -f $(SRC)) || true
 
 doc:

--- a/lib/scheme/Makefile.am
+++ b/lib/scheme/Makefile.am
@@ -146,13 +146,13 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 #
 #
 # $(DEPS):
-# 	(cd ../srfi; $(MAKE)  `basename $@`)
+# 	(cd ../srfi && $(MAKE)  `basename $@`)
 
 
 stream.ostk:     ../streams/primitive.ostk ../streams/derived.ostk
 
 ../streams/derived.ostk ../streams/primitive.ostk:
-	(cd ../streams; $(MAKE) $@)
+	(cd ../streams && $(MAKE) $@)
 
 set.ostk: ../srfi/69.ostk comparator.ostk
 
@@ -162,17 +162,17 @@ charset-incl.c: charset.stk
 
 
 ../srfi/69.ostk:
-	(cd ../srfi; $(MAKE) 69.ostk)
+	(cd ../srfi && $(MAKE) 69.ostk)
 ../srfi/128.ostk:
-	(cd ../srfi; $(MAKE) 128.ostk)
+	(cd ../srfi && $(MAKE) 128.ostk)
 ../srfi/129.ostk:
-	(cd ../srfi; $(MAKE) 129.ostk)
+	(cd ../srfi && $(MAKE) 129.ostk)
 ../srfi/60.ostk:
-	(cd ../srfi; $(MAKE) 60.ostk)
+	(cd ../srfi && $(MAKE) 60.ostk)
 ../srfi/217.ostk:
-	(cd ../srfi; $(MAKE) 217.ostk)
+	(cd ../srfi && $(MAKE) 217.ostk)
 ../stklos/itrie.$(SO):
-	(cd ../stklos; $(MAKE) itrie.$(SO))
+	(cd ../stklos && $(MAKE) itrie.$(SO))
 
 
 bytevector.$(SO): bytevector-incl.c bytevector.c
@@ -206,26 +206,26 @@ regex.ostk: regex/boundary.stk hash-table.ostk list.$(SO) \
 # ======================================================================
 install-sources:
 	@for i in $(SUBDIRS) ;do \
-	   (cd $$i; $(MAKE) install-sources)\
+	   (cd $$i && $(MAKE) install-sources)\
 	done
 	cp $(scheme_sources) $(schemedir)
 
 install-data-hook:
-	(cd regex; $(MAKE) install)
+	(cd regex && $(MAKE) install)
 clean:
-	(cd vector; $(MAKE) clean)
-	(cd regex; $(MAKE) clean)
+	(cd vector && $(MAKE) clean)
+	(cd regex && $(MAKE) clean)
 	rm -f $(scheme_OBJS) *-incl.c *~
 
 distclean: clean
-	(cd vector; $(MAKE) distclean)
-	(cd regex; $(MAKE) distclean)
+	(cd vector && $(MAKE) distclean)
+	(cd regex && $(MAKE) distclean)
 	/bin/rm -f Makefile
 
 uninstall-hook:
-	(cd vector; $(MAKE) uninstall)
-	(cd regex; $(MAKE) uninstall)
-	(cd $(schemedir); rm -f $(scheme_sources))
+	(cd vector && $(MAKE) uninstall)
+	(cd regex && $(MAKE) uninstall)
+	(cd $(schemedir) && rm -f $(scheme_sources)) || true
 	rmdir $(schemedir) || true
 
 doc:

--- a/lib/scheme/vector/Makefile.am
+++ b/lib/scheme/vector/Makefile.am
@@ -117,10 +117,10 @@ f32.stk f64.stk c64.stk c128.stk: tagvector-template.stk base.$(SO)
 # Dependencies
 
 ../../scheme/comparator.ostk:
-	(cd ../../scheme; $(MAKE) comparator.ostk)
+	(cd ../../scheme && $(MAKE) comparator.ostk)
 
 ../../srfi/4.ostk:
-	(cd ../../srfi; $(MAKE) 4.ostk)
+	(cd ../../srfi && $(MAKE) 4.ostk)
 
 base.$(SO): ../../srfi/4.ostk ../../scheme/comparator.ostk base-incl.c base.c
 
@@ -142,7 +142,7 @@ distclean: clean
 	/bin/rm -f Makefile $(srfi_interm)
 
 uninstall-hook:
-	(cd $(srfidir); rm -f $(srfi_sources) $(srfi_interm))
+	(cd $(srfidir) && rm -f $(srfi_sources) $(srfi_interm)) || true
 	rmdir $(srfidir) || true
 ##
 ## # no docs...

--- a/lib/srfi/160/Makefile.am
+++ b/lib/srfi/160/Makefile.am
@@ -98,43 +98,43 @@ c64.ostk:  ../../scheme/vector/c64.ostk
 c128.ostk: ../../scheme/vector/c128.ostk
 
 ../../scheme/vector/base.$(SO):
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/s8.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/u8.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/s16.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/u16.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/s32.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/u32.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/s64.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/u64.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/f32.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/f64.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/c64.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 ../../scheme/vector/c128.ostk:
-	(cd ../../scheme/vector; $(MAKE) $@)
+	(cd ../../scheme/vector && $(MAKE) $@)
 
 
 #======================================================================
@@ -150,7 +150,7 @@ distclean: clean
 	/bin/rm -f Makefile
 
 uninstall-hook:
-	(cd $(srfidir); rm -f $(srfi_sources) )
+	(cd $(srfidir) && rm -f $(srfi_sources) ) || true
 	rmdir $(srfidir) || true
 ##
 ## # no docs...

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -349,62 +349,62 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 238.$(SO): 238-incl.c 238.c
 
 ../streams/derived.ostk:
-	(cd ../streams; $(MAKE) derived.ostk)
+	(cd ../streams && $(MAKE) derived.ostk)
 ../scheme/list.$(SO):
-	(cd ../scheme; $(MAKE) list.$(SO))
+	(cd ../scheme && $(MAKE) list.$(SO))
 ../scheme/charset.ostk:
-	(cd ../scheme; $(MAKE) charset.ostk)
+	(cd ../scheme && $(MAKE) charset.ostk)
 ../scheme/set.ostk:
-	(cd ../scheme; $(MAKE) set.ostk)
+	(cd ../scheme && $(MAKE) set.ostk)
 ../scheme/ilist.$(SO):
-	(cd ../scheme; $(MAKE) ilist.$(SO))
+	(cd ../scheme && $(MAKE) ilist.$(SO))
 ../scheme/list-queue.ostk:
-	(cd ../scheme; $(MAKE) list-queue.ostk)
+	(cd ../scheme && $(MAKE) list-queue.ostk)
 ../scheme/hash-table.ostk:
-	(cd ../scheme; $(MAKE) hash-table.ostk)
+	(cd ../scheme && $(MAKE) hash-table.ostk)
 ../scheme/lseq.ostk:
-	(cd ../scheme; $(MAKE) lseq.ostk)
+	(cd ../scheme && $(MAKE) lseq.ostk)
 ../scheme/sort.$(SO):
-	(cd ../scheme; $(MAKE) sort.$(SO))
+	(cd ../scheme && $(MAKE) sort.$(SO))
 ../scheme/generator.ostk:
-	(cd ../scheme; $(MAKE) generator.ostk)
+	(cd ../scheme && $(MAKE) generator.ostk)
 ../scheme/ideque.ostk:
-	(cd ../scheme; $(MAKE) ideque.ostk)
+	(cd ../scheme && $(MAKE) ideque.ostk)
 ../scheme/division.ostk:
-	(cd ../scheme; $(MAKE) division.ostk)
+	(cd ../scheme && $(MAKE) division.ostk)
 ../scheme/flonum.$(SO):
-	(cd ../scheme; $(MAKE) division.$(SO))
+	(cd ../scheme && $(MAKE) division.$(SO))
 ../scheme/bitwise.$(SO):
-	(cd ../scheme; $(MAKE) bitwise.ostk)
+	(cd ../scheme && $(MAKE) bitwise.ostk)
 ../scheme/vector/@.ostk:
-	(cd ../scheme/vector; $(MAKE) @.ostk)
+	(cd ../scheme/vector && $(MAKE) @.ostk)
 ../scheme/regex.ostk:
-	(cd ../scheme;  $(MAKE) regexp.ostk)
+	(cd ../scheme && $(MAKE) regexp.ostk)
 
 ../stklos/itrie.$(SO):
-	(cd ../stklos; $(MAKE) itrie.$(SO))
+	(cd ../stklos && $(MAKE) itrie.$(SO))
 #======================================================================
 
 install-data-hook:
-	(cd 160; $(MAKE) install)
+	(cd 160 && $(MAKE) install)
 
 install-sources:
 	@for i in $(SUBDIRS) ;do \
-	   (cd $$i; $(MAKE) install-sources)\
+	   (cd $$i && $(MAKE) install-sources)\
 	done
 	cp $(srfi_sources) $(srfidir)
 
 clean:
 	rm -f $(srfi_OBJS) *-incl.c *~
-	(cd 160; $(MAKE) clean)
+	(cd 160 && $(MAKE) clean)
 
 distclean: clean
 	/bin/rm -f Makefile
-	(cd 160; $(MAKE) distclean)
+	(cd 160 && $(MAKE) distclean)
 
 uninstall-hook:
-	(cd 160; $(MAKE) uninstall)
-	(cd $(srfidir); rm -f $(srfi_sources))
+	(cd 160 && $(MAKE) uninstall)
+	(cd $(srfidir) && rm -f $(srfi_sources))
 	rmdir $(srfidir) || true
 
 doc:

--- a/lib/stklos/Makefile.am
+++ b/lib/stklos/Makefile.am
@@ -86,7 +86,7 @@ distclean: clean
 	/bin/rm -f Makefile
 
 uninstall-hook:
-	(cd $(schemedir); rm -f $(scheme_sources))
+	(cd $(schemedir) && rm -f $(scheme_sources)) || true
 	rmdir $(schemedir) || true
 
 doc:

--- a/lib/streams/Makefile.am
+++ b/lib/streams/Makefile.am
@@ -71,7 +71,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 # Dependencies
 derived.ostk: primitive.ostk ../scheme/list.$(SO)
 ../scheme/list.$(SO):
-	(cd ../scheme; $(MAKE) list.$(SO))
+	(cd ../scheme && $(MAKE) list.$(SO))
 
 # ======================================================================
 install-sources:
@@ -84,7 +84,7 @@ distclean: clean
 	/bin/rm -f Makefile
 
 uninstall-hook:
-	(cd $(schemedir); rm -f $(scheme_sources))
+	(cd $(schemedir) && rm -f $(scheme_sources)) || true
 	rmdir $(schemedir) || true
 
 doc:

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -38,7 +38,7 @@ stklos-pp: stklos-pp.stk ../lib/stklos/preproc.ostk
 	$(COMP) -o stklos-pp stklos-pp.stk
 
 ../lib/stklos/preproc.ostk:
-	(cd ../lib/stklos; $(MAKE)  preproc.ostk)
+	(cd ../lib/stklos && $(MAKE)  preproc.ostk)
 
 clean-am:
 	rm -f $(scmbin) $(localscript) *~


### PR DESCRIPTION
Otherwise we may end up removing source files when uninstalling.

Should fix #689 