### PR TITLE
Add `quote-expanded`

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -314,6 +314,31 @@ doc>
       (compile-constant (cadr expr) env tail?)
       (compiler-error 'quote expr "bad usage in ~S" expr)))
 
+#|
+<doc syntax quote-expanded
+ * (quote-expanded form)
+ *
+ * |Quote-expanded| will first expand then quote (without evaluating)
+ * |form|, and it can be used not only on the REPL or on top-level
+ * contexts, but also inside |let-syntax|.
+ *
+ * @lisp
+ * (let-syntax ((%f (syntax-rules ()
+ *                    ((%f) (format  "2")))))
+ *   (quote-expanded (%f)))                    => (format "2")
+ *
+ * (let-syntax ((%f (syntax-rules ()
+ *                    ((%f x) (display x)))))
+ *   (quote-expanded (%f '(a b c))))           => (display '(a b c))
+ * @end lisp
+doc>
+|#
+(define (compile-quote-expanded expr env tail?)
+  (if (= (length expr) 2)
+      (compile-constant (%macro-expand (cadr expr) env) env tail?)
+      (compiler-error 'quote-expanded expr "bad usage in ~S" expr)))
+
+
 ; ======================================================================
 ;
 ;                               DEFINE
@@ -2113,6 +2138,7 @@ both forms.
             ((quasiquote)         (compile-quasiquote     e env tail?))
             ((with-handler)       (compile-with-handler   e env tail?))
             ((define-macro)       (compile-define-macro   e env tail?))
+            ((quote-expanded)     (compile-quote-expanded e env tail?))
 
             ((%%set!)             (compile-%%set!         e env tail?))
 

--- a/tests/test-macros.stk
+++ b/tests/test-macros.stk
@@ -273,6 +273,45 @@
           (g ((quote ...) 2 3 4 5 6)))))
 
 
+
+;; quote-expanded
+
+(let-syntax ((%f (syntax-rules ()
+                    ((%f) (format  "2")))))
+  (test "quote-expanded.1"
+        '(format "2")
+        (quote-expanded (%f))))
+
+(let-syntax ((%f (syntax-rules ()
+                   ((%f x) (display x) ))))
+  (test "quote-expanded.2"
+        '(display '(a b c))
+        (quote-expanded (%f '(a b c)))))
+
+(define-syntax %fgh
+  (syntax-rules ()
+    ((_ a b) '(b a))))
+
+(test "quote-expanded.3-a"
+      ;; the macro introduces a quote
+      '(4 "x")
+      (%fgh "x" 4))
+
+(test "quote-expanded.3-b"
+      ;; the macro introduces a quote, and quote-expanded
+      ;; introduces one more!
+      ''(4 "x")
+      (quote-expanded (%fgh "x" 4)))
+
+(define-macro (%ijk x y) `(something ,x ,y))
+
+(test "quote-expanded.3"
+      '(something 'symbol #(2 3))
+      (quote-expanded (%ijk 'symbol #(2 3))))
+
+
+
+
 ;;FIXME: Add more tests !!!!!!!!!
 
 


### PR DESCRIPTION
Five lines added to the compiler, nothing else :grin:   (Not counting the tests, of course)

`(quote-expanded form)`

`Quote-expanded` will first expand then quote (without evaluating) `form`, and it can be used not only on the REPL or on top-level contexts, but also inside `let-syntax`.

```scheme
(let-syntax ((%f (syntax-rules ()
                   ((%f) (format  "2")))))
  (quote-expanded (%f)))                    => (format "2")

(let-syntax ((%f (syntax-rules ()
                   ((%f x) (display x)))))
  (quote-expanded (%f '(a b c))))           => (display '(a b c))
```

Fixes #712 