### PR TITLE
Fix `(sqrt -inf.0)` and infinities in complex `sqrt`

### DIFF
--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1412,6 +1412,15 @@
       #t
       (nan? (sqrt -nan.0)))
 
+(test "sqrt +x-inf.0i" +inf.0-inf.0i (sqrt 2.0-inf.0i))
+(test "sqrt +x+inf.0i" +inf.0+inf.0i (sqrt 2.0+inf.0i))
+(test "sqrt +inf.0-yi" +inf.0-0.0i   (sqrt +inf.0-2i))
+(test "sqrt +inf.0-yi" +inf.0+0.0i   (sqrt +inf.0+2i))
+(test "sqrt -x-inf.0i" +inf.0-inf.0i (sqrt -2.0-inf.0i))
+(test "sqrt -x+inf.0i" +inf.0+inf.0i (sqrt -2.0+inf.0i))
+(test "sqrt -inf.0-yi" +0.0-inf.0i   (sqrt -inf.0-2i))
+(test "sqrt -inf.0-yi" +0.0+inf.0i   (sqrt -inf.0+2i))
+
 ;;------------------------------------------------------------------
 (test-subsection "logical operations")
 


### PR DESCRIPTION
If should result in `-inf.0i`, but since we were delegating this to the C function `sqrt`, which doesn't handle complexes, it returned a NaN. Now it correctly returns `-inf.0i`

The second patch fixes `sqrt` for complexes with infinite parts.