### PR TITLE
[simple] Be more informative about the 'bad closing parenthesis'

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -167,10 +167,16 @@ static void error_eof_in_string(SCM port)
   signal_error(port, "end of file while reading a string on ~S", port);
 }
 
-
-static void warning_parenthesis(SCM port)
+/* If expected is zero, then it's a stray closing delimitar. If it's different
+   from zero, it is the closing delimiter that was expected. */
+static void warning_parenthesis(SCM port, char bad_closepar, char expected)
 {
-  STk_warning("bad closing parenthesis on line %d of ~S", PORT_LINE(port), port);
+  if (expected)
+    STk_warning("bad closing parenthesis `%c` (expected `%c`) on line %d of ~S",
+                bad_closepar, expected, PORT_LINE(port), port);
+  else
+    STk_warning("bad closing parenthesis `%c` on line %d of ~S",
+                bad_closepar, PORT_LINE(port), port);
 }
 
 static void warning_bad_escaped_sequence(SCM port, int c)
@@ -270,7 +276,7 @@ static SCM read_list(SCM port, char delim, struct read_context *ctx)
 
     if (cur == close_par_cst) {
       c = STk_getc(port);
-      if (c != delim) warning_parenthesis(port);
+      if (c != delim) warning_parenthesis(port, c, delim);
       return start;
     }
 
@@ -1057,7 +1063,7 @@ static SCM read_rec(SCM port, struct read_context *ctx, int inlist)
           STk_ungetc(c, port);
           return close_par_cst;
         }
-        warning_parenthesis(port);
+        warning_parenthesis(port,c,0);
         break;
       case '\'':
         quote_type = sym_quote;


### PR DESCRIPTION

* We now tell the user what closing delimiter was found -- `(` `[` or `{`.
* If we were reading a list then we also inform what closing delimiter was expected instead.

Examples:

```
stklos> '[a)

**** Warning:
bad closing parenthesis `)` (expected `]`) on line 1 of '#[input-virtual-port 7ff782c93840]'
(a)

stklos> 123 ]
123

**** Warning:
bad closing parenthesis `]` on line 3 of '#[input-virtual-port 7f5fa526b840]'
```