### PR TITLE
Make STklos compile with GCC-15

### DIFF
--- a/src/mutex-pthreads.c
+++ b/src/mutex-pthreads.c
@@ -57,7 +57,7 @@ void STk_make_sys_mutex(SCM z)
  *
  * Returns information about the state of the |mutex|. The possible results
  * are:
- * 
+ *
  *  * a thread *T*: the mutex is in the locked/owned state and
  *    thread *T* is the owner of the mutex
  *  * the symbol *not-owned*: the mutex is in the locked/not-owned
@@ -66,7 +66,7 @@ void STk_make_sys_mutex(SCM z)
  *    state
  *  * the symbol *not-abandoned*: the mutex is in the
  *     unlocked/not-abandoned state
- * 
+ *
  * @lisp
  * (mutex-state (make-mutex))  =>  not-abandoned
  *
@@ -121,7 +121,7 @@ DEFINE_PRIMITIVE("mutex-state", mutex_state, subr1, (SCM mtx))
  *    is not supplied),
  *  ** if T is terminated the mutex becomes _unlocked/abandoned_,
  *  ** otherwise mutex becomes _locked/owned_ with T as the owner.
- * 
+ *
  * After changing the state of the mutex, an "abandoned mutex exception" is
  * raised if the mutex was unlocked/abandoned before the state change,
  * otherwise |mutex-lock!| returns |#t|.
@@ -146,7 +146,7 @@ DEFINE_PRIMITIVE("%mutex-lock!", mutex_lock, subr3, (SCM mtx, SCM tm, SCM thread
     ts.tv_nsec = (suseconds_t) ((tmd - ts.tv_sec) * 1000000);
   }
 
-  pthread_cleanup_push((void (*)()) mutex_finalizer, mtx);
+  pthread_cleanup_push((void (*)(SCM)) mutex_finalizer, mtx);
 
   if (pthread_mutex_lock(&MUTEX_MYMUTEX(mtx)) != 0)
     STk_error_deadlock();
@@ -216,7 +216,7 @@ DEFINE_PRIMITIVE("%mutex-unlock!", mutex_unlock, subr3, (SCM mtx, SCM cv, SCM tm
     ts.tv_nsec = (suseconds_t) ((tmd - ts.tv_sec) * 1000000000);
   }
 
-  pthread_cleanup_push((void (*)()) mutex_finalizer, mtx);
+  pthread_cleanup_push((void (*)(SCM)) mutex_finalizer, mtx);
 
   if (pthread_mutex_lock(&MUTEX_MYMUTEX(mtx)) != 0)
     STk_error_deadlock();

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -272,7 +272,11 @@ typedef struct {
 struct primitive_obj {
   stk_header header;
   char *name;
-  SCM (*code)();
+  /* The following line was
+       SCM (*code)();
+     but GCC 15 does not allow us to initialize it with primitives of type
+     (SCM (*code)(void*, void*, ...)), so we use "void*" which works.       */
+  void *code;
   SCM plist;
 };
 
@@ -1181,7 +1185,7 @@ int   STk_init_reader(void);
 int   STk_keyword_colon_convention(void); // pos. of ':' in symbol to make a  keyword
 void STk_add_uvector_reader_tag(const char *tag); // to add #s8(..), #u16(...) ...
 void STk_set_port_case_sensitivity(SCM port, int sensitive);
-  
+
 
 
 /*

--- a/src/thread-pthreads.c
+++ b/src/thread-pthreads.c
@@ -91,7 +91,7 @@ static void *start_scheme_thread(void *arg)
   THREAD_VM(thr)->start_stack = start_stack;
 
   pthread_setspecific(vm_key, THREAD_VM(thr));
-  pthread_cleanup_push(terminate_scheme_thread, thr);
+  pthread_cleanup_push((void (*)(SCM))terminate_scheme_thread, thr);
 
   res = STk_C_apply(THREAD_THUNK(thr), 0);
   if (THREAD_EXCEPTION(thr) == STk_false) {
@@ -154,7 +154,7 @@ DEFINE_PRIMITIVE("thread-yield!", thread_yield, subr0, (void))
  * |thread-terminate!| does not return. Otherwise, |thread-terminate!|
  * returns an unspecified value; the termination of the thread will occur
  * before |thread-terminate!| returns.
- * 
+ *
  * [NOTE]
  * ====
  * -  This operation must be used carefully because it terminates a thread


### PR DESCRIPTION
I'm not actually sure about the first change. @egallesio what do you think?

* Use `void *code` instead of `SCM (*code)()` in `struct primitive_obj`, so GCC won't check types (it's just a void pointer now).

* Use `SCM` for the arguments to pthreads functions.

Passes all tests.