### PR TITLE
[simple] Describe mutexes

### DIFF
--- a/lib/describe.stk
+++ b/lib/describe.stk
@@ -203,6 +203,19 @@ doc>
                                 (if (positive? (hash-table-size x))
                                     (format #f " with ~a entries" (hash-table-size x))
                                     "")))
+     ((mutex? x)        (let ((name     (mutex-name     x))
+                              (state    (if (thread? (mutex-state    x))
+                                            (format #f "locked by thread ~a" (mutex-state x))
+                                            (mutex-state x)))
+                              (specific (if (void? (mutex-specific x))
+                                            "void"
+                                            "non-void")))
+                          (if name
+                              (format port "a mutex with name ~a, state ~a and ~a specific field"
+                                      name state specific)
+                              (format port "an unnamed mutex with state ~a and ~a specific field"
+                                      state specific))))
+
      (else              (let ((user-type-name (%user-type-name x)))
                           (if user-type-name
                               ;; Object type is user defined.


### PR DESCRIPTION
Currently, `describe` does not explain anything about a mutex. With this PR it does:

```
stklos> (define m (make-mutex "xy"))
;; m
stklos> ,d m
#[mutex xy] is a mutex with name xy, state not-abandoned and void specific field.
stklos> (mutex-lock! m)
#t
stklos> ,d m
#[mutex xy] is a mutex with name xy, state locked by thread #[thread primordial (runnable)] and void specific field.
stklos> (mutex-specific-set! m (current-time))
stklos> ,d m
#[mutex xy] is a mutex with name xy, state locked by thread #[thread primordial (runnable)] and non-void specific field.
```