### PR TITLE
[simple] Fix double compilation of multiplication

### DIFF
--- a/lib/compiler.stk
+++ b/lib/compiler.stk
@@ -1245,9 +1245,9 @@ doc>
               ((2)  (let ((a (car actuals))
                           (b (cadr actuals)))
                       (if (small-integer-constant? a)
-                          (oper2 'IN-SINT-MUL2 b a))
-                      (comp2 'IN-MUL2)))
-              (else (compile-normal-call fct actuals len env epair #f))))
+                          (oper2 'IN-SINT-MUL2 b a)
+                          (comp2 'IN-MUL2))))
+               (else (compile-normal-call fct actuals len env epair #f))))
       ((/)    (case len
                 ((0)   (compiler-error '/ epair "needs at least one argument"))
                 ((1)   (if (number? (car actuals))


### PR DESCRIPTION
```
stklos> (disassemble-expr '(* a 2))

000:  GLOBAL-REF           0
002:  IN-SINT-MUL2         2
004:  INT-PUSH             2
006:  GLOBAL-REF           0
008:  IN-MUL2
```

We're compiling twice!
This is because of a wrongly put parenthesis in `compiler.stk`:

```scheme
      ((*)  (case len
              ((0)  (emit 'IM-ONE))
              ((1)  (if (number? (car actuals))
                        (compile (car actuals) env epair tail?)
                        (compile-normal-call fct actuals len env epair #f)))
              ((2)  (let ((a (car actuals))
                          (b (cadr actuals)))
                      (if (small-integer-constant? a)
                          (oper2 'IN-SINT-MUL2 b a))
                      (comp2 'IN-MUL2)))                 ;; OOPS! Will be recompiled always!
              (else (compile-normal-call fct actuals len env epair #f))))
```

In the above example, (comp2 'IN-MUL2) was supposed to be the alternative for the IF, but it is outside it, so will always be executed.

This PR fixes it.

Fix #750

Passes all tests.

Makes the execution time of * become half what it was before (obviously, but I measured anyway).