### PR TITLE
Optimize `list.c`

### DIFF
--- a/lib/module.stk
+++ b/lib/module.stk
@@ -23,6 +23,17 @@
 ;;;;    Creation date:  1-Jun-2000 12:26 (eg)
 ;;;;
 
+;;; NOTE:
+;;;
+;;;
+;;; This code makes use of `list-deep-copy` because import sets, which are
+;;; alists, are copied. If one uses `list-copy`, then the assoc pairs are
+;;; not newly allocated, and are shared with the old import set. This will
+;;; cause problems, since this code uses set-cdr! to change the name of
+;;; a binding.
+;;;
+;;; So: *** use list-deep-copy, not list-copy! ***
+
 ;;=============================================================================
 ;;
 ;;                              MODULE-SYMBOLS*

--- a/lib/module.stk
+++ b/lib/module.stk
@@ -431,7 +431,7 @@ doc>
     (let* ((mod       (eventually-load-library name))
            (imported  (build-import-list mod
                                          keylist
-                                         (list-copy (%module-exports mod)))))
+                                         (list-deep-copy (%module-exports mod)))))
       ;; Make aliases for all symbols in imported list
       (if only-syntax
           (for-each (lambda (pair)
@@ -476,10 +476,10 @@ doc>
                 (%grab-file-information (symbol->string (car x))))
               imp)
     ;; Do importation at compile time AND at execution time
-    (%do-imports (compiler-current-module) (list-copy imp) #t)
+    (%do-imports (compiler-current-module) (list-deep-copy imp) #t)
 
     ;; Run time expansion
-    `(%do-imports (current-module) (list-copy ',imp) #f)))
+    `(%do-imports (current-module) (list-deep-copy ',imp) #f)))
 
 (define (%%import lib modules)
   (let ((imp (%parse-imports modules)))
@@ -490,7 +490,7 @@ doc>
               imp)
     ;; Do importation at compile time AND at execution time
     ;(%do-imports  (compiler-current-module) (list-copy imp) #t)
-    (%do-imports lib (list-copy imp) #f)))
+    (%do-imports lib (list-deep-copy imp) #f)))
 
 
 ;;=============================================================================

--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -34,7 +34,7 @@
         truncate-remainder floor-remainder
         square exact-integer-sqrt exact inexact
         boolean=?
-        make-list member assoc
+        member assoc
         symbol=?
         string=?     %string2=?
         string<?     %string2<?
@@ -538,23 +538,6 @@ doc>
                         (eq? (car lst) val)
                         (verify val (cdr lst)))))))
     (verify e1 rest)))
-
-;;;; ----------------------------------------------------------------------
-;;;; 6.4 Pairs and lists
-;;;; ----------------------------------------------------------------------
-
-#|
-<doc R7RS make-list
- * (make-list k)
- * (make-list k fill)
- *
- * Returns a newly allocated list of k elements. If a second
- * argument is given, then each element is initialized to fill .
- * Otherwise the initial contents of each element is unspecified.
-doc>
-|#
-(define (make-list k :optional (fill (void)))
-  (vector->list (make-vector k fill)))
 
 
 ;;;; ----------------------------------------------------------------------

--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -467,14 +467,15 @@
           (not (null? x))))
     (not (null? x)))))
 
-(define (circular-list? x)
-  (let lp ((x x) (lag x))
-    (and (pair? x)
-     (let ((x (cdr x)))
-       (and (pair? x)
-        (let ((x   (cdr x))
-              (lag (cdr lag)))
-          (or (eq? x lag) (lp x lag))))))))
+;; In STklos core
+;; (define (circular-list? x)
+;;   (let lp ((x x) (lag x))
+;;     (and (pair? x)
+;;      (let ((x (cdr x)))
+;;        (and (pair? x)
+;;         (let ((x   (cdr x))
+;;               (lag (cdr lag)))
+;;           (or (eq? x lag) (lp x lag))))))))
 
 (define (not-pair? x) (not (pair? x)))  ; Inline me.
 
@@ -1769,6 +1770,9 @@ FILTER an FILTER! are primitives in STklos
 (redefine make-list)
 (redefine assoc)
 (redefine member)
+
+;; Not R7RS, but also moved to STklos core:
+(redefine circular-list?)
 
 )  ; END OF MODULE
 

--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -694,11 +694,12 @@
 
 (define (last lis) (car (last-pair lis)))
 
-(define (last-pair lis)
-  (check-arg pair? lis last-pair)
-  (let lp ((lis lis))
-    (let ((tail (cdr lis)))
-      (if (pair? tail) (lp tail) lis))))
+;; Already in STklos core
+;; (define (last-pair lis)
+;;   (check-arg pair? lis last-pair)
+;;   (let lp ((lis lis))
+;;     (let ((tail (cdr lis)))
+;;       (if (pair? tail) (lp tail) lis))))
 
 
 ;;; Unzippers -- 1 through 5
@@ -1772,6 +1773,7 @@ FILTER an FILTER! are primitives in STklos
 (redefine member)
 
 ;; Not R7RS, but also moved to STklos core:
+(redefine last-pair)
 (redefine circular-list?)
 
 )  ; END OF MODULE

--- a/lib/scheme/vector/tagvector-template.stk
+++ b/lib/scheme/vector/tagvector-template.stk
@@ -403,12 +403,14 @@
 
 
 (define (TAGvector->list v :optional (start 0) (end (TAGvector-length v)))
-  (let ((v (TAGvector-copy v start end)))
-    (let loop ((i (fx- (TAGvector-length v) 1))
-               (lst '()))
-      (if (fx< i 0)
-          lst
-          (loop (fx- i 1) (cons (TAGvector-ref v i) lst))))))
+  (let* ((len (fx- end start))
+         (L (make-list len))
+         (ptr L))
+    (repeat len
+      (set-car! ptr (TAGvector-ref v start))
+      (set! ptr (cdr ptr))
+      (set! start (fx+ 1 start)))
+    L))
 
 
 (define (reverse-list->TAGvector lst)

--- a/src/list.c
+++ b/src/list.c
@@ -1076,7 +1076,10 @@ doc>
  */
 DEFINE_PRIMITIVE("last-pair", last_pair, subr1, (SCM l))
 {
-  if (!CONSP(l)) error_wrong_type(l);
+  int len;
+  SCM x = STk_list_type_and_length(l, &len);
+  if (!x) error_bad_list(l);
+  if (CONSP(x)) error_circular_list(l);
 
   while (CONSP(CDR(l)))
     l = CDR(l);

--- a/src/list.c
+++ b/src/list.c
@@ -1111,11 +1111,15 @@ DEFINE_PRIMITIVE("filter", filter, subr2, (SCM pred, SCM list))
   register SCM ptr, l;
   SCM result;
 
+  int len;
+  SCM x = STk_list_type_and_length(list, &len);
+  if (!x) error_bad_list(list);
+  if (CONSP(x)) error_circular_list(list);
+  if (!NULLP(x)) error_improper_list(list);
+
   if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
-  if (!CONSP(list) && !NULLP(list)) error_bad_list(list);
 
   for (ptr=l=list, result=STk_nil; !NULLP(l); ) {
-    if (!CONSP(l)) error_bad_list(list);
 
     if (STk_C_apply(pred, 1, CAR(l)) != STk_false) {
       if (NULLP(result)) {
@@ -1129,21 +1133,24 @@ DEFINE_PRIMITIVE("filter", filter, subr2, (SCM pred, SCM list))
       CAR(ptr) = CAR(l);
       CDR(ptr) = STk_nil;
     }
-    if ((l=CDR(l)) == list) error_circular_list(list);
-  }
+    l=CDR(l);
+ }
   return result;
 }
 
 
 DEFINE_PRIMITIVE("filter!", dfilter, subr2, (SCM pred, SCM list))
 {
-  SCM previous, l, start=list;
+  SCM previous, l;
+  int len;
+  SCM x = STk_list_type_and_length(list, &len);
+  if (!x) error_bad_list(list);
+  if (CONSP(x)) error_circular_list(list);
+  if (!NULLP(x)) error_improper_list(list);
 
   if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
-  if (!CONSP(list) && !NULLP(list)) error_bad_list(list);
 
   for (previous=STk_nil, l=list; !NULLP(l); ) {
-    if (!CONSP(l)) error_bad_list(list);
     if (BOXED_INFO(l) & CONS_CONST) error_const_cell(l);
 
     if (STk_C_apply(pred, 1, CAR(l)) == STk_false) {
@@ -1154,7 +1161,7 @@ DEFINE_PRIMITIVE("filter!", dfilter, subr2, (SCM pred, SCM list))
     } else {
       previous = l;
     }
-    if ((l=CDR(l)) == start) error_circular_list(list);
+    l = CDR(l);
   }
   return list;
 }

--- a/src/list.c
+++ b/src/list.c
@@ -232,7 +232,7 @@ DEFINE_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name))
    * NOTE: using strings (instead of keywords) is less efficient because
    * the char * is at the end of the object. Using symbols is also fast
    * (even a bit faster, don't know why), but it is harder  to detect that
-   * that we can inline when we have (%cxr lst 'daa), because of the quote. 
+   * that we can inline when we have (%cxr lst 'daa), because of the quote.
    */
   if (KEYWORDP(name)) {
     SCM lst   = l;
@@ -298,6 +298,23 @@ doc>
 {
   return MAKE_BOOLEAN(STk_int_length(x) >= 0);
 }
+
+/*
+<doc R7RS make-list
+ * (make-list k)
+ * (make-list k fill)
+ *
+ * Returns a newly allocated list of k elements. If a second
+ * argument is given, then each element is initialized to fill .
+ * Otherwise the initial contents of each element is unspecified.
+doc>
+*/
+DEFINE_PRIMITIVE("make-list", make_list, subr12, (SCM n, SCM init)) {
+  if (!INTP(n)) STk_error("bad integer ~s", n);
+  if (!init) init = STk_void;
+  return STk_must_malloc_list(INT_VAL(n), init);
+}
+
 
 DEFINE_PRIMITIVE("list", list, vsubr, (int argc, SCM * argv))
 /*
@@ -1061,6 +1078,7 @@ int STk_init_list(void)
   ADD_PRIMITIVE(cxr);
   ADD_PRIMITIVE(nullp);
   ADD_PRIMITIVE(listp);
+  ADD_PRIMITIVE(make_list);
   ADD_PRIMITIVE(list);
   ADD_PRIMITIVE(list_length);
   ADD_PRIMITIVE(append);

--- a/src/list.c
+++ b/src/list.c
@@ -84,6 +84,143 @@ int STk_int_length(SCM l)
   }
 }
 
+/* STk_list_type_and_length():
+
+   List checking (proper improper, cyclic) AND length computing.
+
+   If l is:
+
+   1. PROPER LIST: return STk_nil.
+   2. CYCLIC LIST: A CONS cell (this is where the cycle starts).
+   3. FINITE PROPER LIST: The last CDR.
+   4. NOT A LIST: NULL.
+
+   - In cases (1), (2), and (3) the length of the list is returned
+     in the len argument.
+
+   - If the list consists of a single cycle, then we guarantee that
+     the poitner returned is to the FIRST cell of the list.
+ */
+SCM STk_list_type_and_length(SCM l, int *len) {
+  /*
+    About the cycle detecting and copying algorithm:
+
+    1. Detect cycles using Floyd's algorithm.  The algorithm runs two
+       pointers, "fast" and "slow" through the list. Both are placed
+       at the CAR, then at each step, slow goes forward one link, and
+       fast goes forward two links.
+
+    2. If there is a cycle:
+
+       2.i) we position fast back at the CAR and now move the two
+            pointers *one* link at each time. The pointers will
+            *necessarily meet* exactly *at the beginning of the cycle.
+
+       2.ii) If there is a cycle, we mark the cell in which it starts
+             example, the cycle below starts at C:
+
+                        +--------------+
+                        |              |
+                        v              |
+              A -> B -> C -> D -> E -> F
+
+              We keep an extra pointer to C.
+
+       2.iii) Now we count the number of cells from the beginning (A)
+              to the SECOND time we see C (minus one). This is the
+              "length" of the list (the size to be allocated to the
+              copy).
+
+    3. If there is no cycle, count the number of elements as usual (but
+       allowing for improper lists)
+
+   */
+
+    if (!CONSP(l) && !NULLP(l)) return NULL;      /* Case (4) in function description */
+    if (NULLP(l))  { (*len)=0;  return STk_nil; } /* Case (1) in function description,
+                                                  specifically for the proper list '().*/
+
+    /* 1. Detect possible cycles using Floyd's algorithm */
+    SCM slow  = l;
+    SCM fast  = l;
+    int cycle = 0;
+    SCM cycle_start;
+    int single_cycle = 0;
+
+    while(CONSP(fast) && CONSP(CDR(fast))) {
+        slow = CDR(slow);
+        fast = CDR(CDR(fast));
+        if(slow == fast) {
+            cycle = 1;
+            break;
+        }
+    }
+
+    if (cycle) {
+      /* 2.i Put fast back in the beginning, and now move slow and
+             fast one link at a time. When they meet, we found the
+             cycle start. */
+        fast = l;
+        while(CDR(slow)!=CDR(fast)){
+          slow = CDR(slow);
+          fast = CDR(fast);
+        }
+
+        /* 2.ii Keep a link to the cell where the cycle starts */
+
+        /* Special case: if slow == fast, then the list is a single cycle,
+           and we'd be cunting one more cons cell than necesary. */
+        if (slow == fast)
+          single_cycle = 1;
+
+        cycle_start = CDR(slow);
+
+        /* 2.iii Count the cyclic list size. */
+
+        (*len) = 0;
+
+        slow = l;
+        int passed_cycle = 0;
+        while (1) {
+          (*len)++;
+          if (CDR(slow) == cycle_start) {
+            if (passed_cycle) break;
+            else              passed_cycle = 1;
+          }
+          slow = CDR(slow);
+        }
+
+    } else {
+      /* 3 Count the uncyclic list size. */
+      (*len)=0;
+      slow = l;
+      for ( ; ; ) {
+        /* See the beginning of the function -- l is guaranteed to be
+           non-nil (actual pair), so we can take the CDR of slow
+           (which was initialzed to l).
+           This way we'll have CDR(slow) point to the proper place
+           (the list's last CDR, since this is a non-circular list) */
+        if (!CONSP(CDR(slow)) || NULLP(CDR(slow))) {
+          (*len)++;
+          break;
+        }
+        slow = CDR(slow);
+        (*len)++;
+      }
+    }
+
+    /* LEN now has the length of the list to be copied, and we only
+       need to return CDR(slow), which will be what we promised (NIL
+       for proper lists, cycle_start for cyclic lists, or the last-cdr
+       for improper lists.  Except that -- if it's a single cycle, we
+       don't want to return the (random) place where slow and fast
+       met. We'll return the start ot the list! */
+
+    if (single_cycle) return l;
+    return CDR(slow);
+}
+
+
 SCM STk_argv2list(int argc, SCM *argv)
 {
   SCM res = STk_nil;
@@ -296,7 +433,8 @@ DEFINE_PRIMITIVE("list?", listp, subr1, (SCM x))
 doc>
  */
 {
-  return MAKE_BOOLEAN(STk_int_length(x) >= 0);
+  int len;
+  return MAKE_BOOLEAN(NULLP(STk_list_type_and_length(x, &len)));
 }
 
 /*
@@ -718,18 +856,129 @@ DEFINE_PRIMITIVE("assoc", assoc, subr23, (SCM obj, SCM alist, SCM cmp))
 
 
 /*
-<doc R7RS list-copy
- * (list-copy obj)
+<doc circular-list?
+ * (circular-list? obj)
  *
- * |list-copy| recursively copies trees of pairs. If |obj| is
- * not a pair, it is returned; otherwise the result is a new pair whose
- * |car| and |cdr| are obtained by calling |list-copy| on
- * the |car| and |cdr| of |obj|, respectively.
+ * Returns |#t#| if |obj| is a circular list, and |#f| otherwise.
+ *
+ * @lisp
+ * (define L (list 1 2 3 4))
+ * (set-cdr! (cdddr L) (cdr L))
+ * (circular-list? L)               => #t
+ * (circular-list? 10)              => #f
+ * (circular-list? '#0=(a b . #0#) )=> #t
+ * @end lisp
+doc>
+*/
+DEFINE_PRIMITIVE("circular-list?", circ, subr1, (SCM l)) {
+  int len;
+  SCM x = STk_list_type_and_length(l, &len);
+  return MAKE_BOOLEAN (x && CONSP(x));
+}
+
+/*
+<doc list-copy list-deep-copy
+ * (list-copy obj)
+ * (list-deep-copy obj)
+ *
+ * These procedures copy trees of pairs. |list-copy| will copy the
+ * pairs, but wil not recurse into them for copying; but |list-deep-copy|
+ * will recurse into the structure, so a new tree or association list will
+ * be returned.
+ *
+ * |List-deep-copy| is particularly useful to copy association lists when
+ * one needs the new list items to *not* be |eq?| to the old ones.
+ *
+ * Note that |list-deep-copy| will only recurse into lists, not vectors,
+ * structs and other data structures.
+ *
+ * @lisp
+ * (define X (cons 1 2))
+ * (define y (list X 10))
+ * (eq? y (list-copy y))                  => #f
+ * (eq? (car y) (car (list-copy y)))      => #t
+ * (eq? (car y) (car (list-deep-copy y))) => #f
+ *
+ * (define X '#(1 2))
+ * (define y (list X 10))
+ * (eq? y (list-copy y))                  => #f
+ * (eq? (car y) (car (list-copy y)))      => #t
+ * (eq? (car y) (car (list-deep-copy y))) => #t ; <= didn't recurse into vector
+ * @end lisp
 doc>
  */
-DEFINE_PRIMITIVE("list-copy", list_copy, subr1, (SCM l))
-{
-  return CONSP(l) ? STk_cons(STk_list_copy(CAR(l)), STk_list_copy(CDR(l))): l;
+SCM list_copy(SCM l, int deep) {
+  if (!CONSP(l)) return l;
+  if (NULLP(l))  return STk_nil;
+
+  int len;
+  SCM last = STk_list_type_and_length(l, &len);
+  SCM cycle_start = last;
+  int cycle = CONSP(last);
+
+  /*
+    1. Allocate the new list.
+
+    2. Copy the elements from the old to the new list.
+
+    3. Adjust the last CDR:
+
+       3.i) If the last CDR of the old list is NIL (proper list), or if
+            it is NOT a CONS pair (list ending with non-nil, but still
+            finite), make the last CDR the same.
+
+       3.ii) If there was a cycle, then make the last CDR of the new
+             list point to the marked cell.
+  */
+
+    /* 1. Allocate the list and copy the CARs */
+    SCM ptr, ptr_res, res = STk_must_malloc_list(len, STk_false);
+    SCM cycle_start_in_new_list = STk_nil;
+    ptr = l;
+    ptr_res = res;
+
+    if (cycle && l == cycle_start) len--;
+
+    /* 2. Copy. */
+
+    for (int ctr = 0; ctr < len-1; ctr++) {
+        if (deep)  CAR(ptr_res) = list_copy(CAR(ptr),1);
+        else       CAR(ptr_res) = CAR(ptr);
+      /* Mark where the cycle start is in the copy: */
+      if (cycle && ptr == cycle_start)
+        cycle_start_in_new_list = ptr_res;
+
+      ptr_res = CDR(ptr_res);
+      ptr = CDR(ptr);
+    }
+
+    /* 3. Adjust last CDR: */
+
+    if (deep)  CAR(ptr_res) = list_copy(CAR(ptr),1);
+    else       CAR(ptr_res) = CAR(ptr);
+
+    if (!cycle && (CDR(ptr) == STk_nil || /* No cycle */
+                   !CONSP(CDR(ptr))))     /* Improper list */
+      CDR(ptr_res) = CDR(ptr);
+
+    else if (cycle && l == cycle_start) /* Cycle */
+      CDR(ptr_res) = res;
+
+    else if (cycle && CDR(ptr) == cycle_start) /* Cycle */
+      CDR(ptr_res) = cycle_start_in_new_list;
+
+    else {
+      STk_error("impossible error"); /* ??? */
+    }
+    return res;
+}
+
+DEFINE_PRIMITIVE("list-copy", list_copy, subr1, (SCM l)) {
+  return list_copy(l,0);
+}
+
+DEFINE_PRIMITIVE("list-deep-copy", list_deep_copy, subr1, (SCM l)) {
+  return list_copy(l,1);
 }
 
 
@@ -1092,7 +1341,9 @@ int STk_init_list(void)
   ADD_PRIMITIVE(assq);
   ADD_PRIMITIVE(assv);
   ADD_PRIMITIVE(assoc);
+  ADD_PRIMITIVE(circ);
   ADD_PRIMITIVE(list_copy);
+  ADD_PRIMITIVE(list_deep_copy);
 
   ADD_PRIMITIVE(pair_mutable);
   ADD_PRIMITIVE(list_star);

--- a/src/proc.c
+++ b/src/proc.c
@@ -367,10 +367,16 @@ DEFINE_PRIMITIVE("procedure-source", proc_source, subr1, (SCM proc))
  *                      M A P   &   F O R - E A C H
  *
 \*===========================================================================*/
+
+/* map does both 'map' and 'for-each':
+   - when in_map is non-zero, the result of each operation will be stored
+     in a result list
+   - when it is zero, no result is stored, and AN EMPTY LIST is returned
+     (not void -- the primitive "for-each" will do that). */
 static SCM map(int argc, SCM *argv, int in_map)
 {
-  SCM fct, res, v, tmp, *args;
-  int i, j;
+  SCM fct, res, ptr, v, tmp, *args;
+  int i, j, len, tmplen;
 
   if (argc <= 1) STk_error("expected at least 2 arguments (given %d)", argc);
 
@@ -378,33 +384,77 @@ static SCM map(int argc, SCM *argv, int in_map)
   argc -= 1;
   res   = STk_nil;
 
+
   if (argc == 1) {
     /* frequent case (map (lambda (x) ...) list). Do it specially */
-    for (v = *argv; !NULLP(v); v = CDR(v)) {
+
+    v = *argv;
+
+    if (in_map) {
+        /* Calculate the length so we can use STk_must_malloc_list(): */
+        len = STk_int_length(v);
+        if (len < 0) STk_error("bad list ~W", v);
+        /* Allocate the result list: */
+        res = STk_must_malloc_list(len, STk_false);
+    }
+
+    /* Just fill in the list and return it: */
+    for (ptr = res; !NULLP(v); v = CDR(v)) {
       if (!CONSP(v)) error_malformed_list(v);
       tmp = STk_C_apply(fct, 1, CAR(v));
-      if (in_map)
-        res = STk_cons(tmp, res);
+      if (in_map) {
+        CAR(ptr) = tmp;
+        ptr = CDR(ptr);
+      }
     }
-    return STk_dreverse(res);
+    return res;
+
   } else {
+
     /* General case */
     v    = STk_makevect(argc, (SCM) NULL);
     args = VECTOR_DATA(v);
 
+      if (in_map) {
+        /* Find out the length of the smaller list and allocate
+           the reulting list of that size. */
+        len = INT_MAX;
+        for (i=0, j=0; i < argc; i++, j--) {
+          tmplen = STk_int_length(argv[j]);
+          /* If tmplen is negative, we ignore it. This is because we
+             should accept circular lists, so long as there is a
+             non-circular list also in the arguments See SRFI 1 test:
+             (map + '(3 1 4 1) (circular-list 1 0)) expects (4 1 5 1) */
+          if (tmplen >= 0 && tmplen < len) len = tmplen;
+        }
+        if (len == INT_MAX) STk_error("at least one proper list required");
+
+        res = STk_must_malloc_list(len, STk_false);
+        ptr = res;
+    }
+
     for ( ; ; ) {
-      /* Build the parameter list */
-      for (i=0, j=0; i < argc; i++,j--) {
+      /* Build the parameter list.
+         'argc' was decreased by one, so it is now *exactlty* the
+         number of lists on which MAP will operate. Which is also
+         the argument count of the function to be applied. */
+      for (i=0, j=0; i < argc; i++, j--) {
         if (NULLP(argv[j]))
-          return STk_dreverse(res); /* // FIXME: verifier longueurs */
+          return res;
         if (!CONSP(argv[j])) error_malformed_list(argv[j]);
-        args[i] = CAR(argv[j]);
-        argv[j] = CDR(argv[j]);
+
+        args[i] = CAR(argv[j]); /* set i-th argument to fct */
+        argv[j] = CDR(argv[j]); /* get the next argument from MAP */
       }
 
       tmp = STk_C_apply(fct, -argc, args);
-      if (in_map)
-        res = STk_cons(tmp, res);
+
+      /* If we're storing the resulting list, set the CAR at this
+         position, and update the pointer. */
+      if (in_map) {
+        CAR(ptr) = tmp;
+        ptr = CDR(ptr);
+      }
     }
   }
   return STk_void;      /* never reached */

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -170,6 +170,7 @@ extern "C"
 #define STk_gc()                        GC_gcollect()
 #define STk_gc_base(ptr)                GC_base(ptr)
 
+
 void STk_gc_init(void);
 
 
@@ -183,6 +184,10 @@ void STk_gc_init(void);
 #define MAX_CELL_TYPES          256
 
 typedef void* SCM;
+/* Function added to allocate a list of size n. This is faster than
+   repeatedly calling STk_must_malloc. It is defined here, and not with
+   the allocation API, because it needs the SCM type. */
+SCM STk_must_malloc_list(int n, SCM init);
 
 typedef enum {
   tc_not_boxed=-1,
@@ -711,6 +716,7 @@ EXTERN_PRIMITIVE("cons", cons, subr2, (SCM x, SCM y));
 EXTERN_PRIMITIVE("car", car, subr1, (SCM x));
 EXTERN_PRIMITIVE("cdr", cdr, subr1, (SCM x));
 EXTERN_PRIMITIVE("%cxr", cxr, subr2, (SCM l, SCM name));
+EXTERN_PRIMITIVE("make-list", make_list, subr12, (SCM n, SCM init));
 EXTERN_PRIMITIVE("list", list, vsubr, (int argc, SCM * argv));
 EXTERN_PRIMITIVE("memq", memq, subr2, (SCM obj, SCM list));
 EXTERN_PRIMITIVE("memv", memv, subr2, (SCM obj, SCM list));

--- a/src/str.c
+++ b/src/str.c
@@ -939,22 +939,19 @@ DEFINE_PRIMITIVE("string->list", string2list, subr1, (SCM str))
   register char *s;
   int len;
   utf8_char c;
-  SCM tmp, tmp1, z;
+  SCM tmp, z;
 
   if (!STRINGP(str)) error_bad_string(str);
 
   len = STRING_LENGTH(str);
   s   = STRING_CHARS(str);
 
-  tmp = z = STk_nil;
+  tmp = z = STk_must_malloc_list(len,STk_false);
 
-  while (len--) {
+  for (int i=0; i<len; i++) {
     s = STk_utf8_grab_char(s, &c);
-    tmp1 = STk_cons(MAKE_CHARACTER(c), STk_nil);
-    if (z == STk_nil)
-      tmp = z = tmp1;
-    else
-      tmp = CDR(tmp) = tmp1;
+    CAR(tmp) = MAKE_CHARACTER(c);
+    tmp = CDR(tmp);
   }
   return z;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -1969,6 +1969,90 @@ DEFINE_PRIMITIVE("os-name", os_name, subr0, (void))
   return STk_Cstring2string(name.sysname);
 }
 
+/* Allocates up to *n CONS cells. That is, the result is a list with
+   AT MOST *n cells, but maybe less.
+
+   1. The parameter (*n) will be changed to the number of cells still
+      missing, or zero if the list is complete.
+   2. The parameter (*last) will be set to the last CONS cell of the
+      list. This is to optimize the situation in which this function
+      did not yet return enough cells, and will be called again. Later,
+      this link will be used to glue the lists together without the
+      need to use APPEND.  */
+SCM STk_must_malloc_list_upton(int *n, SCM init, SCM *last) {
+  if (*n == 0) return STk_nil;
+  if (*n < 0)  STk_error("Negative list size ~s", MAKE_INT(*n));
+
+  /* libgc does not allow us to choose how many objects we'd like to
+     allocate.  We ask for many objects and get a linked list where
+     each object has the size given as argument.
+     The first word of the object is a link to the next.   */
+  void **ptr = GC_malloc_many(sizeof(struct cons_obj));
+  if (!ptr) STk_error("Cannot allocate list of size ~s", MAKE_INT(*n));
+
+  /* GC_NEXT gets the next in the list. */
+  void **next =  GC_NEXT(ptr);
+
+  /* Adjust the first CONS cell (there is at least one, since we
+     already returned STk_nil for zero) */
+  BOXED_TYPE((struct cons_obj* ) ptr) = tc_cons;
+  BOXED_INFO((struct cons_obj* ) ptr) = 0;
+  CAR((struct cons_obj* ) ptr) = init;
+  CDR((struct cons_obj* ) ptr) = STk_nil;
+
+  /* ptr will be the last cons on the list, so we update the
+     last parameter: */
+  *last = (SCM) ptr;
+
+  /* count is the number of actually allocated cells. */
+  int count = 1;
+  void **tmp;
+
+  while ((void **) next) {
+    tmp = GC_NEXT(next);
+    /* We only run up to n cells. After that, we just follow the
+       links, clearing up the first word in order to give them back to
+       the GC. */
+    if (count >= *n) {
+      next = NULL;
+    } else {
+      count++;
+      BOXED_TYPE((struct cons_obj* ) next) = tc_cons;
+      BOXED_INFO((struct cons_obj* ) next) = 0;
+      CAR((struct cons_obj* ) next) = init;
+      CDR((struct cons_obj* ) next) = ptr;
+      ptr = next;
+    }
+    next = tmp;
+  }
+  /* Let's count the bytes effectively given to the user, not those
+   * that we threw away. */
+  if (STk_count_allocations)
+    STk_thread_inc_allocs(STk_current_thread(),
+                          count * sizeof(struct cons_obj));
+  /* *n will hold the cells still missing. */
+  *n -= count;
+  return (SCM) ptr;
+}
+
+/* Allocates, at once, a list of n cons cells, all of them initialzied
+   with the value of init. */
+SCM STk_must_malloc_list(int n, SCM init) {
+  SCM z2;
+  SCM last, new_last;
+  SCM z = STk_must_malloc_list_upton(&n, init, &last);
+  while (n) {
+    /* n is the remaining cells to allocate. Try again:*/
+    z2 = STk_must_malloc_list_upton(&n, init, &new_last);
+
+    /* last was the last cell in the old list. We point its CDR to
+       the new list, and set last to the new_last (of the new list).
+       This effectively appends z2 to the end of the old list. */
+    CDR((SCM)last) = z2;
+    last = new_last;
+  }
+  return z;
+}
 
 int STk_init_system(void)
 {


### PR DESCRIPTION
Hi @egallesio !
These are several enhancements to `list.c` and related functions in `proc.c`.

Passes all tests. :)

And there are some really big performance gains, besides some enhancements in argument checking and error messages. (This brings the new allocator for lists, which does not repeatedly cons, but asks for a large set of cells each time)

# Optimize make-list and vector->list

Allocate more cells at once in `make-list`.

`libgc` only offers an interface to "get several objects", without telling us how many. It's usually a not very large number like 128 objects for example). We give the size, and receive a list.

This patch does this:

1. Implements `SCM STk_must_malloc_list(int n, SCM init)` that will allocate a list of CONS cells.
2. Changes `vector->list` so it will use the new function
3. Removes `make-list` and use the new function instead

There is also an internal function `STk_must_malloc_list_upton`, which allocates a list of size "at most n". This function will receive a size argument `n`, and will call the `libgc` function to allocate many objects.
1. If there is more than `n`, it will run through the list, cleaning the pointers so they are released.
2. If there is less than `n`, it will return the number of missing cells (not allocated) in the parameter `n`

`STk_must_malloc_list`  does:
1. calls `STk_must_malloc_list_upton`
3. If there are enough cells, stop
4. If not, call  `STk_must_malloc_list_upton` again, and append the two lists. Appending is NOT linear, it is O(1) here, because `STk_must_malloc_list_upton` returns a pointer to the last cell :)

New timings:
```scheme
(time
  (let ((a (make-vector 1000 'x)))
    (repeat 100000 (vector->list a))
    'ok))
```
Old code: 4152.755ms 100000001 allocation calls
New code: 2552.173ms  934202 allocation calls

```scheme
(time
  (let ((a #f))
    (repeat 100000
      (set! a (make-list 1000)))
    'ok))
```
Old code: 5339.514 ms 100100000 allocation calls
New code:  2249.643 ms 935418 allocation calls

Now make 10x less lists, with 10x more elements per list:
```scheme
(time
  (let ((a #f))
    (repeat 10000
      (set! a (make-list 10000)))
    'ok))
```
Old code: 4928.766 ms 100010000 allocation calls
New code: 2706.778 ms 873160 allocation calls

Also -- one more thing.

The new code properly counts allocation.

The size of `struct cons_object` on my machine is `24`.
```c

typedef struct {
  int16_t type, cell_info;
} stk_header;

struct cons_obj {
  stk_header header;
  void * car;
  void* cdr;
};
int main() {
	printf("size is %ld\n", sizeof(struct cons_obj));
}
```
The above program prints 24.

So -- with the new code,

```scheme
(time (make-list 10))
;    Elapsed time: 0.017 ms
;    Allocations: 240 bytes in 1 allocation call (GC: 0)

(time (make-list 10000))
;    Elapsed time: 0.131 ms
;    Allocations: 240000 bytes in 116 allocation calls (GC: 0)
```
**Exactly** the requested number of bytes (ok, we're cheating, because we allocated more and threw hem away, but they're gone immediately after allocation).

The old code, for some reason, was allocating more than necessary:
```scheme
(time (make-list 10))
;    Elapsed time: 0.007 ms
;    Allocations: 328 bytes in 11 allocation calls (GC: 0)

(time (make-list 10000))
;    Elapsed time: 0.955 ms
;    Allocations: 320008 bytes in 10001 allocation calls (GC: 0)
```
# Optimize MAP

Allocate the result list at once instead of consing all of the result list.

```scheme
(import (scheme list))

(let ((L (iota 30000000)))
  (time (begin (map - L)
               -1)))
```
Old code: 1728.254 ms
New code: 1131.081 ms

```scheme
(let ((L (iota 20000000))
      (M (reverse (map - (iota 18000000)))))
  (time (begin (map * L M)
               -1)))
```
Old code: 1273.321 ms
New code: 1021.081 ms

# Optimize and enhance list-copy, add list-deep-copy

1. Use Floyd's algorithm to detect cycles. It now copies:
   - proper lists
   - improper lists
   - cyclic lists
2. Allocate the list at once, not cell-by-cell
3. Do not use recursion. This avoids crashes with large lists
4. For all this to work, we implement a new C function,  `STk_list_type_and_length()`, which
   - tells wether the object is a proper list, improper list,  cyclic list or no list at all;
   - calculates the length of the list (if it is one)
5. Since we did all that, move circular-list? from SRFI-1  to the core
6. Add list-deep-copy. This is necessary in the module import  code. The previous version of `list-copy` would recurse    into the list, and the new won't. Reasons for making it    different, and create the separate `list-deep-copy`:
   - Every Scheme except STklos behaves the same way (they  won't recurse into the list); Gauche even has a  specialized `alist-copy`.
   - The `list-copy` primitiveis much faster than the old  one

See comments in the code.

```scheme
(let ((L (iota 20000)))
  (time (begin (repeat 3000 (list-copy L))
               -1)))
```
Old code: 2157.288 ms
New code: 1590.699 ms

```scheme
(let ((L (iota 20000000)))
  (begin (list-copy L)
          -1))
```
Old code crashed
New code works fine (The C function doesn't do recursive calls).

# Optimize and enhance reverse

`reverse` is a bit faster now, since it calls list-copy to allocate cells all at once.

And now STklos tells when a list is circular or improper:

stklos> (reverse '(1 . 2))
**** Error:
reverse: improper list '(1 . 2)'

stklos> (reverse (circular-list 1 2 3))
**** Error:
reverse: list '#0=(1 2 3 . #0#)' is circular

stklos> (reverse (append '(11 22) (circular-list 1 2 3)))
**** Error:
reverse: list '(11 22 . #0=(1 2 3 . #0#))' is circular
	(type ",help" for more information)

The two last examples would make STklos enter an infinite loop before this change.

#  Optimize and enhance `last-pair`

There was already a `last-pair` primitive (?) in STklos, but there was also a closure overriding it.
We enhanced the primitive a bit, and made it be used by default.

# Enhance `filter`

It now complains more clearly about circular and improper lists.