### PR TITLE
[simple] Don't redefine some string procedures in SRFI-13

### DIFF
--- a/lib/srfi/13.stk
+++ b/lib/srfi/13.stk
@@ -254,19 +254,19 @@
 ;;;
 ;;; Exported procedures
 ;;;
-(define (string-copy str :optional (start 0) (end -1))
-  (%check-indexes str start end 'string-copy)
-  (substring str start end))
+;; (define (string-copy str :optional (start 0) (end -1))
+;;   (%check-indexes str start end 'string-copy)
+;;   (substring str start end))
 
 (define (substring/shared str :optional (start 0) (end -1))
   (%check-indexes str start end 'substring/shared)
   (%substring/shared str start end))
 
-(define (string-copy! to tstart from :optional (fstart 0) (fend -1))
-  (%check-indexes from fstart fend 'string-copy!)
-  (check-arg integer? tstart 'string-copy!)
-  (%check-substring-indexes  to tstart (+ tstart (- fend fstart)) 'string-copy!)
-  (%string-copy! to tstart from fstart fend))
+;; (define (string-copy! to tstart from :optional (fstart 0) (fend -1))
+;;   (%check-indexes from fstart fend 'string-copy!)
+;;   (check-arg integer? tstart 'string-copy!)
+;;   (%check-substring-indexes  to tstart (+ tstart (- fend fstart)) 'string-copy!)
+;;   (%string-copy! to tstart from fstart fend))
 
 (define (string-take s n)
   (check-arg string? s 'string-take)
@@ -344,12 +344,12 @@
 ;;;;                            M O D I F I C A T I O N
 ;;;;
 ;;;; ======================================================================
-(define (string-fill! str char :optional (start 0) (end -1))
-  (%check-indexes str start end 'string-fill!)
-  (check-arg char? char 'string-fill!)
-  (do ((i (- end 1) (- i 1)))
-      ((< i start))
-    (string-set! str i char)))
+;; (define (string-fill! str char :optional (start 0) (end -1))
+;;   (%check-indexes str start end 'string-fill!)
+;;   (check-arg char? char 'string-fill!)
+;;   (do ((i (- end 1) (- i 1)))
+;;       ((< i start))
+;;     (string-set! str i char)))
 
 ;;;; ======================================================================
 ;;;;
@@ -1254,6 +1254,16 @@
                              (if (= vi -1) 0
                                  (Loop2 vi))))))))))))
 
+;;; Some functions are now defined in R7RS, or are in STklos
+;;; core. They have been deleted from this file. However, in order to
+;;; keep a list of exported symbol which is coherent with the text of
+;;; the SRFI
+(define-macro (redefine symb)
+  `(define ,symb (in-module |SCHEME| ,symb)))
+
+(redefine string-fill!)
+(redefine string-copy)
+(redefine string-copy!)
 
 ;;; End of module SRFI-13
 )

--- a/lib/srfi/13.stk
+++ b/lib/srfi/13.stk
@@ -192,11 +192,11 @@
 ;;;;            L I S T   &   S T R I N G   C O N V E R S I O N
 ;;;;
 ;;;; ======================================================================
-(define (string->list str :optional (start 0) (end -1))
-  (%check-indexes str start end 'string->list)
-  (do ((i (- end 1) (- i 1))
-       (res '() (cons (string-ref str i) res)))
-      ((< i start) res)))
+;; (define (string->list str :optional (start 0) (end -1))
+;;   (%check-indexes str start end 'string->list)
+;;   (do ((i (- end 1) (- i 1))
+;;        (res '() (cons (string-ref str i) res)))
+;;       ((< i start) res)))
 
 (define (reverse-list->string char-list)
   (list->string (reverse char-list)))
@@ -1261,9 +1261,10 @@
 (define-macro (redefine symb)
   `(define ,symb (in-module |SCHEME| ,symb)))
 
-(redefine string-fill!)
-(redefine string-copy)
-(redefine string-copy!)
+(redefine string-fill!) ; R7RS
+(redefine string-copy)  ; R7RS
+(redefine string-copy!) ; R7RS
+(redefine string->list) ; R7RS
 
 ;;; End of module SRFI-13
 )


### PR DESCRIPTION
They're already in the core, as primitives, and their signatures are identical.

Passes all tests. :)