### PR TITLE
Making cross-compilation easier

### DIFF
--- a/INSTALL-cross-compile.md
+++ b/INSTALL-cross-compile.md
@@ -1,0 +1,36 @@
+# Cross-compiling STklos
+
+## How to cross-compile
+
+Cross-compilation is just like compilation
+
+```
+./configure prefix=some-tmp-dir CC=some-C-compiler CFLAGS=your-c-flags ...
+make
+make install
+```
+
+The relevant environment variables are described in the output
+of `configure --help`.
+
+***However:***
+
+* You *need* a STklos binary in order to compile STklos. When not
+  cross-copiling,
+  - the binary is generated as `src/stklos`
+  - the build proceeds using `src/stklos` as the STklos binary that
+    can be used to compile `.stk` files
+  However, when cross-compiling `src/stklos` will be a binary for a
+  different (target) architecture, and the build will fail, unless we
+  have a native STklos in the system that can be used instead.
+
+* Put the full path of the STklos binary in the `STKLOS_BINARY`
+  variable when calling `make`:
+
+```
+./configure --prefix=/usr/some/place
+make `STKLOS_BINARY=/usr/local/bin/stklos`
+make install
+```
+
+Now you can copy the `usr/some/place` directory to the target machine.

--- a/lib/scheme/Makefile.am
+++ b/lib/scheme/Makefile.am
@@ -151,8 +151,11 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 
 stream.ostk:     ../streams/primitive.ostk ../streams/derived.ostk
 
-../streams/derived.ostk ../streams/primitive.ostk:
-	(cd ../streams && $(MAKE) $@)
+../streams/derived.ostk:
+	(cd ../streams && $(MAKE) derived.ostk)
+
+../streams/primitive.ostk:
+	(cd ../streams && $(MAKE) primitive.ostk)
 
 set.ostk: ../srfi/69.ostk comparator.ostk
 

--- a/utils/tmpcomp
+++ b/utils/tmpcomp
@@ -62,12 +62,14 @@ case $# in
 esac
 
 prefix="$(cd -- "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)"
+[ "x$STKLOS_BINARY" != "x" ] || STKLOS_BINARY=${prefix}/src/stklos
 
 STKLOS_LOAD_PATH=".:../lib:${prefix}/lib:"
 STKLOS_BUILDING=1
 export STKLOS_LOAD_PATH STKLOS_BUILDING
 
-${prefix}/src/stklos -c -q -f ${prefix}/utils/stklos-compile.stk -- \
+
+${STKLOS_BINARY} -c -q -f ${prefix}/utils/stklos-compile.stk -- \
      --no-time $Copt --output=$out $in
 
 status=$?

--- a/utils/tmpgenlex
+++ b/utils/tmpgenlex
@@ -24,10 +24,11 @@
 #    Creation date:  1-Jan-2002 18:57 (eg)
 #
 
+prefix="$(cd -- "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)"
+[ "x$STKLOS_BINARY" != "x" ] || STKLOS_BINARY=${prefix}/src/stklos
 
-STKLOS_LOAD_PATH="../lib"
-export STKLOS_LOAD_PATH 
-
-../src/stklos -c -q -b ../src/boot.img -f ../utils/stklos-genlex -- $*
+STKLOS_LOAD_PATH=".:../lib:${prefix}/lib:"
+export STKLOS_LOAD_PATH
 
 
+${STKLOS_BINARY} -c -q -b ../src/boot.img -f ../utils/stklos-genlex -- $*


### PR DESCRIPTION
@egallesio : 

I have been cross-compiling STklos for wireless routers (and it works really well - STklos has a very short startup time, and that makes a huge difference on some devices!)

But some recent changes made cross-compilation a bit more difficult. Looking into it, I see it would actually be nice if a few changes were applied to the `Makefile`s and also to `tmpcomp`/`tmpgenlex`.

### 1 -  Use `$STKLOS_BINARY`, not `src/stklos` during compilation
    
This is a very small change, but is crucial for cross-compilation.
    
When the variable `STKLOS_BINARY` is set, it will be used (during cross-compilation, it will be the locally installed stklos); when it is not set, then `${prefix}/src/stklos` is used.
    
Also, in `tmpcomp`, the prefix was computed as `../`, relative to utils. But in `tmpgenlex` it was hardcoded. This PR also changes `tmpgenlex` to do the same as `tmpcomp`.

### 2 -  Don't use `$@` when calling make recursively
    
This seems to break cross-copilation.
    
The program `tmpcomp` uses the environment variable `STKLOS_BINARY`  to tell which STklos executable it can use. However, when we use this rule:
  
```
../streams/derived.ostk: ../streams/primitive.ostk:
        (cd ../streams && $(MAKE) $@)
```
    
that variable is not passed recursively to the child `make`, and  the process fails during cross-compilation.
    
If we do this:

```
../streams/derived.ostk:
        (cd ../streams && $(MAKE) derived.ostk)

../streams/primitive.ostk:
        (cd ../streams && $(MAKE) primitive.ostk)
```
    
It (magically?) works.

### 3 - A short text explaining how to cross-compile 

Basically, it says one should set the `STKLOS_BINARY` variable.

