### PR TITLE
[simple] Add `readline-set-option` (and for example, allow the user to set parenthesis blinking when closing them)

### DIFF
--- a/lib/readline-complete.c
+++ b/lib/readline-complete.c
@@ -130,6 +130,11 @@ DEFINE_PRIMITIVE("%init-readline-completion-function",readline_init_completion,s
 }
 
 DEFINE_PRIMITIVE("readline-set-option",readline_set_option,subr2, (SCM option, SCM value)) {
+  if (!STRINGP(option)) STk_error("bad string ~s", option);
+  if (!STRINGP(value)) STk_error("bad string ~s", value);
+  if (STRING_SIZE(option) + STRING_SIZE(value) > 195)
+    STk_error("option and value strings too long (max 195 bytes)");
+
   char s[201];
   snprintf(s,200,"set %s %s",STRING_CHARS(option), STRING_CHARS(value));
   int res = rl_parse_and_bind(s);


### PR DESCRIPTION
For example,

```scheme
(readline-set-option "blink-matching-paren" "on")
```

will make STklos blink the opening parenthesis when we close it.

And we can dynamically change the options. If we do 

```scheme
(readline-set-option "blink-matching-paren" "off")
```

if stops blinking (no restart necessary!)
