### PR TITLE
Pair immutability and `(features)`

### DIFF
--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -1639,10 +1639,17 @@ doc>
 |#
 (define (features)
   (let ((all (in-module |SRFI-0| *all-features*)))
-    (apply append
-           (map (lambda (x)
-                  (cond
-                    ((symbol? x)     (list x))
-                    ((pair? (car x)) (car x))
-                    (else            (list (car x)))))
-                all))))
+    ;; R7RS says it is an error to try to modify this list, so we make
+    ;; it immutable:
+    (let ((L (apply append
+                    (map (lambda (x)
+                       (cond
+                        ((symbol? x)     (list x))
+                        ((pair? (car x)) (car x))
+                        (else            (list (car x)))))
+                         all))))
+      (let loop ((ptr L))
+        (if (null? ptr)
+            L
+            (begin (pair-immutable! ptr)
+                   (loop (cdr ptr))))))))


### PR DESCRIPTION
@egallesio after the other PR for lists is dealt with, then we could perhaps have also a `list-immutable!` procedure. But it would be better to use the new C function that works on circular lists.