### PR TITLE
[trivial] More informative error message in integer division error

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -816,7 +816,7 @@ static inline SCM real2integer(SCM r)
   */
   if (floor(v) != v || isinf(v)) {
     /* This is not an inexact integer (weak test) */
-    STk_error("bad number (~s) in an integer division", r);
+    STk_error("non-integer real number (~s) in an integer division", r);
   }
   return double2integer(v);
 }


### PR DESCRIPTION
```
stklos> (remainder 4 5.1)
**** Error:
remainder: bad number (5.1) in an integer division
```

But 5.1 is a perfectly good number :smile:   It's just not integer... So now we report the error as

```
stklos> (remainder 4 5.1)
**** Error:
remainder: non-integer real number (5.1) in an integer division
```