### PR TITLE
[trivial] Better error message for `numerator`/`denominator`

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3056,7 +3056,7 @@ DEFINE_PRIMITIVE("numerator", numerator, subr1, (SCM q))
     case tc_rational: return RATIONAL_NUM(q);
     case tc_bignum:
     case tc_integer:  return q;
-    default:          error_bad_number(q);
+    default:          error_not_a_real_number(q);
   }
   return STk_void; /* never reached */
 }
@@ -3068,7 +3068,7 @@ DEFINE_PRIMITIVE("denominator", denominator, subr1, (SCM q))
     case tc_rational: return RATIONAL_DEN(q);
     case tc_bignum:
     case tc_integer:  return MAKE_INT(1);
-    default:          error_bad_number(q);
+    default:          error_not_a_real_number(q);
   }
   return STk_void; /* never reached */
 }


### PR DESCRIPTION
We now say

- "not a real number", when it's complex, or
- "is a bad number" when it's not a number at all.

Before, we had:

```scheme
(numerator 1.0-2i)
**** Error:
numerator: '1.0-2i' is a bad number
```

But `1.0-2i` *is* a number...

*Remark*: actually R7RS says the argument should be a rational. But in a computer using the IEEE format (for `double`) or other formats (GMP, `long`), all numbers are rationals. So we *can* return the numerator and denominator for "reals"...