### PR TITLE
Optimize `1+` and `1-`

### DIFF
--- a/lib/comprewrite.stk
+++ b/lib/comprewrite.stk
@@ -186,3 +186,23 @@
                    expr))
              expr))
        expr)))
+
+(compiler:add-rewriter!            ;; '1+' rewriter
+ '1+
+ ;; (1+ x) ===> (+ x 1)
+ ;; which will be compiled into IN-INCR x
+ (lambda (expr len env)
+   (if (= len 2)
+       (let ((v (rewrite-expression (cadr expr) env)))
+         (list '+ v 1))
+       expr)))
+
+(compiler:add-rewriter!            ;; '1-' rewriter
+ '1-
+ ;; (1+ x) ===> (+ 1 x)
+ ;; which will be compiled into IN-DECR x
+ (lambda (expr len env)
+   (if (= len 2)
+       (let ((v (rewrite-expression (cadr expr) env)))
+         (list '- v 1))
+       expr)))


### PR DESCRIPTION
...with a rewrite rule. :)

We turn:

```scheme
(1+ x) into (+ x 1)
(1- x) into (- x 1)
```

So currently,

```
stklos> (disassemble-expr '(1+ a))

000:  PREPARE-CALL
001:  GLOBAL-REF-PUSH      0
003:  GREF-INVOKE          1 1
```

Now,

```
stklos> (disassemble-expr '(1+ a))

000:  GLOBAL-REF           0
002:  IN-INCR
```

Timings:

```scheme
(let ((a 10))
  (time
    (repeat 100000000 (1+ a))))
```

Old code: 3025.695 ms
New code: 1186.262 ms