### PR TITLE
Make `list-copy` work on lists with cycles

### DIFF
--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -771,5 +771,37 @@ b|)
             (eval-from-string "(DisPlaY 3.14)"))
 
 
+(test-subsection "copy lists with cycles")
+
+;; We do NOT put cyclic lists in the expected value of tests, because the
+;; test suite would try to print them in a way that loops forever.
+;; Instead, we test for #t outcome from EQUAL?
+
+(test "list-copy with cycles 1"
+      #t
+      (equal? '#0=(1 2 3 . #0#)
+              (list-copy '#0=(1 2 3 . #0#))))
+
+(test "list-copy with cycles 2"
+      #t
+      (equal? '(1 2 . #0=(3 4 5 . #0#))
+              (list-copy '(1 2 . #0=(3 4 5 . #0#)))))
+
+(test "list-copy with cycles 3"
+      #t
+      (equal? '#0=(1 . #0#)
+              (list-copy '#0=(1 . #0#))))
+
+
+(let ((results (make-list 50 #f)))
+  (dotimes (i 50)
+    (let ((L (make-list 1000 #void)))
+      (set-cdr! (last-pair L) (list-tail L (+ 500 i)))
+      (list-set! results i (equal? L (list-copy L)))))
+  (test ""
+        #t
+        (every (lambda (x) x)  results)))
+
+
 ;;------------------------------------------------------------------
 (test-section-end)


### PR DESCRIPTION
The current `list-copy` crashes on lists with cycles:
    
```
stklos> (list-copy '#0=(1 2 3 . #0#) )
Segmentation fault
```

This is because its implementation is non-tail recursive, and does  not detect cycles.

This patch makes `list-copy` detect cycle, and correctly copy the list.
    
About the cycle detecting and copying algorithm:
    
1. Detect cycles using Floyd's algorithm.  The algorithm runs two pointers, "fast" and "slow" through the list. Both are placed at the `CAR`, then at each step, slow goes forward one link, and fast goes forward two links.
    
2. If there is a cycle:
    
   2.i) we position fast back at the CAR and now move the two  pointers *one* link at each time. The pointers will *necessarily meet* exactly *at the beginning of the cycle.
    
   2.ii) If there is a cycle, we break the list in two parts. For example, the cycle below starts at `C`:
```    
                        +--------------+
                        |              |
                        v              |
              A -> B -> C -> D -> E -> F
```    
              We break the links from B to C and from F to C:
```    
              A -> B    C -> D -> E -> F
```    
Then we just copy the two lists and put back the links.
    
3. If there is no cycle, use a simple copying subroutine to copy  the list.
    
Remarks:
    
1. See that when there are cycles, we change the links *in the  original list* also (but we fix it before returning).
    
2. We use `STk_last_pair`, which is not optimal. But we also expect  lists with cycles not not be frequent, and also to not be huge.  And `STk_last_pair` is linear anyway.
3. The code still works for improper lists (as did the previous  code).
4. The performance seems the same for cycle-free lists, since the  cycle test is very fast:
    
```scheme
(import (scheme list))
(define L (iota 100_000))
(time (repeat 100 (list-copy L)))
```
    
This stays around ~430 ms on the same machine, with the old and the new version of `list-copy`.
    
5. However, since the algorithm used to actually do the copy is still non-tail recursive, `list-copy` will still crash on very long lists:
    
```scheme
(define L (iota 10_000_000))
(list-copy L)   ;; <= segfault
```

But this already happened before, and I'd say it's OK since for deep copying one does need a stack anyway (either implicitly with recursion or explicitly).
    
Remaining:
    
There is one case that is still not ok: if the **CAR** of the list contains a reference to a previous node, `list-copy` will crash    (as it did before).  This is probably very, very unusual.


Should at least partially fix #719 