### PR TITLE
More optimizations using `STk_C_make_list`

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -290,10 +290,11 @@ static SCM list_type_and_length(SCM l, int *len)
 
 SCM STk_argv2list(int argc, SCM *argv)
 {
-  SCM res = STk_nil;
-
-  while (argc--) {
-    res = STk_cons(argv[-argc], res);
+  SCM res = STk_C_make_list(argc,STk_false);
+  SCM ptr = res;
+  for(int i=0; i<argc; i++) {
+    CAR(ptr) = argv[i];
+    ptr = CDR(ptr);
   }
   return res;
 }

--- a/src/list.c
+++ b/src/list.c
@@ -602,29 +602,30 @@ doc>
  */
 SCM STk_append2(SCM l1, SCM l2)
 {
-  register SCM prev, tmp, l;
-  SCM res;
+  int n;
+  SCM type = list_type_and_length(l1, &n);
+  if (type == STk_nil) { /* proper list */
 
-  if (NULLP(l1)) return l2;
-  if (!CONSP(l1)) goto Error;
+    if (NULLP(l1)) return l2;
 
-  prev = res = STk_nil;
-  for (l = l1; ; l = CDR(l)) {
-    if (NULLP(l)) break;
-    if (!CONSP(l)) goto Error;
-    tmp = STk_cons(CAR(l), STk_nil);
-
-    if (res == STk_nil) {
-      prev = res = tmp;
-    } else {
-      CDR(prev) = tmp;
-      prev = tmp;
+    SCM res = STk_C_make_list(n, STk_false);
+    register SCM ptr = res;
+    register int i;
+    while(CONSP(CDR(ptr))) {
+      CAR(ptr) = CAR(l1);
+      ptr = CDR(ptr);
+      l1  = CDR(l1);
     }
+
+    CAR(ptr) = CAR(l1);
+    CDR(ptr) = l2;
+
+    return res;
   }
-  CDR(prev) = l2;
-  return res;
-Error:
-  error_bad_list(l1);
+  if (type == NULL) error_bad_list(l1);
+  if (CONSP(type))  error_circular_list(l1);
+  error_improper_list(l1);
+
   return STk_void; /* never reached */
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -535,10 +535,14 @@ DEFINE_PRIMITIVE("list", list, vsubr, (int argc, SCM * argv))
 doc>
  */
 {
-  register SCM *tmp, l = STk_nil;
+  register SCM *tmp;
+  SCM l = STk_C_make_list(argc, STk_false);
+  register SCM p = l;
 
-  for (tmp = argv-argc+1; tmp <= argv; tmp++)
-    l = STk_cons(*tmp, l);
+  for (tmp = argv; tmp > (argv-argc) ; tmp--) {
+    CAR(p) = *tmp;
+    p = CDR(p);
+  }
 
   return l;
 }


### PR DESCRIPTION
The most interesting is APPEND. It really becomes faster, and conses much less.

```scheme
(import (scheme list))

(let ((a (iota 10000))
      (b (map - (iota 10000))))
  (time (repeat 10000 (append a b))))
```

Old code:
4097.964 ms
100000000 allocation calls

New code:
2899.566 ms
10000 allocation calls

Plus, the code doesn't use goto anymore, AND we report different errors for cyclic lists, improper lists and no-lists. :)