### PR TITLE
Rewrite any and every in C

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -28,7 +28,6 @@
         ... => _ else
         improper-list?
         remove remove! delete delete!
-        every any
         call-with-input-string call-with-output-string
         read-case-sensitive
         open-input-virtual open-output-virtual
@@ -267,114 +266,61 @@ doc>
   (filter! (lambda (y) (not (comp x y))) l))
 
 
-#|
-<doc EXT every
- * (every pred list1 list2 ...)
- *
- * |every| applies the predicate |pred| across the lists, returning true if
- * the predicate returns true on every application.
- * @l
- * If there are n list arguments |list1| ... |listn|, then |pred| must be
- * a procedure taking n arguments and returning a boolean result.
- * @l
- * |every| applies pred to the first elements of the |listi| parameters. If
- * this application returns false, every immediately returns `#f`.
- * Otherwise, it iterates, applying |pred| to the second elements of the |listi|
- * parameters, then the third, and so forth. The iteration stops when a
- * false value is produced or one of the lists runs out of values.
- * In the latter case, |every| returns the true value produced by its final
- * application of pred. The application of pred to the last element of the
- * lists is a tail call.
- * @l
- * If one of the |listi| has no elements, |every| simply returns `#t`.
- * @l
- * Like |any|, |every|'s name does not end with a question mark -- this is to
- * indicate that it does not return a simple boolean (`#t` or `#f`), but a
- * general value.
-doc>
-|#
-(define (every pred l . others)         ;; compatible with SRFI-1
-  (unless (procedure? pred)
-    (error 'every "bad procedure" pred))
+#| any and every here were suppressed in order to be rewritten in C. |#
+;; (define (every pred l . others)         ;; compatible with SRFI-1
+;;   (unless (procedure? pred)
+;;     (error 'every "bad procedure" pred))
 
-  (if (null? others)
-      ;; EVERY called with mono argument predicate
-      (letrec ((every (lambda (l)
-                        (cond
-                         ((null? l)        #t)
-                         ((null? (cdr l)) (pred (car l)))
-                         (else            (and  (pred (car l))
-                                                (every (cdr l))))))))
-        (every l))
+;;   (if (null? others)
+;;       ;; EVERY called with mono argument predicate
+;;       (letrec ((every (lambda (l)
+;;                         (cond
+;;                          ((null? l)        #t)
+;;                          ((null? (cdr l)) (pred (car l)))
+;;                          (else            (and  (pred (car l))
+;;                                                 (every (cdr l))))))))
+;;         (every l))
 
-      ;; General case
-      (letrec ((every (lambda (l last)
-                        (if (memq '() l)
-                            last
-                            (let ((cars  (map car l))
-                                  (cdrs (map cdr l)))
-                              (if (memq '() cdrs)
-                                  (apply pred cars)
-                                  (let ((res (apply pred cars)))
-                                    (and res
-                                         (every cdrs res)))))))))
-        (every (cons l others) #t))))
+;;       ;; General case
+;;       (letrec ((every (lambda (l last)
+;;                         (if (memq '() l)
+;;                             last
+;;                             (let ((cars  (map car l))
+;;                                   (cdrs (map cdr l)))
+;;                               (if (memq '() cdrs)
+;;                                   (apply pred cars)
+;;                                   (let ((res (apply pred cars)))
+;;                                     (and res
+;;                                          (every cdrs res)))))))))
+;;         (every (cons l others) #t))))
 
 #|
-<doc EXT any
- * (any pred list1 list2 ...)
- *
- * |any| applies the predicate across the lists, returning true if the
- * predicate returns true on any application.
- *
- * If there are n list arguments |list1| ... |listn|, then |pred| must be
- * a procedure taking n arguments.
- *
- * |any| applies |pred| to the first elements of the |listi| parameters. If
- * this application returns a true value, |any| immediately returns that value.
- * Otherwise, it iterates, applying |pred| to the second elements of the |listi|
- * parameters, then the third, and so forth. The iteration stops when a true
- * value is produced or one of the lists runs out of values; in the latter case,
- * any returns `#f`. The application of |pred| to the last element of the
- * lists is a tail call.
- *
- * Like |every|, |any|'s name does not end with a question mark -- this is
- * to indicate that it does not return a simple boolean (`#t` or `#f`), but
- * a general value.
- *
- * @lisp
- * (any integer? '(a 3 b 2.7))   => #t
- * (any integer? '(a 3.1 b 2.7)) => #f
- * (any < '(3 1 4 1 5)
- *        '(2 7 1 8 2))          => #t
- * @end lisp
-doc>
 |#
-(define (any pred l . others)           ;; compatible with SRFI-1
-  (unless (procedure? pred)
-    (error 'any "bad procedure" pred))
+;; (define (any pred l . others)           ;; compatible with SRFI-1
+;;   (unless (procedure? pred)
+;;     (error 'any "bad procedure" pred))
 
-  (if (null? others)
-      ;; ANY called with mono argument predicate
-      (letrec ((any (lambda (l)
-                      (cond
-                       ((null? l)       #f)
-                       ((null? (cdr l)) (pred (car l)))
-                       (else            (or (pred (car l))
-                                            (any (cdr l))))))))
-        (any l))
-      ;; General case
-      (letrec ((any (lambda (l last)
-                      (if (memq '() l)
-                          last
-                          (let ((cars  (map car l))
-                                (cdrs (map cdr l)))
-                            (if (memq '() cdrs)
-                                (apply pred cars)
-                                (let ((res (apply pred cars)))
-                                  (or res
-                                      (any cdrs res)))))))))
-        (any (cons l others) #f))))
+;;   (if (null? others)
+;;       ;; ANY called with mono argument predicate
+;;       (letrec ((any (lambda (l)
+;;                       (cond
+;;                        ((null? l)       #f)
+;;                        ((null? (cdr l)) (pred (car l)))
+;;                        (else            (or (pred (car l))
+;;                                             (any (cdr l))))))))
+;;         (any l))
+;;       ;; General case
+;;       (letrec ((any (lambda (l last)
+;;                       (if (memq '() l)
+;;                           last
+;;                           (let ((cars  (map car l))
+;;                                 (cdrs (map cdr l)))
+;;                             (if (memq '() cdrs)
+;;                                 (apply pred cars)
+;;                                 (let ((res (apply pred cars)))
+;;                                   (or res
+;;                                       (any cdrs res)))))))))
+;;        (any (cons l others) #f))))
 
 
 ;;;

--- a/src/list.c
+++ b/src/list.c
@@ -1360,7 +1360,161 @@ SCM STk_int_assq(SCM obj, SCM alist)
   return STk_false;
 }
 
+/*
+<doc EXT every
+ * (every pred list1 list2 ...)
+ *
+ * |every| applies the predicate |pred| across the lists, returning true if
+ * the predicate returns true on every application.
+ * @l
+ * If there are n list arguments |list1| ... |listn|, then |pred| must be
+ * a procedure taking n arguments and returning a boolean result.
+ * @l
+ * |every| applies pred to the first elements of the |listi| parameters. If
+ * this application returns false, every immediately returns `#f`.
+ * Otherwise, it iterates, applying |pred| to the second elements of the |listi|
+ * parameters, then the third, and so forth. The iteration stops when a
+ * false value is produced or one of the lists runs out of values.
+ * In the latter case, |every| returns the true value produced by its final
+ * application of pred. The application of pred to the last element of the
+ * lists is a tail call.
+ * @l
+ * If one of the |listi| has no elements, |every| simply returns `#t`.
+ * @l
+ * Like |any|, |every|'s name does not end with a question mark -- this is to
+ * indicate that it does not return a simple boolean (`#t` or `#f`), but a
+ * general value.
+doc>
+<doc EXT any
+ * (any pred list1 list2 ...)
+ *
+ * |any| applies the predicate across the lists, returning true if the
+ * predicate returns true on any application.
+ *
+ * If there are n list arguments |list1| ... |listn|, then |pred| must be
+ * a procedure taking n arguments.
+ *
+ * |any| applies |pred| to the first elements of the |listi| parameters. If
+ * this application returns a true value, |any| immediately returns that value.
+ * Otherwise, it iterates, applying |pred| to the second elements of the |listi|
+ * parameters, then the third, and so forth. The iteration stops when a true
+ * value is produced or one of the lists runs out of values; in the latter case,
+ * any returns `#f`. The application of |pred| to the last element of the
+ * lists is a tail call.
+ *
+ * Like |every|, |any|'s name does not end with a question mark -- this is
+ * to indicate that it does not return a simple boolean (`#t` or `#f`), but
+ * a general value.
+ *
+ * @lisp
+ * (any integer? '(a 3 b 2.7))   => #t
+ * (any integer? '(a 3.1 b 2.7)) => #f
+ * (any < '(3 1 4 1 5)
+ *        '(2 7 1 8 2))          => #t
+ * @end lisp
+doc>
+*/
 
+/* any_every does the work for the any and every procedures.
+   When the argument 'any' is non-zero, it does any; when it's
+   zero, it does every.
+   *argv is the list of lists, received from the Scheme vsubr
+   procedure any/every; n is the number of lists.
+*/
+SCM any_every(SCM pred, SCM *argv, int n, int any) {
+    if (STk_procedurep(pred) != STk_true) error_bad_proc(pred);
+    SCM *argv_ptr = argv;
+
+    /* Check the list arguments. If there is any NULL list, we can
+       return already. If there are any non-lists, we signal an
+       error. */
+    for (int i=0; i<n; i++, argv_ptr--) {
+        if (!CONSP(*argv_ptr)) {
+            if (NULLP(*argv_ptr))   return any ? STk_false : STk_true;
+            else                     error_bad_list(*argv_ptr);
+        }
+    }
+
+    SCM lists_ptr;
+    SCM res = any ? STk_false : STk_true;
+
+    /* FAST PATH n = 1 */
+    if (n == 1) {
+        /* *argv is the ONLY list that needs to be used. */
+        lists_ptr = *argv;
+        while(CONSP(lists_ptr)) {
+            res = STk_C_apply(pred,1,CAR(lists_ptr));
+            if (any   && res != STk_false) return res;
+            if (!any  && res == STk_false) return STk_false;
+            lists_ptr = CDR(lists_ptr);
+        }
+        if (!NULLP(lists_ptr)) error_bad_list(*argv);
+    } else {
+        /* cars will be a list with the cars from the given lists; and
+           we'll keep moving forward through the lists, updating each
+           element in cars, using cars_ptr. */
+        SCM cars = STk_C_make_list(n, STk_false);
+        SCM cars_ptr;
+
+        int stop=0;
+        int i;
+
+        /* Make a list of lists and copy the lists in argv into it */
+        SCM l = STk_C_make_list(n, STk_false);
+        lists_ptr = l;
+        argv_ptr = argv;
+        for (int i=0; i<n; i++) {
+            CAR(lists_ptr) = *argv_ptr--;
+            lists_ptr=CDR(lists_ptr);
+        }
+        /* Now l is a list of lists, similar to the argument given to
+           any/every, but we'll use it as a multi-pointer through thte
+           lists. */
+
+        while (!stop) {
+            /* Load arguments into cars */
+            lists_ptr = l;
+            cars_ptr  = cars;
+            for(i=0; i<n; i++) {
+                /* When one of thet lists is over, stop.
+                   And if it's improper, signal an error. */
+                if (!CONSP(CAR(lists_ptr))) {
+                    /* Do not allow improper lists... SRFI-116 wants this: */
+                    if (!NULLP(CAR(lists_ptr))) error_bad_list(l);
+                    stop = 1;
+                    break;
+                }
+                /* Load the next argument from the list of lists: */
+                CAR(cars_ptr) = CAR(CAR(lists_ptr));
+                cars_ptr = CDR(cars_ptr);             /* advance cars pointer */
+
+                /* and advance the pointers: */
+                CAR(lists_ptr) = CDR(CAR(lists_ptr)); /* of this (i-th) list  */
+                lists_ptr = CDR(lists_ptr);           /* of the list of lists */
+            }
+
+            if (!stop) {
+                /* The heart of it all is here: */
+                res = STk_C_apply_list(pred, cars);
+                if (any   && res != STk_false) return res;
+                if (!any  && res == STk_false) return STk_false;
+            }
+        }
+    }
+    return res;
+}
+
+DEFINE_PRIMITIVE("any", any, vsubr, (int argc, SCM *argv)) {
+    if (argc < 1) STk_error("at least one argument needed");
+    SCM pred = *argv--; argc--;
+    return any_every(pred, argv, argc, 1);
+}
+
+DEFINE_PRIMITIVE("every", every, vsubr, (int argc, SCM *argv)) {
+    if (argc < 1) STk_error("at least one argument needed");
+    SCM pred = *argv--; argc--;
+    return any_every(pred, argv, argc, 0);
+}
 
 /* ======================================================================
  *
@@ -1464,6 +1618,9 @@ int STk_init_list(void)
   ADD_PRIMITIVE(dfilter);
   ADD_PRIMITIVE(dappend);
   ADD_PRIMITIVE(dreverse);
+
+  ADD_PRIMITIVE(any);
+  ADD_PRIMITIVE(every);
 
   ADD_PRIMITIVE(epairp);
   ADD_PRIMITIVE(epair_file);


### PR DESCRIPTION
Reasons:

- they're very important, used in several places of bonus.stk and also in SRFIs
- it becomes incredibly faster and conses much less
- the C code is almost the same in size

Timings:

1. Fast path (single argument)
```scheme
(let ((X (iota 5000)))
  (time
    (repeat 10000 (any null? X))))

Old code:
2529.879 ms
Allocations: 1280000 bytes in 30000 allocation calls

New code:
1030.316 ms
Allocations: 0 bytes in 0 allocation calls
```

2. Normal path (two argument in this case)

```scheme
(let ((X (iota 5000))
      (Y  (iota 5000)))
  (time
    (repeat 10000 (every = X Y))))

Old code:
17490.161 ms
Allocations: 4801760000 bytes in 100050000 allocation calls

New code:
2991.282 ms
Allocations: 800960000 bytes in 50020000 allocation calls
```