### PR TITLE
Optimize `length+`, `dotted-list?` and `iota` in SRFI-1

### DIFF
--- a/lib/scheme/list.stk
+++ b/lib/scheme/list.stk
@@ -366,16 +366,17 @@
 
 ;;; IOTA count [start step] (start start+step ... start+(count-1)*step)
 
-(define (iota count :optional (start 0) (step 1))
-  (check-arg integer? count iota)
-  (check-arg number? start iota)
-  (check-arg number? step iota)
-  (if (< count 0) (error 'iota "negative step count ~S" count))
-  (let ((last-val (+ start (* (- count 1) step))))
-    (do ((count count (- count 1))
-     (val last-val (- val step))
-     (ans '() (cons val ans)))
-    ((<= count 0)  ans))))
+;; Reweitten in C
+;; (define (iota count :optional (start 0) (step 1))
+;;   (check-arg integer? count iota)
+;;   (check-arg number? start iota)
+;;   (check-arg number? step iota)
+;;   (if (< count 0) (error 'iota "negative step count ~S" count))
+;;   (let ((last-val (+ start (* (- count 1) step))))
+;;     (do ((count count (- count 1))
+;;      (val last-val (- val step))
+;;      (ans '() (cons val ans)))
+;;     ((<= count 0)  ans))))
 
 ;;; I thought these were lovely, but the public at large did not share my
 ;;; enthusiasm...
@@ -456,16 +457,20 @@
 ;;; <dotted-list> ::= <non-nil,non-pair>    ; Empty dotted list
 ;;;               |   (cons <x> <dotted-list>)  ; Proper-list pair
 
-(define (dotted-list? x)
-  (let lp ((x x) (lag x))
-    (if (pair? x)
-    (let ((x (cdr x)))
-      (if (pair? x)
-          (let ((x   (cdr x))
-            (lag (cdr lag)))
-        (and (not (eq? x lag)) (lp x lag)))
-          (not (null? x))))
-    (not (null? x)))))
+;; Suppressed dotted-list? and circular-list? because we build them easily
+;; in C, using list_type_and_length().
+
+;; In STklos core
+;; (define (dotted-list? x)
+;;   (let lp ((x x) (lag x))
+;;     (if (pair? x)
+;;     (let ((x (cdr x)))
+;;       (if (pair? x)
+;;           (let ((x   (cdr x))
+;;             (lag (cdr lag)))
+;;         (and (not (eq? x lag)) (lp x lag)))
+;;           (not (null? x))))
+;;     (not (null? x)))))
 
 ;; In STklos core
 ;; (define (circular-list? x)
@@ -514,18 +519,19 @@
 ;        (lp (cdr x) (+ len 1))     ; diverges.
 ;        len)))
 
-(define (length+ x)         ; Returns #f if X is circular.
-  (let lp ((x x) (lag x) (len 0))
-    (if (pair? x)
-    (let ((x (cdr x))
-          (len (+ len 1)))
-      (if (pair? x)
-          (let ((x   (cdr x))
-            (lag (cdr lag))
-            (len (+ len 1)))
-        (and (not (eq? x lag)) (lp x lag len)))
-          len))
-    len)))
+;; Suppressed length+: re-written in C, using list_type_and_length():
+;; (define (length+ x)         ; Returns #f if X is circular.
+;;   (let lp ((x x) (lag x) (len 0))
+;;     (if (pair? x)
+;;     (let ((x (cdr x))
+;;           (len (+ len 1)))
+;;       (if (pair? x)
+;;           (let ((x   (cdr x))
+;;             (lag (cdr lag))
+;;             (len (+ len 1)))
+;;         (and (not (eq? x lag)) (lp x lag len)))
+;;           len))
+;;     len)))
 
 (define (zip list1 . more-lists) (apply map list list1 more-lists))
 
@@ -1771,6 +1777,7 @@ FILTER an FILTER! are primitives in STklos
 (redefine make-list)
 (redefine assoc)
 (redefine member)
+
 
 ;; Not R7RS, but also moved to STklos core:
 (redefine last-pair)

--- a/src/list.c
+++ b/src/list.c
@@ -181,7 +181,7 @@ SCM STk_C_make_list(int n, SCM init)
  *   - If the list consists of a single cycle, then we guarantee that
  *    the pointer returned is to the FIRST cell of the list.
  */
-static SCM list_type_and_length(SCM l, int *len)
+SCM list_type_and_length(SCM l, int *len)
 {
   //     About the cycle detecting and copying algorithm:
   //

--- a/src/stklos.h
+++ b/src/stklos.h
@@ -637,7 +637,7 @@ enum f_codes {
 int STk_C_type2number(SCM key);
 SCM STk_call_ext_function(SCM fct, int argc, SCM *argv);
 SCM STk_ext_func_name(SCM fct);
-  
+
 int STk_init_ffi(void);
 
 
@@ -741,6 +741,7 @@ SCM STk_dappend2(SCM l1, SCM l2);       /* destructive append */
 SCM STk_dremq(SCM obj, SCM list);       /* destructive remove with eq? */
 SCM STk_econs(SCM car, SCM cdr, char *file, int line, int pos);
 SCM STk_C_make_list(int n, SCM init);  /* GC friendly list allocation */
+SCM list_type_and_length(SCM l, int *len);
 
 EXTERN_PRIMITIVE("cons", cons, subr2, (SCM x, SCM y));
 EXTERN_PRIMITIVE("car", car, subr1, (SCM x));


### PR DESCRIPTION
1. Optimize `length+`, `dotted-list?`

Since we already have the C function `list_type_and_length()` in STklos core, it makes no sense to keep these in Scheme.

2. Optimize `iota`

Because it's easy. And we can allocate the full list at once now. The code in SRFI-1 will do N allocations...

BUT

We had to declare `list_type_and_length` non-static and include it in `stklos.h`...

Results:

```scheme
(time
  (repeat 10 (iota 10000000)))
New code:
1463.77 ms
2400000000 bytes in 10 allocation calls

Old code:
7940.318 ms
2400001920 bytes in 100000050 allocation calls

(time
  (let ((x (iota 1000000)))
    (repeat 100 (length+ x))))
New code:
507.476 ms
24000000 bytes in 1 allocation call

Old code:
5892.6 ms
24011392 bytes in 1000305 allocation calls

(let ((x (iota 1000000)))
  (set-cdr! (last-pair x) 1)
  (time (repeat 100 (length+ x))))
New code:
494.158 ms
Allocations: 0

Old code:
5714.828 ms
11200 bytes in 300 allocation calls
```