### PR TITLE
Do not take `CAR` of `()` in " `#,()` "

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1214,6 +1214,9 @@ static SCM read_srfi10(SCM port, SCM l)
   if (len < 0)
     signal_error(port, "bad list in a #,(...) form ~S", l);
 
+  if (len == 0)
+    signal_error(port, "empty tag in a #,(...) form", STk_nil);
+
   tmp = STk_int_assq(CAR(l), ctor_table);
   if (tmp == STk_false)
     signal_error(port, "bad tag in a #,(...) form ~S", CAR(l));


### PR DESCRIPTION
Fixes the following segfault:

```
 stklos> #,()

 Program received signal SIGSEGV, Segmentation fault.
 0x00005555555a66e3 in read_srfi10 (port=0x7ffff7441840, l=0x3) at read.c:1217
 1217	  tmp = STk_int_assq(CAR(l), ctor_table);
 (gdb) where
 #0  0x00005555555a66e3 in read_srfi10 (port=0x7ffff7441840, l=0x3) at read.c:1217
 #1  0x00005555555a5fea in read_sharp (port=0x7ffff7441840, ctx=0x7fffffffdae0, inlist=0) at read.c:987
 #2  0x00005555555a62ee in read_rec (port=0x7ffff7441840, ctx=0x7fffffffdae0, inlist=0) at read.c:1078
 #3  0x00005555555a64c3 in read_it (port=0x7ffff7441840, case_significant=1024, constant=1) at read.c:1150
 #4  0x00005555555a653a in STk_read_constant (port=0x7ffff7441840, case_significant=1024) at read.c:1167
 #5  0x000055555559dd4a in STk_scheme_read_cst (port=0x7ffff7441840) at port.c:315
 #6  0x00005555555bd750 in run_vm (vm=0x7ffff77dcf00) at vm.c:2248
 #7  0x00005555555be97a in STk_boot_from_C () at vm.c:2683
 #8  0x00005555555aaae9 in main (argc=0, argv=0x7fffffffe0e0) at stklos.c:290
```