### PR TITLE
[simple] Add a length parameter to `cpointer->string`

### DIFF
--- a/tests/test-ffi.stk
+++ b/tests/test-ffi.stk
@@ -235,6 +235,14 @@
       "aBcD"
       (cpointer->string buff))
 
+(test "read back the (forged) C string.2"
+      "aB"
+      (cpointer->string buff 2))
+
+(test/error "cpointer->string bad integer" (cpointer->string buff 'a))
+(test/error "cpointer->string bad length"  (cpointer->string buff -1))
+
+
 
 (let ((array (allocate-bytes (* 10 (c-size-of :long)))))
   (dotimes (i 10)


### PR DESCRIPTION
```scheme
 (define buff (allocate-bytes 5))
 (cpointer-set! buff :uchar #\a 0)
 (cpointer-set! buff :uchar #\B 1)
 (cpointer-set! buff :uchar #\c 2)
 (cpointer-set! buff :uchar #\D 3)
 (cpointer-set! buff :uchar #\null 4)

 (cpointer->string buff)    => "aBcD"
 (cpointer->string buff 2)  => "aB"
 (cpointer->string buff -1) => error
```