### PR TITLE
Optimize `make-list` and `vector->list`

### DIFF
--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -34,7 +34,7 @@
         truncate-remainder floor-remainder
         square exact-integer-sqrt exact inexact
         boolean=?
-        make-list member assoc
+        member assoc
         symbol=?
         string=?     %string2=?
         string<?     %string2<?
@@ -538,23 +538,6 @@ doc>
                         (eq? (car lst) val)
                         (verify val (cdr lst)))))))
     (verify e1 rest)))
-
-;;;; ----------------------------------------------------------------------
-;;;; 6.4 Pairs and lists
-;;;; ----------------------------------------------------------------------
-
-#|
-<doc R7RS make-list
- * (make-list k)
- * (make-list k fill)
- *
- * Returns a newly allocated list of k elements. If a second
- * argument is given, then each element is initialized to fill .
- * Otherwise the initial contents of each element is unspecified.
-doc>
-|#
-(define (make-list k :optional (fill (void)))
-  (vector->list (make-vector k fill)))
 
 
 ;;;; ----------------------------------------------------------------------

--- a/src/list.c
+++ b/src/list.c
@@ -309,6 +309,7 @@ doc>
 doc>
 */
 DEFINE_PRIMITIVE("make-list", make_list, subr12, (SCM n, SCM init)) {
+  if (!INTP(n)) STk_error("bad integer ~s", n);
   if (!init) init = STk_void;
   return STk_must_malloc_list(INT_VAL(n), init);
 }

--- a/src/list.c
+++ b/src/list.c
@@ -232,7 +232,7 @@ DEFINE_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name))
    * NOTE: using strings (instead of keywords) is less efficient because
    * the char * is at the end of the object. Using symbols is also fast
    * (even a bit faster, don't know why), but it is harder  to detect that
-   * that we can inline when we have (%cxr lst 'daa), because of the quote. 
+   * that we can inline when we have (%cxr lst 'daa), because of the quote.
    */
   if (KEYWORDP(name)) {
     SCM lst   = l;
@@ -298,6 +298,21 @@ doc>
 {
   return MAKE_BOOLEAN(STk_int_length(x) >= 0);
 }
+
+/* <doc R7RS make-list
+ * (make-list k)
+ * (make-list k fill)
+ *
+ * Returns a newly allocated list of k elements. If a second
+ * argument is given, then each element is initialized to fill .
+ * Otherwise the initial contents of each element is unspecified.
+doc>
+*/
+DEFINE_PRIMITIVE("make-list", make_list, subr12, (SCM n, SCM init)) {
+  if (!init) init = STk_void;
+  return STk_must_malloc_list(INT_VAL(n), init);
+}
+
 
 DEFINE_PRIMITIVE("list", list, vsubr, (int argc, SCM * argv))
 /*
@@ -1061,6 +1076,7 @@ int STk_init_list(void)
   ADD_PRIMITIVE(cxr);
   ADD_PRIMITIVE(nullp);
   ADD_PRIMITIVE(listp);
+  ADD_PRIMITIVE(make_list);
   ADD_PRIMITIVE(list);
   ADD_PRIMITIVE(list_length);
   ADD_PRIMITIVE(append);

--- a/src/proc.c
+++ b/src/proc.c
@@ -367,10 +367,16 @@ DEFINE_PRIMITIVE("procedure-source", proc_source, subr1, (SCM proc))
  *                      M A P   &   F O R - E A C H
  *
 \*===========================================================================*/
+
+/* map does both 'map' and 'for-each':
+   - when in_map is non-zero, the result of each operation will be stored
+     in a result list
+   - when it is zero, no result is stored, and AN EMPTY LIST is returned
+     (not void -- the primitive "for-each" will do that). */
 static SCM map(int argc, SCM *argv, int in_map)
 {
-  SCM fct, res, v, tmp, *args;
-  int i, j;
+  SCM fct, res, ptr, v, tmp, *args;
+  int i, j, len, tmplen;
 
   if (argc <= 1) STk_error("expected at least 2 arguments (given %d)", argc);
 
@@ -378,33 +384,77 @@ static SCM map(int argc, SCM *argv, int in_map)
   argc -= 1;
   res   = STk_nil;
 
+
   if (argc == 1) {
     /* frequent case (map (lambda (x) ...) list). Do it specially */
-    for (v = *argv; !NULLP(v); v = CDR(v)) {
+
+    v = *argv;
+
+    if (in_map) {
+        /* Calculate the length so we can use STk_must_malloc_list(): */
+        len = STk_int_length(v);
+        if (len < 0) STk_error("bad list ~W", v);
+        /* Allocate the result list: */
+        res = STk_must_malloc_list(len, STk_false);
+    }
+
+    /* Just fill in the list and return it: */
+    for (ptr = res; !NULLP(v); v = CDR(v)) {
       if (!CONSP(v)) error_malformed_list(v);
       tmp = STk_C_apply(fct, 1, CAR(v));
-      if (in_map)
-        res = STk_cons(tmp, res);
+      if (in_map) {
+        CAR(ptr) = tmp;
+        ptr = CDR(ptr);
+      }
     }
-    return STk_dreverse(res);
+    return res;
+
   } else {
+
     /* General case */
     v    = STk_makevect(argc, (SCM) NULL);
     args = VECTOR_DATA(v);
 
+      if (in_map) {
+        /* Find out the length of the smaller list and allocate
+           the reulting list of that size. */
+        len = INT_MAX;
+        for (i=0, j=0; i < argc; i++, j--) {
+          tmplen = STk_int_length(argv[j]);
+          /* If tmplen is negative, we ignore it. This is because we
+             should accept circular lists, so long as there is a
+             non-circular list also in the arguments See SRFI 1 test:
+             (map + '(3 1 4 1) (circular-list 1 0)) expects (4 1 5 1) */
+          if (tmplen >= 0 && tmplen < len) len = tmplen;
+        }
+        if (len == INT_MAX) STk_error("at least one proper list required");
+
+        res = STk_must_malloc_list(len, STk_false);
+        ptr = res;
+    }
+
     for ( ; ; ) {
-      /* Build the parameter list */
-      for (i=0, j=0; i < argc; i++,j--) {
+      /* Build the parameter list.
+         'argc' was decreased by one, so it is now *exactlty* the
+         number of lists on which MAP will operate. Which is also
+         the argument count of the function to be applied. */
+      for (i=0, j=0; i < argc; i++, j--) {
         if (NULLP(argv[j]))
-          return STk_dreverse(res); /* // FIXME: verifier longueurs */
+          return res;
         if (!CONSP(argv[j])) error_malformed_list(argv[j]);
-        args[i] = CAR(argv[j]);
-        argv[j] = CDR(argv[j]);
+
+        args[i] = CAR(argv[j]); /* set i-th argument to fct */
+        argv[j] = CDR(argv[j]); /* get the next argument from MAP */
       }
 
       tmp = STk_C_apply(fct, -argc, args);
-      if (in_map)
-        res = STk_cons(tmp, res);
+
+      /* If we're storing the resulting list, set the CAR at this
+         position, and update the pointer. */
+      if (in_map) {
+        CAR(ptr) = tmp;
+        ptr = CDR(ptr);
+      }
     }
   }
   return STk_void;      /* never reached */

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -170,6 +170,7 @@ extern "C"
 #define STk_gc()                        GC_gcollect()
 #define STk_gc_base(ptr)                GC_base(ptr)
 
+
 void STk_gc_init(void);
 
 
@@ -183,6 +184,10 @@ void STk_gc_init(void);
 #define MAX_CELL_TYPES          256
 
 typedef void* SCM;
+/* Function added to allocate a list of size n. This is faster than
+   repeatedly calling STk_must_malloc. It is defined here, and not with
+   the allocation API, because it needs the SCM type. */
+SCM STk_must_malloc_list(int n, SCM init);
 
 typedef enum {
   tc_not_boxed=-1,

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -716,6 +716,7 @@ EXTERN_PRIMITIVE("cons", cons, subr2, (SCM x, SCM y));
 EXTERN_PRIMITIVE("car", car, subr1, (SCM x));
 EXTERN_PRIMITIVE("cdr", cdr, subr1, (SCM x));
 EXTERN_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name));
+EXTERN_PRIMITIVE("make-list", make_list, subr12, (SCM n, SCM init));
 EXTERN_PRIMITIVE("list", list, vsubr, (int argc, SCM * argv));
 EXTERN_PRIMITIVE("memq", memq, subr2, (SCM obj, SCM list));
 EXTERN_PRIMITIVE("memv", memv, subr2, (SCM obj, SCM list));

--- a/src/system.c
+++ b/src/system.c
@@ -2040,7 +2040,6 @@ SCM STk_must_malloc_list_upton(int *n, SCM init, SCM *last) {
 SCM STk_must_malloc_list(int n, SCM init) {
   SCM z2;
   SCM last, new_last;
-  int original_n = n;
   SCM z = STk_must_malloc_list_upton(&n, init, &last);
   while (n) {
     /* n is the remaining cells to allocate. Try again:*/


### PR DESCRIPTION
Instead of going through the vector and consing, we allocate all list cells in a single memory region, in a single call to the allocator. This seems to be twice as fast as the old code.

```scheme
(time
  (let ((a (make-vector 1000 'x)))
    (repeat 100000 (vector->list a))
    'ok))
```
Old code: 4152.755ms 100000001 allocation calls
New code: 1805.502ms 100001 allocation calls

But this only changes the R5RS version of `vector->lsit`. I've tried to make the R7RS version in C, but that is trickier than what I thought. I'll work on that later.