### PR TITLE
Do not accept non-strings in provide/require/etc

### DIFF
--- a/lib/load.stk
+++ b/lib/load.stk
@@ -485,12 +485,14 @@ doc>
   (set! require
     (lambda (what)
       #:require
+      (unless (string? what) (error "bad string ~S" what))
       (%%require what (load-path))))
 
 
   (set! require/provide
     (lambda (what)
       #:require/provide
+      (unless (string? what) (error "bad string ~S" what))
       (unless (member what provided)
         (%load what (load-path) (load-suffixes) #f))
       (provide what)))
@@ -499,6 +501,7 @@ doc>
   (set! provide
     (lambda (what)
       #:provide
+      (unless (string? what) (error "bad string ~S" what))
       (unless (member what provided)
         (set! provided (cons what provided)))
       what))
@@ -507,6 +510,7 @@ doc>
   (set! provided?
     (lambda (what)
       #:provided
+      (unless (string? what) (error "bad string ~S" what))
       (and (member what provided) #t))))
 
 


### PR DESCRIPTION
Because it should be (according to the help text) a file name.