### PR TITLE
Turn `mpz_t` into `long` if possible, reading from bytevector; also let `bytevector-uint-set!` accept fixnums

### DIFF
--- a/lib/scheme/bytevector.c
+++ b/lib/scheme/bytevector.c
@@ -42,6 +42,9 @@ struct bignum_obj {
 
 #define BIGNUM_VAL(p)   (((struct bignum_obj *) (p))->val)
 
+#define BIGNUM_FITS_INTEGER(_bn) (mpz_cmp_si((_bn), INT_MIN_VAL) >= 0 && \
+                                  mpz_cmp_si((_bn), INT_MAX_VAL) <= 0)
+
 #define LONG_FITS_INTEGER(_l) \
   (((int64_t)INT_MIN_VAL) <= (_l) && \
    (_l) <= ((int64_t) INT_MAX_VAL))
@@ -341,10 +344,11 @@ bytevector_uint_ref_aux(SCM b, endianness_t end, size_t idx, size_t size, int si
       mpz_add_ui(num2,num,1);
       mpz_neg(num,num2);
 
+      if (BIGNUM_FITS_INTEGER(num))  return MAKE_INT(mpz_get_si(num));
+
       NEWCELL(z, bignum);
       mpz_set(BIGNUM_VAL(z), num);
       return z;
-
     } else {
       /***
           Positive case: the GMP already has a function for that!
@@ -360,6 +364,8 @@ bytevector_uint_ref_aux(SCM b, endianness_t end, size_t idx, size_t size, int si
                   e,                                   /* endianness within words */
                   0,                                   /* nails (skipped bits)    */
                   &(((char *) UVECTOR_DATA(b))[idx])); /* from                    */
+
+      if (BIGNUM_FITS_INTEGER(num))  return MAKE_INT(mpz_get_si(num));
 
       NEWCELL(z, bignum);
       mpz_set(BIGNUM_VAL(z), num);

--- a/tests/lib/scheme/bytevector.stk
+++ b/tests/lib/scheme/bytevector.stk
@@ -266,6 +266,9 @@
 
       (test "31" (bytevector-sint-ref b 0 (endianness little) 16)
             -3)
+
+      (test "31.5" #t (fixnum? (bytevector-sint-ref b 0 (endianness little) 16)))
+
       (test "32" (bytevector->u8-list b)
             '(253 255 255 255 255 255 255 255
                   255 255 255 255 255 255 255 255))
@@ -278,6 +281,8 @@
             #xfffffffffffffffffffffffffffffffd)
 
       (test "35" (bytevector-sint-ref b 0 (endianness big) 16) -3)
+
+      (test "35.5" #t (fixnum? (bytevector-sint-ref b 0 (endianness big) 16)))
 
       (test "36" (bytevector->u8-list b)
             '(255 255 255 255 255 255 255 255


### PR DESCRIPTION
We had this situation:

```scheme
stklos> ,i scheme/bytevector
stklos> (define b  (make-bytevector 16 -127))
;; b
stklos>  (bytevector-uint-set! b 0 (- (expt 2 128) 3) (endianness little) 16)

stklos> ,d (bytevector-sint-ref b 0 (endianness little) 16)
-3 is a bignum integer number.
```

With this PR, the number is made into a fixnum (which it is!)

This addresses the problem described in PR #768 