### PR TITLE
Make `eqv?` and `symbol=?` agree.

### DIFF
--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -569,12 +569,13 @@ doc>
 doc>
 |#
 (define (symbol=? e1 . rest)
-  (letrec ((verify (lambda (val lst)
-                  (or (null? lst)
-                     (and (symbol? (car lst))
-                        (eq? (car lst) val)
-                        (verify val (cdr lst)))))))
-    (verify e1 rest)))
+  (unless (symbol? e1) (error "bad symbol ~s" e1))
+  (letrec ((verify (lambda (lst)
+                     (cond ((null? lst)               #t)
+                           ((not (symbol? (car lst))) (error "bad symbol ~s" (car lst)))
+                           ((eq? (car lst) e1)        (verify (cdr lst)))
+                           (else                      #f)))))
+    (verify rest)))
 
 
 ;;;; ----------------------------------------------------------------------

--- a/src/boolean.c
+++ b/src/boolean.c
@@ -192,6 +192,7 @@ DEFINE_PRIMITIVE("eqv?", eqv, subr2, (SCM x, SCM y))
 
   switch (STYPE(x)) {
     case tc_symbol:
+        if (x != y) return STk_false; /* one of the is uninterned! */
         if (SYMBOLP(y) && strcmp(SYMBOL_PNAME(x), SYMBOL_PNAME(y)) == 0)
           return STk_true;
         break;
@@ -468,7 +469,7 @@ static SCM equal_count(SCM x, SCM y, int max, int *cycle)
 /* The code below is a rewriting of the equiv? function given in the Reference
  * implementation of the (withdrwn) SRFI 85 (Recursive Equivalence
  * Predicates).
- * 
+ *
  * Original Scheme code is "Copyright 2006 William D Clinger"
  *
  * EQUIV? is a version of EQUAL? that terminates on all arguments.

--- a/tests/test-r7rs.stk
+++ b/tests/test-r7rs.stk
@@ -835,10 +835,11 @@
 ;;------------------------------------------------------------------
 (test-subsection "6.5 Symbols")
 
-(test "symbol=?.1" #t (symbol=? 'a 'a (string->symbol "a")))
-(test "symbol=?.2" #t (symbol=? '|A| (string->symbol "A")))
-(test "symbol=?.3" #f (symbol=? '|A| (string->symbol "a")))
-(test "symbol=?.4" #f (symbol=? 'a 'a "a"))
+(test "symbol=?.1" #t    (symbol=? 'a 'a (string->symbol "a")))
+(test "symbol=?.2" #t    (symbol=? '|A| (string->symbol "A")))
+(test "symbol=?.3" #f    (symbol=? '|A| (string->symbol "a")))
+(test/error "symbol=?.4" (symbol=? 'a 'a "a"))
+(test "symbol=?.5" #f    (eqv? (string->uninterned-symbol "x") (string->uninterned-symbol "x")))
 
 
 ;;-------------------------------------------------------------------


### PR DESCRIPTION
Currently, if one of the symbols is uninterned, `eqv?` may consider both to be the same. With this patch, `eqv?` won't deal with uninterned symbols, treating them always as "different from whatever else".

This is the same behavior as Chez, Chicken, Gambit, Gauche, MIT, ypsilon. (Bigloo, Kawa, Chibi do not have string->uninterned-symbol).

The change is:

1. In `eqv?`, check for hard equality (with `==`) so if one of the symbols is uninterned, the result is `#f`
2. Since we're at it, rewrite `symbol=?` so it will not accept non-symbol arguments (so its behavior will be the same as `string=?`

So now:
```scheme
(eqv? (string->uninterned-symbol "x")
      (string->uninterned-symbol "x"))       => #f
```

This should fix #709