### PR TITLE
[simple] Optimize `(/ log a b)`

### DIFF
--- a/lib/comprewrite.stk
+++ b/lib/comprewrite.stk
@@ -206,3 +206,21 @@
        (let ((v (rewrite-expression (cadr expr) env)))
          (list '- v 1))
        expr)))
+
+(compiler:add-rewriter!            ;; '(/ log a b)' rewriter
+ '/
+ ;; (/ (log a) (log b) ===> (log a b)
+ ;; Why?
+ ;; 1. It's faster
+ ;; 2. Doesn't introduce inexactness when not necessary:
+ ;;    (/ (log 4) (log 2))  =>  2
+ (lambda (expr len env)
+   (if (and (= len 3)
+            (pair? (cadr  expr))       ;; (log a)
+            (pair? (caddr expr))       ;; (log b)
+            (eq? 'log (caadr expr))    ;; 'log (first)
+            (eq? 'log (caaddr expr)))  ;; 'log (second)
+       (let ((a (rewrite-expression (cadr (cadr  expr)) env))
+             (b (rewrite-expression (cadr (caddr expr)) env)))
+         `(log ,a ,b))
+       expr)))


### PR DESCRIPTION
It's a rewriter:
```scheme
 (/ (log a) (log b) ===> (log a b)
```

Why?
1. It's faster
2. Doesn't introduce inexactness when not necessary: `(/ (log 4) (log 2))  =>  2`

```scheme
(let ((a (expt 3 70))
      (b (expt 5 70)))
  (time
    (repeat 10000000
      (/ (log a) (log b)))))

old code: 1586.978 ms
new code: 1463.421 ms

(let ((a 3.3)
      (b 2.2))
  (time
    (repeat 30000000
      (/ (log a) (log b)))))

old code: 4466.972 ms
new code: 3710.965 ms

(time (repeat 300000000 (/ (log 100) (log 111))))
old code: 2010.131 ms
new code: 1969.842 ms
```

Also, now we have:

```scheme
(/ (log 4) (log 2)) => 2
```

We had `2.0` before.

I'm just not sure if it's OK to write too many rewriters... But we don't yet have "a lot".