### PR TITLE
[simple] Add `symbol-interned?`

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -321,6 +321,8 @@ static inline SCM hash_get_symbol(struct hash_table_obj *h, const char *s, int *
   return (SCM) NULL;
 }
 
+SCM STk_hash_get_symbol(struct hash_table_obj *h, const char *s, int *index)
+{ return hash_get_symbol(h, s, index); }
 
 SCM STk_hash_intern_symbol(struct hash_table_obj *h, const char *s, SCM (*create) (const char *s))
 {

--- a/src/hash.h
+++ b/src/hash.h
@@ -91,6 +91,7 @@ void STk_hashtable_init(struct hash_table_obj *h, int flag);
  */
 SCM STk_hash_intern_symbol(struct hash_table_obj *h, const char *s,
                            SCM (*create)(const char *s));
+SCM STk_hash_get_symbol(struct hash_table_obj *h, const char *s, int *index);
 
 /*
  * Function for accessing module hash table. Don't use them but the

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -88,6 +88,35 @@ SCM STk_intern(char *name)
   return res;
 }
 
+/*
+<doc EXT symbol-interned?
+ * (symbol-interned? sym)
+ *
+ * Returns |#t| if |sym| is an interned symbol, amd |#f| if |sym| is an
+ * uninterned symbol. When |sym| is not a symbol, an error is signalled.
+ * @lisp
+ * (symbol-interned? (gensym))      => #f
+ * (symbol-interned? (gensym "x-")) => #f
+ * (symbol-interned? 'a)            => #t
+ * (symbol-interned? "x")           => error
+ * @end lisp
+doc>
+*/
+DEFINE_PRIMITIVE("symbol-interned?", symbol_interned_p, subr1, (SCM x))
+{
+  int unused;
+  if (!SYMBOLP(x)) STk_error("bad symbol ~s", x);
+  SCM s = STk_hash_get_symbol(&obarray, SYMBOL_PNAME(x), &unused);
+
+  /* If it's not in the table, it's not interned: */
+  if (!s) return STk_false;
+
+  /* Howeer, it's not enough to check its presence in the table. We
+     need to see wether the symbol found there is eq? to the one we
+     have: */
+  return STk_eq(s,x);
+}
+
 DEFINE_PRIMITIVE("symbol?", symbolp, subr1, (SCM x))
 /*
 <doc  symbol?
@@ -206,5 +235,6 @@ int STk_init_symbol(void)
   ADD_PRIMITIVE(symbol2string);
   ADD_PRIMITIVE(string2symbol);
   ADD_PRIMITIVE(string2usymbol);                /* + */
+  ADD_PRIMITIVE(symbol_interned_p);
   return TRUE;
 }

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -51,6 +51,16 @@ b|)
 (test/error "non finished hex sequence.2" (read-from-string "a\\x123"))
 (test/error "too long hex sequence" (read-form-string "\\x111111111111111111111111"))
 
+(test "gensym.1" #t (symbol? (gensym)))
+(test "gensym.2" #t (symbol? (gensym 'a)))
+(test "gensym.3" #t (symbol? (gensym "a")))
+(test "symbol-interned?.1" #f (symbol-interned? (gensym)))
+(test "symbol-interned?.2" #f (symbol-interned? (gensym 'a)))
+(test "symbol-interned?.3" #f (symbol-interned? (gensym "a-")))
+(test "symbol-interned?.4" #t (symbol-interned? 'a))
+(test/error "symbol-interned?.4" (symbol-interned? "a"))
+(test "string->unsymbol-interned?.1" #t (symbol? (string->uninterned-symbol  "aaa")))
+(test "string->unsymbol-interned?.2" #f (symbol-interned? (string->uninterned-symbol  "aaa")))
 
 ;;----------------------------------------------------------------------
 (test-subsection "Paths")


### PR DESCRIPTION
```scheme
(define aaa 1)

(symbol-interned? (string->uninterned-symbol  "aaa"))   => #f
(symbol-interned? (string->uninterned-symbol  "aaaaa")) => #f
(symbol-interned? (gensym))                             => #f

(symbol-interned? 'a)                                   => #t
(symbol-interned? 'aaa)                                 => #t
```

Inspired by a discussion on the SRFI-258 mailing list.