### PR TITLE
Rewrite `remove` in C

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -27,7 +27,7 @@
         macro-expand macro-expand* unquote unquote-splicing
         ... => _ else
         improper-list?
-        remove remove! delete delete!
+        delete delete!
         every any
         call-with-input-string call-with-output-string
         read-case-sensitive
@@ -212,24 +212,6 @@ doc>
 (define (improper-list? lst)
   (and (pair? lst)
        (not (list? lst))))
-
-
-#|
-<doc EXT remove remove!
- * (remove pred list)
- *
- * |Remove| returns |list| without the elements that satisfy predicate |pred|:
- * @l
- * The list is not disordered -- elements that appear in the result list occur
- * in the same order as they occur in the argument list. |Remove!| does the
- * same job than |remove| by physically modifying its |list| argument
- * @lisp
- * (remove even? '(0 7 8 8 43 -4)) => (7 43)
- * @end lisp
-doc>
-|#
-(define (remove  pred l) (filter  (lambda (x) (not (pred x))) l))
-(define (remove! pred l) (filter! (lambda (x) (not (pred x))) l))
 
 
 #|

--- a/src/list.c
+++ b/src/list.c
@@ -1181,13 +1181,27 @@ DEFINE_PRIMITIVE("last-pair", last_pair, subr1, (SCM l))
  * @end lisp
  * An error is signaled if |list| is a constant list.
 doc>
+<doc EXT remove remove!
+ * (remove pred list)
+ * (remove! pred list)
+ *
+ * |Remove| returns |list| without the elements that satisfy predicate |pred|:
+ * @l
+ * The list is not disordered -- elements that appear in the result list occur
+ * in the same order as they occur in the argument list. |Remove!| does the
+ * same job than |remove| by physically modifying its |list| argument
+ * @lisp
+ * (remove even? '(0 7 8 8 43 -4)) => (7 43)
+ * @end lisp
+doc>
  */
-DEFINE_PRIMITIVE("filter", filter, subr2, (SCM pred, SCM list))
+SCM filter_remove (SCM pred, SCM list, int filter)
 {
   register SCM ptr, l;
   SCM result;
   int len;
   SCM x = list_type_and_length(list, &len);
+  int cmp;
 
   if (!x) error_bad_list(list);
   if (CONSP(x)) error_circular_list(list);
@@ -1197,7 +1211,12 @@ DEFINE_PRIMITIVE("filter", filter, subr2, (SCM pred, SCM list))
 
   for (ptr=l=list, result=STk_nil; !NULLP(l); ) {
 
-    if (STk_C_apply(pred, 1, CAR(l)) != STk_false) {
+    /* cmp is the comparison, which *would* go inside the if condition.
+       We pre-compute it, and invert it if filter is set to zero. */
+    cmp = (STk_C_apply(pred, 1, CAR(l)) != STk_false);
+    if (!filter) cmp = !cmp;
+
+    if (cmp) {
       if (NULLP(result)) {
         NEWCELL(result, cons);
         ptr = result;
@@ -1214,12 +1233,20 @@ DEFINE_PRIMITIVE("filter", filter, subr2, (SCM pred, SCM list))
   return result;
 }
 
+DEFINE_PRIMITIVE("filter", filter, subr2, (SCM pred, SCM list)) {
+  return filter_remove(pred, list, 1);
+}
+DEFINE_PRIMITIVE("remove", remove, subr2, (SCM pred, SCM list)) {
+  return filter_remove(pred, list, 0);
+}
 
-DEFINE_PRIMITIVE("filter!", dfilter, subr2, (SCM pred, SCM list))
+
+SCM dfilter_remove (SCM pred, SCM list, int filter)
 {
   SCM previous, l;
   int len;
   SCM x = list_type_and_length(list, &len);
+  int cmp;
 
   if (!x) error_bad_list(list);
   if (CONSP(x)) error_circular_list(list);
@@ -1230,7 +1257,12 @@ DEFINE_PRIMITIVE("filter!", dfilter, subr2, (SCM pred, SCM list))
   for (previous=STk_nil, l=list; !NULLP(l); ) {
     if (BOXED_INFO(l) & CONS_CONST) error_const_cell(l);
 
-    if (STk_C_apply(pred, 1, CAR(l)) == STk_false) {
+    /* cmp is the comparison, which *would* go inside the if condition.
+       We pre-compute it, and invert it if filter is set to zero. */
+    cmp = (STk_C_apply(pred, 1, CAR(l)) == STk_false);
+    if (!filter) cmp = !cmp;
+
+    if (cmp) {
       if (previous == STk_nil)
         list = CDR(list);
       else
@@ -1241,6 +1273,13 @@ DEFINE_PRIMITIVE("filter!", dfilter, subr2, (SCM pred, SCM list))
     l = CDR(l);
   }
   return list;
+}
+
+DEFINE_PRIMITIVE("filter!", dfilter, subr2, (SCM pred, SCM list)) {
+  return dfilter_remove(pred, list, 1);
+}
+DEFINE_PRIMITIVE("remove!", dremove, subr2, (SCM pred, SCM list)) {
+  return dfilter_remove(pred, list, 0);
 }
 
 /*
@@ -1461,6 +1500,8 @@ int STk_init_list(void)
   ADD_PRIMITIVE(list_star);
   ADD_PRIMITIVE(last_pair);
   ADD_PRIMITIVE(filter);
+  ADD_PRIMITIVE(remove);
+  ADD_PRIMITIVE(dremove);
   ADD_PRIMITIVE(dfilter);
   ADD_PRIMITIVE(dappend);
   ADD_PRIMITIVE(dreverse);


### PR DESCRIPTION
Actually, the code for `filter` is almost what we need. The change is minimal.

Also, since we have `filter` as a primitive, it would make sense to have `remove` too (for symmetry).

```scheme
(let ((X (iota 5000)))
  (time
    (repeat 10000 (remove odd? X))))
Old code:
3045.002 ms
Allocations: 600880000 bytes in 25020000 allocation calls

New code:
1800.999 ms
Allocations: 600000000 bytes in 25000000 allocation calls

(let ((X (iota 5000)))
  (time
    (repeat 10000 (remove! odd? X))))
Old code:
1196.142 ms
Allocations: 880000 bytes in 20000 allocation calls

New code:
578.752 ms
Allocations: 0 bytes in 0 allocation calls
```