### PR TITLE
[trivial] Update `srfis.stk`

### DIFF
--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -279,21 +279,26 @@
     (238 "Codesets" () "srfi-238")
     ;; 239 Destructuring lists
     ;; 240 Reconciled records
-    ;; 241 Match -- Simple Pattern-Matching Syntax to Express Catamorphisms on Scheme Data (drafr)
-    ;; 242 The CFG Language (draft)
-    ;; 243 Unreadable objects (draft)
+    ;; 241 Match -- Simple Pattern-Matching Syntax to Express Catamorphisms on Scheme Data
+    ;; 242 The CFG Language
+    ;; 243 ...... withdrawn (Unreadable data)
     (244 "Multiple-value definitions")
     ;; 245 ...... withdrawn (Mixing definitions and expressions within bodies)
     ;; 246 ...... withdrawn (Guardians)
     ;; 247 Syntactic Monads
     ;; 248 Minimal delimited continuations (draft)
     ;; 249 ...... withdrawn (Restarting conditions)
-    ;; 250 ...... withdrawn (Insertion-ordered hash tables)
+    ;; 250 Insertion-ordered hash tables (draft)
     ;; 251 Mixing groups of definitions with expressions within bodies
     ;; 252 Property Testing
     (253 "Data (Type-)Checking" () "srfi-253")
     ;; 254 Ephemerons and Guardians (draft)
-    ;; 255 Restarting conditions (draft)
+    ;; 255 Restarting conditions
+    ;; 256 ...... withdrawn (Minimal extension to SRFI 9/R7RS small record type definitions for inheritance)
+    ;; 257 Simple extendable pattern matcher with backtracking (draft)
+    ;; 258 Uninterned symbols (draft)
+    ;; 259 Tagged procedures with type safety (draft)
+    ;; 260 Generated Symbols (draft)
     ))
 
 ;; Some shortcuts to add to the SRFI-features which permit to load seveal file


### PR DESCRIPTION
@egallesio we should probably have a script to update this from the SRFI site: https://github.com/scheme-requests-for-implementation/srfi-common/

This is the file wit SRFI data:

https://raw.githubusercontent.com/scheme-requests-for-implementation/srfi-common/master/admin/srfi-data.scm

Maybe:

1. Only store the number of implemented SRFIs in a list, `(define implemented-srfis '(0 1 2 4 ...))`
2. Have the compiler fetch the data from the site
3. Have a version of the SRFI data within STklos source, to be used when (2) doesn't work (due to lack of network access for example)

What do you think?