### PR TITLE
Add (stklos roman-numerals)`

### DIFF
--- a/lib/stklos/Makefile.am
+++ b/lib/stklos/Makefile.am
@@ -30,20 +30,22 @@ SO = @SH_SUFFIX@
 #
 # Libraries written in Scheme only
 #
-SRC_STK  = apropos.stk      \
-           describe.stk     \
-           getopt.stk       \
-           help.stk         \
-           preproc.stk      \
-           pretty-print.stk \
+SRC_STK  = apropos.stk        \
+           describe.stk       \
+           getopt.stk         \
+           help.stk           \
+           preproc.stk        \
+           pretty-print.stk   \
+           roman-numerals.stk \
            trace.stk
 
-SRC_OSTK = apropos.ostk      \
-           describe.ostk     \
-           getopt.ostk       \
-           help.ostk         \
-           preproc.ostk      \
-           pretty-print.ostk \
+SRC_OSTK = apropos.ostk        \
+           describe.ostk       \
+           getopt.ostk         \
+           help.ostk           \
+           preproc.ostk        \
+           pretty-print.ostk   \
+           roman-numerals.ostk \
            trace.ostk
 
 #

--- a/lib/stklos/roman-numerals.stk
+++ b/lib/stklos/roman-numerals.stk
@@ -1,0 +1,140 @@
+;;;;
+;;;; roman-numerals.stk         -- convert from/to roman numerals
+;;;;
+;;;; Copyright © 2025 Jerônimo Pellegrini <j_p@aleph0.info>
+;;;;
+;;;;
+;;;; This program is free software; you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation; either version 3 of the License, or
+;;;; (at your option) any later version.
+;;;;
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program; if not, write to the Free Software
+;;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+;;;; USA.
+;;;;
+;;;;           Author: Jerônimo Pellegrini [j_p@aleph0.info]
+;;;;    Creation date:  9-Sep-2025 15:01
+;;;;
+
+(define-library (stklos roman-numerals)
+
+  (import SCHEME)
+  (export integer->roman
+          roman->integer)
+
+  (begin
+
+    ;; Assoc list of symbols and integer value, in reverse
+    ;; order of value
+    (define numerals '(("M"  . 1000)
+                       ("CM" .  900)
+                       ("D"  .  500)
+                       ("CD" .  400)
+                       ("C"  .  100)
+                       ("XC" .   90)
+                       ("L"  .   50)
+                       ("XL" .   40)
+                       ("X"  .   10)
+                       ("IX" .    9)
+                       ("V"  .    5)
+                       ("IV" .    4)
+                       ("I"  .    1)))
+
+    #|
+    * <doc EXT integer->roman
+    * (integer->roman n [ :case c ] [ :zero z])
+    *
+    * Converts the integer n to roman numerals. If the keyword
+    * argument |case| is the symbol |lower|, then lower case will be used.
+    * If the keyword argument |zero| is passed, it is
+    * used as the string for "zero". By default, the string "N" is
+    * used for zero.
+    *
+    * Only integer numbers between 0 and 4999 are allowed.
+    *
+    * @lisp
+    * (integer->roman 23)               => "XXIII"
+    * (integer->roman 23 :case 'lower)  => "xxiii"
+    * (integer->roman 0)                => "N"
+    * (integer->roman 0 :zero "nulla")  => "nulla"
+    * (integer->roman 6000)             => error
+    * (integer->roman -1)               => error
+    * @end lisp
+    * doc>
+    |#
+    (define (integer->roman n :key (case 'upper) (zero "N"))
+      (unless (integer? n) (error "bad integer ~s" n))
+      (unless (< -1 n 5000) (error "number out of range ~s" n))
+      (unless (string? zero) (error "bad string ~w for zero" zero))
+
+      (if (zero? n)
+          zero
+          (let ((result ""))
+            (for-each (lambda (L)
+                        (let ((sym (car L))
+                              (val (cdr L)))
+                          (while (>= n val)
+                            (set! result (string-append result sym))
+                            (dec! n val))))
+                      numerals)
+            (if (eq? case 'lower)
+                (string-lower result)
+                result))))
+
+    ;; Regular expression for roman numerals.
+    (define re (string->regexp
+                (string-append "^"                  ;; beginning of string
+                               "(?i)"               ;; case-insensitive
+                               "M{0,4}"             ;; thousands
+                               "(CM|CD|D?C{0,3})"   ;; hundreds
+                               "(XC|XL|L?X{0,3})"   ;; tens
+                               "(IX|IV|V?I{0,3})"   ;; units
+                               "$")))               ;; end of string
+
+#|
+* <doc EXT roman->integer
+* (roman->integer n [:zero z])
+*
+* Converts the roman number |n| (represented as a string) into
+* an integer. If the keyword argument |zero| is passed, it is
+* used as the string for "zero". By default, the string "N" is
+* used for zero.
+*
+* Only simple numbers between "I" (1) and "MMMMCMXCIX" (4999)
+* are supported.
+*
+* @lisp
+* (roman->integer "xvii")                    => 17
+* (roman->integer "DxI")                     => 511
+* (roman->integer "nothing" :zero "nothing") => 0
+* (roman->integer "nothing")                 => error
+* (roman->integer "abcde")                   => error
+* @end lisp
+* doc>
+|#
+    (define (roman->integer r :key (zero "N"))
+      (unless (string? zero) (error "bad string ~w for zero" zero))
+      (if (string=? r zero)
+          0
+          (let ((r (string-upper r)) ;; compare using upper-case only
+                (result 0)
+                (index 0))
+            (unless (regexp-match re r) (error "bad roman number ~s" r))
+            (for-each (lambda (L)
+                        (let ((sym (car L))
+                              (val (cdr L)))
+                          (while (and (<= (fx+ index (string-length sym)) (string-length r))
+                                      (string=? (substring r index (fx+ index (string-length sym))) sym))
+                            (inc! result val)
+                            (inc! index (string-length sym)))))
+                      numerals)
+            result)))
+
+    ))

--- a/tests/do-test.stk
+++ b/tests/do-test.stk
@@ -53,6 +53,7 @@
   (load "test-macros.stk")
   (load "test-misc.stk")
   (load "test-r5rs-pitfall.stk")
+  (load "test-roman-numerals.stk")
 )
 
 

--- a/tests/test-roman-numerals.stk
+++ b/tests/test-roman-numerals.stk
@@ -1,0 +1,79 @@
+;(define-module test-roman-numerals
+;  (import SCHEME
+;          (stklos roman-numerals))
+;  (begin
+(import (stklos roman-numerals))
+  ;  (define (run)
+
+      (dotimes (i 5000)
+        (test "integer->roman returns string"
+              #t
+              (string? (integer->roman i))))
+
+      (dotimes (i 5000)
+        (test "roman->integer returns fixnum integer"
+              #t
+              (fixnum? (roman->integer (integer->roman i)))))
+
+      (dotimes (i 5000)
+        (test "roman <-> integer"
+              #t
+              (fx= (roman->integer (integer->roman i)))))
+
+      (test "roman nulla.1"
+            "N"
+            (integer->roman 0))
+
+      (test "roman nulla.2"
+            0
+            (roman->integer "N"))
+
+      ;; The following test crashes, and I could not identify the reason.
+      ;;(test "roman nulla.3"
+      ;;      "nulla"
+      ;;      (integer->roman 0 #:zero "nulla"))
+
+      (test "roman integer real"
+            "III"
+            (integer->roman 3.0))
+
+      (test "roman mixed case"
+            17
+            (roman->integer "xViI"))
+
+      (test "roman upper case"
+            "DLXII"
+            (integer->roman 562))
+
+      ;; The following test crashes, and I could not identify the reason.
+      ;;(test "roman lower case"
+      ;;      "dlxii"
+      ;;      (integer->roman 562 #:case 'lower))
+
+      (test/error "roman bad roman number.1"
+                  (roman->integer "A"))
+
+      (test/error "roman bad roman number.2"
+                  (roman->integer 'XV))
+
+      (test/error "roman bad roman number.3"
+                  (roman->integer "IIX"))
+
+      (test/error "roman bad roman number.4"
+                  (roman->integer "ixvii"))
+
+      (test/error "roman bad integer input.5"
+                  (integer->roman 6000))
+
+      (test/error "roman bad integer input.6"
+                  (integer->roman -2))
+
+      (test/error "roman bad integer input.7"
+                  (integer->roman 3.1))
+
+ ;     )
+
+;(run)
+;;))
+
+;((in-module test-roman-numerals run))


### PR DESCRIPTION
Hi @egallesio !

I thought it would be a nice addition to STklos...

```scheme
(integer->roman 4999)   => "MMMMCMXCIX"
(roman->integer "DCIX") => 609
```

There are two tests commented out. They pass when running from the REPL, but crash when called from the test suite. I couldn't tell why. 