### PR TITLE
Implement vector patterns in syntax-rules

### DIFF
--- a/lib/mbe.stk
+++ b/lib/mbe.stk
@@ -185,7 +185,7 @@ doc>
 ;; hyg:tag uses gensym to rename variables (actually, tag the ones which will be renamed).
 ;;
 ;; e is the form
-;; kk ar ethe keywords
+;; kk are the keywords
 ;; al is an assoc list
 ;;
 ;; returns a list with
@@ -196,9 +196,13 @@ doc>
 ;;
 ;; the list al is appended to the output CDR, so the assoc list may be build gradually.
 ;;
-;; (hyg:tag '(f a b c) '(a c)          '()) => ((G984 a G985 c) (G985 . b) (G984 . f))
-;; (hyg:tag 1          '(fun x fun oh) '()) => (1)
-;; (hyg:tag '(f a b c) '(a c)          '((G-something . y))) => ((G1333 a G1334 c) (G1334 . b) (G1333 . f) (G-something . y))
+;; (hyg:tag '(f a b c) '(a c)          '() '...) => ((G984 a G985 c) (G985 . b) (G984 . f))
+;; (hyg:tag 1          '(fun x fun oh) '() '...) => (1)
+;; (hyg:tag '(f a b c) '(a c)          '((G-something . y)) '...)
+;;                                               => ((G1333 a G1334 c)
+;;                                                   (G1334 . b)
+;;                                                   (G1333 . f)
+;;                                                   (G-something . y))
 (define hyg:tag
   (lambda (e kk al ellipsis)
     (cond ((pair? e)
@@ -431,10 +435,12 @@ doc>
 (define hyg:flatten
   (lambda (e)
     (let loop ((e e) (r '()))
-      (cond ((pair? e) (loop (car e)
-                             (loop (cdr e) r)))
-            ((null? e) r)
-            (else (cons e r))))))
+
+      (cond ((pair? e)    (loop (car e)
+                                (loop (cdr e) r)))
+            ((vector? e)  (loop (vector->list e) r))
+            ((null? e)    r)
+            (else         (cons e r))))))
 
 ;;;; End of hygiene filter.
 
@@ -505,10 +511,14 @@ doc>
 			                       (lambda (x) (mbe:matches-pattern? p-head x k ellipsis))
                                    e-head)
 			                      (mbe:matches-pattern? p-tail e-tail k ellipsis))))))))
-            ((pair? p)
-             (and (pair? e)
-		          (mbe:matches-pattern? (car p) (car e) k ellipsis)
+            ((and (pair? p) (pair? e))
+		     (and (mbe:matches-pattern? (car p) (car e) k ellipsis)
 		          (mbe:matches-pattern? (cdr p) (cdr e) k ellipsis)))
+            ((and (vector? p) (vector? e))
+             (let ((list-p (vector->list p))
+                   (list-e (vector->list e)))
+               (and (mbe:matches-pattern? (car list-p) (car list-e) k ellipsis)
+		            (mbe:matches-pattern? (cdr list-p) (cdr list-e) k ellipsis))))
             ((symbol? p) (if (memq p k) (eq? p e) #t))
             (else (equal? p e)))))
 
@@ -528,7 +538,10 @@ doc>
 ;;   => ((f . *) (a . 2) (b . 4))
 ;;
 ;; (mbe:get-bindings '(f a . b) '(func 1 2 3) '() '...)
-;;   =>((f . func) (a . 1) (b 2 3))
+;;   => ((f . func) (a . 1) (b 2 3))
+;;
+;; (mbe:get-bindings '(f #(a b)) '(func #(1 2)) '() '...)
+;;   => ((f . func) (a . 1) (b . 2))
 ;;
 ;; (mbe:get-bindings '(f a ...) '(func 1 2) '() '...) ; see how lists are dealt with!
 ;;   => ((f . func) ((a) ((a . 1)) ((a . 2))))
@@ -564,6 +577,9 @@ doc>
           ((pair? p)
 	       (append (mbe:get-bindings (car p) (car e) k ellipsis)
 	               (mbe:get-bindings (cdr p) (cdr e) k ellipsis)))
+          ((and (vector? p)  (vector? e) (= (vector-length p)
+                                            (vector-length e)))
+           (mbe:get-bindings (vector->list p) (vector->list e) k ellipsis))
           ((symbol? p)
            (if (memq p k) '() (list (cons p e))))
           (else '()))))
@@ -693,18 +709,18 @@ doc>
 ;;     ((f a b)   (+ a b))
 ;;     ((f a b c) (* b c))))
 ;;
-;; (find-clause 'f '(2 3) '() '( ((f a b)   (+ a b)) ((f a b c) (* b c))))
+;; (find-clause 'f '(2 3) '() '( ((f a b)   (+ a b)) ((f a b c) (* b c))) '...)
 ;; => (+ 2 3)
 ;;
-;; (find-clause 'f '(1 2 3) '() '( ((f a b)   (+ a b)) ((f a b c) (* b c))))
+;; (find-clause 'f '(1 2 3) '() '( ((f a b)   (+ a b)) ((f a b c) (* b c))) '...)
 ;; => (* 2 3)
 (define (find-clause macro-name macro-args keywords clauses ellipsis)
   (let ((macro-form (cons macro-name macro-args)))
     (let Loop ((l clauses))
       (if (null? l)
           (syntax-error macro-name "no matching clause for ~S" macro-form)
-          (let ((in-pattern  (caar  l))
-                (out-pattern (cadar l)))
+          (let ((in-pattern  (caar  l))  ; example '(f a b)
+                (out-pattern (cadar l))) ; example '(+ a b)
             (if (mbe:matches-pattern? in-pattern macro-form keywords ellipsis)
                 (let ((tmp (hyg:tag out-pattern
                                     (append! (hyg:flatten in-pattern) keywords)
@@ -767,7 +783,7 @@ doc>
     ,@body))
 
 ;;;;
-;;;; STklos code for define-syntax and syntax-rules 
+;;;; STklos code for define-syntax and syntax-rules
 ;;;;
 
 (define-macro (syntax-rules . syn-rules)

--- a/tests/test-macros.stk
+++ b/tests/test-macros.stk
@@ -275,6 +275,24 @@
           (g ((quote ...) 2 3 4 5 6)))))
 
 
+;;; vector patterns
+
+(define-syntax %%%%f (syntax-rules () ((_ #(a b)) b)))
+(test "vector-pattern.1" 2 (%%%%f #(1 2)))
+
+(let-syntax ((f (syntax-rules () ((_ #(a b)) b))))
+  (test "vector-pattern.2" 2 (f #(1 2))))
+
+(let-syntax ((f (syntax-rules () ((_ #(a b)) b))))
+  (test/compile-error "vector-pattern.3" (f #(1 2 3))))
+
+(let-syntax ((f (syntax-rules () ((f (a #(b c) d)) (list d c b a)))))
+  (test "vector-pattern.4" '(4 3 2 1)  (f (1 #(2 3) 4))))
+
+(let-syntax ((f (syntax-rules () ((f a #(b c) d) (list d c b a)))))
+  (test "vector-pattern.5" '(4 3 2 1)  (f 1 #(2 3) 4)))
+
+
 ;;FIXME: Add more tests !!!!!!!!!
 
 


### PR DESCRIPTION
Hi @egallesio !

Finally I got some time to work on this issue. This PR makes vector patterns work:

```scheme
(let-syntax ((f (syntax-rules ()
               ((f (a #(b c) d))
                (list d c b a)))))
  (f (1 #(2 3) 4)))

=> (4 3 2 1)
```

Some tests included.

Would fix #752 
