### PR TITLE
[trivial] Remove bars from lambda in runtime macro definition

### DIFF
--- a/lib/runtime-macros.stk
+++ b/lib/runtime-macros.stk
@@ -47,7 +47,7 @@
 (define-macro (let* . args)          `(%%let* ,@args))
 (define-macro (letrec . args)        `(%%letrec ,@args))
 (define-macro (with-handler . args)  `(%%with-handler ,@args))
-(define-macro (|lambda| . args)      `(%%lambda ,@args))
+(define-macro (lambda . args)        `(%%lambda ,@args))
 (define-macro (|λ| . args)           `(%%lambda ,@args))
 (define-macro (quote . args)         `(%%quote ,@args))
 (define-macro (set! . args)          `(%%set! ,@args))
@@ -115,5 +115,3 @@
   (if (zero? (length args))
       (error 'syntax-error "needs at least one argument")
       `(%syntax-error ,@args)))
-
-


### PR DESCRIPTION
Runs perfectly without it...

`|lamdba|` $\longrightarrow$ `lambda`