### PR TITLE
[trivial] `length`: reject bad lists, and be more informative

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -232,7 +232,7 @@ DEFINE_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name))
    * NOTE: using strings (instead of keywords) is less efficient because
    * the char * is at the end of the object. Using symbols is also fast
    * (even a bit faster, don't know why), but it is harder  to detect that
-   * that we can inline when we have (%cxr lst 'daa), because of the quote. 
+   * that we can inline when we have (%cxr lst 'daa), because of the quote.
    */
   if (KEYWORDP(name)) {
     SCM lst   = l;
@@ -335,10 +335,13 @@ DEFINE_PRIMITIVE("length", list_length, subr1, (SCM l))
 doc>
  */
 {
+  if (NULLP(l)) return MAKE_INT(0);
+  if (!CONSP(l)) STk_error("bad list ~s", l);
+
   int len = STk_int_length(l);
 
   if (len >= 0) return MAKE_INT(len);
-  STk_error("length of ~W is not calculable", l);
+  STk_error("length of improper list ~W is not calculable", l);
   return STk_void; /* never reached */
 }
 


### PR DESCRIPTION
1. Do not pass non-lists to `STk_int_length()`  (why did it never crashed before?)
2. Explain that the length of a list is not calculable because it is improper.

Now we have:

```
stklos> (length '(a . b))
**** Error:
length: length of improper list '(a . b)' is not calculable

stklos> (length 'a)
**** Error:
length: bad list a
```

In both cases, the behavior was (before) to say that "length of ... is not calculable". And STk_int_length was called in non-lists.