### PR TITLE
[simple,R7RS] Fix unary sum and multiplication

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2216,7 +2216,12 @@ DEFINE_PRIMITIVE("+", plus, vsubr, (int argc, SCM *argv))
   SCM res;
 
   if (argc == 0) return MAKE_INT(0);
-  if (argc == 1) return add2(MAKE_INT(0), *argv);
+  if (argc == 1)
+    if (STk_numberp(*argv) == STk_true)
+      return *argv;
+    else
+      error_cannot_operate("addition",MAKE_INT(0),*argv);
+
 
   for (res = *argv--; --argc; argv--)
     res = add2(res, *argv);
@@ -2366,7 +2371,11 @@ DEFINE_PRIMITIVE("*", multiplication, vsubr, (int argc, SCM *argv))
   SCM res;
 
   if (argc == 0) return MAKE_INT(1);
-  if (argc == 1) return mul2(MAKE_INT(1), *argv);
+  if (argc == 1)
+    if (STk_numberp(*argv) == STk_true)
+      return *argv;
+    else
+      error_cannot_operate("multiplication",MAKE_INT(1),*argv);
 
   for (res = *argv--; --argc; argv--)
     res = mul2(res, *argv);

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -575,6 +575,8 @@
 ;;------------------------------------------------------------------
 (test-subsection "integer addition")
 
+(test/error "bad operator - unary addition" (+ "x"))
+
 (define x #xffffffff00000000ffffffff00000000)
 (define xx (- x))
 (define y #x00000002000000000000000200000000)
@@ -735,6 +737,8 @@
 
 ;;------------------------------------------------------------------
 (test-subsection "integer multiplication")
+
+(test/error "bad operator - unary addition" (* "x"))
 
 (define (m-result x) (list x (- x) (- x) x))
 (define (m-tester x y)


### PR DESCRIPTION
    Currently:
    
```
stklos> (+ +)
#[primitive +]
stklos> (+ "a")
"a"
stklos> (* "a")
"a"
```

With this PR the type check is being performed.


instead of "bad number" we report "cannot operate", so the behavior is consistent with that of `/` and `-`:

```
stklos> (/ "x")
**** Error:
/: cannot perform division on '1' and '"x"'
	(type ",help" for more information)
stklos> (* "x")
**** Error:
*: cannot perform multiplication on '1' and '"x"'

stklos> (- "x")
**** Error:
-: cannot perform difference on '0' and '"x"'
	(type ",help" for more information)
stklos> (+ "x")
**** Error:
+: cannot perform addition on '0' and '"x"'
	(type ",help" for more information)
```