### PR TITLE
[simple] Make exit be as per R7RS

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1274,21 +1274,24 @@ DEFINE_PRIMITIVE("%pre-exit", pre_exit, subr1, (SCM retcode))
  * If  program has registered exit functions with |register-exit-function!|,
  * they are called (in an order which is the reverse of their call order).
  * @l
- * NOTE: The {{stklos}} |exit| primitive accepts also an
- * integer value as parameter (R7RS accepts only a boolean).
+ * This primitive accepts an integer value as parameter. If the value is not
+ * a small integer, then the integer 1 will be returned to the operating
+ * system. Other arguments are ignored.
 doc>
 */
-DEFINE_PRIMITIVE("exit", exit, subr01, (SCM retcode))
+DEFINE_PRIMITIVE("exit", exit, vsubr, (int argc, SCM *argv))
 {
   long ret = 0;
   SCM cond;
 
-  if (retcode) {
+  if (argc > 0) {
+    SCM retcode = *argv;
     if (BOOLEANP(retcode)) {
       ret = (retcode != STk_true);
     } else {
       ret = STk_integer_value(retcode);
-      if (ret == LONG_MIN) STk_error("bad return code ~S", retcode);
+      if (ret == LONG_MIN)
+        ret = 1;
     }
   }
 
@@ -1308,20 +1311,23 @@ DEFINE_PRIMITIVE("exit", exit, subr01, (SCM retcode))
  * dynamic-wind _after_ procedures and communicates an exit
  * value to the operating system in the same manner as |exit|.
  * @l
- * NOTE: The {{stklos}} |emergency-exit| primitive accepts also an
- * integer value as parameter (R7RS accepts only a boolean).
+ * This primitive accepts an integer value as parameter. If the value is not
+ * a small integer, then the integer 1 will be returned to the operating
+ * system. Other arguments are ignored.
 doc>
 */
-DEFINE_PRIMITIVE("emergency-exit", emergency_exit, subr01, (SCM retcode))
+DEFINE_PRIMITIVE("emergency-exit", emergency_exit, vsubr, (SCM argc, SCM *argv))
 {
   long ret = 0;
 
-  if (retcode) {
+  if (argc > 0) {
+    SCM retcode = *argv;
     if (BOOLEANP(retcode)) {
       ret = (retcode != STk_true);
     } else {
       ret = STk_integer_value(retcode);
-      if (ret == LONG_MIN) STk_error("bad return code ~S", retcode);
+      if (ret == LONG_MIN)
+        ret = 1;
     }
   }
   _exit(ret);


### PR DESCRIPTION
See issue #745 . 

`exit` should never signal errors, and it should actually exit (never get back to the REPL or to the program).

Bigloo, Chibi, Chez, Cyclone, Gauche, Guile never signal errors or return from `exit`. They all ignore the second argument, and will exit the program regardless of the type of the first argument.

Chicken will only signal an error for wrong type. For several arguments, so long as the first  is an integer, it does exit the program. But it does not accept booleans (?)

Loko, MIT Scheme and Sagittarius only signal an error for too many arguments. They will exit when the single argument is not a number.

Kawa and Gambit behave as STklos today (signal erorrs for too many arguments, and for wrong type).

Biwa and LIPS don't have an `exit` procedure.
