### PR TITLE
[simple] Fix crash on integer division with infinities

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -811,7 +811,10 @@ static inline SCM real2integer(SCM r)
 {
   double v = REAL_VAL(r);
 
-  if (floor(v) != v) {
+  /* For NaNs, the test floor(v) == v will return false.
+     But for infinities, it returns true. And we can't do double2integer on
+     an inf. */
+  if (floor(v) != v || isinf(v)) {
     /* This is not an inexact integer (weak test) */
     STk_error("bad number (~s) in an integer division", r);
   }

--- a/tests/srfis/144.stk
+++ b/tests/srfis/144.stk
@@ -621,6 +621,15 @@
      (test-assert "srfi-144.236 " (fleven? zero))
      (test-deny "srfi-144.237 "   (fleven? one))
 
+     (test/error "srfi-144.237.1" (flodd? +inf.0))
+     (test/error "srfi-144.237.2" (flodd? +nan.0))
+     (test/error "srfi-144.237.3" (flodd? -inf.0))
+     (test/error "srfi-144.237.4" (flodd? -nan.0))
+     (test/error "srfi-144.237.5" (fleven? +inf.0))
+     (test/error "srfi-144.237.6" (fleven? +nan.0))
+     (test/error "srfi-144.237.7" (fleven? -inf.0))
+     (test/error "srfi-144.237.8" (fleven? -nan.0))
+
      (test "srfi-144.238 " (map flfinite? somereals)
            (map (lambda (x) #t) somereals))
      (test "srfi-144.239 " (map flfinite? weird)

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -937,6 +937,10 @@
                             974849)
                   319489))
 
+(test/error "quotient w/inf.1" (quotient +inf.0 10))
+(test/error "quotient w/inf.2" (quotient 10 +inf.0))
+
+
 ;;------------------------------------------------------------------
 (test-subsection "remainder")
 
@@ -999,6 +1003,9 @@
       (r-tester 3735928559.0 27353))
 (test "inexact rem inexact -> inexact" (r-result 1113.0 #f)
       (r-tester 3735928559.0 27353.0))
+
+(test/error "remainder w/inf.1" (remainder +inf.0 10))
+(test/error "remainder w/inf.2" (remainder 10 +inf.0))
 
 ;;------------------------------------------------------------------
 (test-subsection "modulo")
@@ -1090,6 +1097,9 @@
 (test "mersenne prime? 48" #f (mersenne-prime? 48))
 (test "mersenne prime? 100" #f (mersenne-prime? 100))
 (test "mersenne prime? (* 61 19)" #f (mersenne-prime? (* 61 19)))
+
+(test/error "modulo w/inf.1" (modulo +inf.0 10))
+(test/error "modulo w/inf.2" (modulo 10 +inf.0))
 
 ;;------------------------------------------------------------------
 (test-subsection "gcd and lcm")
@@ -1255,6 +1265,9 @@
 (test/compile-error "lcm" (lcm 1 #\a))
 (test/compile-error "lcm" (lcm 1 "a"))
 (test/compile-error "lcm" (lcm 1 lcm))
+
+(test/error "gcd w/inf" (gcd 10 +inf.0 2))
+(test/error "lcm w/inf" (lcm 10 +inf.0 2))
 
 (compiler:inline-common-functions %%%___inline-common-functions)
 
@@ -1656,6 +1669,8 @@
       (bit-or #x-aa55aa55aa #x-6666666666))
 (test "bit-or (-big | -big)" #x-103454301aacca9
       (bit-or #x-123456789abcdef #x-fedcba987654321fedcba987654321fedcba))
+
+(test/error "bit-shift w/inf" (bit-shift 2.0 -inf.0))
 
 ;;------------------------------------------------------------------
 (test-subsection "transcendental functions")

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -533,6 +533,11 @@
 (test "even?" #f (even? 0+1.0i))
 (test/error "even?" (even? "i am a number"))
 
+(test "odd?"  #f (odd?  +inf.0))
+(test "odd?"  #f (odd?  +inf.0))
+(test "even?" #f (even? -inf.0))
+(test "even?" #f (even? -inf.0))
+
 (test "zero?" #t (zero? 0))
 (test "zero?" #t (zero? 0.0))
 (test "zero?" #t (zero? (- 10 10.0)))


### PR DESCRIPTION
This patch fixes the following problem:

```
stklos> (quotient -inf.0 2)
Floating point exception

stklos> ,i scheme/flonum
stklos> (flodd? +inf.0)
Floating point exception
```

and includes tests.