### PR TITLE
Don't reference char of empty symbol's name

### DIFF
--- a/lib/repl.stk
+++ b/lib/repl.stk
@@ -481,6 +481,7 @@ doc>
 
              ((and (symbol? e)
                    (not (symbol-bound? e))
+                   (not (eq? e '||))
                    (char=? (string-ref (symbol->string e) 0) #\!))
                  ;; Shell command "!xxx arg1 arg2"
                  (let* ((end (read-line (current-input-port)))


### PR DESCRIPTION
```
stklos> ||
**** Error:
string-ref: index '0' out of bound in string '""'
```

This is because, if the line begins with a symbol, the REPL will try to look into its name to check if it's "!", (a shell command).  But the empty symbol has no chars in its name...

With this PR, the behavior is:

```
stklos> ||
**** Error:
%execute: symbol '||' unbound in module 'stklos'
```