### PR TITLE
[simple] Fix `fxsqrt` and optimize `exact-integer-sqrt`

### DIFF
--- a/lib/r7rs.stk
+++ b/lib/r7rs.stk
@@ -32,7 +32,8 @@
         exact-integer?
         floor-quotient floor/ truncate/ truncate-quotient
         truncate-remainder floor-remainder
-        square exact-integer-sqrt exact inexact
+        square
+        exact inexact
         boolean=?
         member assoc
         symbol=?
@@ -482,46 +483,6 @@ doc>
 (define truncate-quotient  quotient)
 (define truncate-remainder remainder)
 (define floor-remainder    modulo)
-
-
-#|
-<doc R7RS exact-integer-sqrt
- * (exact-integer-sqrt k)
- *
- * Returns two non negatives integers |s| and |r| where
- * |k=s**2+r| and |k<(s+1)**2|.
- *
- * @lisp
- * (exact-integer-sqrt 4)     => 2 0
- * (exact-integer-sqrt 5)     => 2 1
- * @end lisp
-doc>
-|#
-(define (exact-integer-sqrt k)
-  (define (isqrt n)
-    ;; Compute integer square root using Newton's method.
-
-    ;; We take special care when picking the initial guess, which
-    ;; is computed in the 'xn' argument to the named let below:
-    ;; this is a very good estimate (much better than the usual
-    ;; textbook "n/2" guess), and safe:
-    ;;
-    ;; (expt 2 (+ 1 (quotient (integer-length n) 2)))
-    ;;
-    ;; which is the least power of two bigger than SQRT(n).
-    (let loop ((xn (expt 2 (+ 1 (quotient (integer-length n) 2)))))
-      (let ((xn1 (quotient (+ xn (quotient n xn)) 2)))
-        (if (>= xn1 xn)
-            xn
-            (loop xn1)))))
-
-  (unless (and (exact-integer? k)(>= k 0))
-    (error "non negative integer expected. It was: ~S" k))
-  (let ((s (if (fixnum? k)
-               (let ((v (sqrt k)))
-                 (if (exact? v) v (inexact->exact (floor v))))
-               (isqrt k))))
-    (values s (- k (* s s)))))
 
 
 #|

--- a/src/fixnum.c
+++ b/src/fixnum.c
@@ -400,7 +400,7 @@ DEFINE_PRIMITIVE("fxsqrt", fxsqrt, subr1, (SCM o))
   {
     long no = INT_VAL(o);
     if (no < 0)   STk_error("non negative fixnum expected. It was: ~S", o);
-    long n1 = (long) sqrt((float)no);
+    long n1 = (long) sqrt((double)no);
     long n2 = no - (n1*n1);
     return STk_n_values(2,
                         MAKE_INT(n1),

--- a/src/number.c
+++ b/src/number.c
@@ -4104,6 +4104,37 @@ DEFINE_PRIMITIVE("sqrt", sqrt, subr1, (SCM z))
   return STk_void; /* never reached */
 }
 
+/*
+<doc R7RS exact-integer-sqrt
+ * (exact-integer-sqrt k)
+ *
+ * Returns two non negatives integers |s| and |r| where
+ * |k=s**2+r| and |k<(s+1)**2|.
+ *
+ * @lisp
+ * (exact-integer-sqrt 4)     => 2 0
+ * (exact-integer-sqrt 5)     => 2 1
+ * @end lisp
+doc>
+*/
+EXTERN_PRIMITIVE("fxsqrt", fxsqrt, subr1, (SCM o));
+DEFINE_PRIMITIVE("exact-integer-sqrt", exact_int_sqrt, subr1, (SCM z))
+{
+  if ( (!(INTP(z) || BIGNUMP(z))) ||
+       negativep(z))
+    STk_error("non negative integer expected. It was: ~s", z);
+
+  if (INTP(z)) return STk_fxsqrt(z);
+
+  mpz_t root;
+  mpz_t rem;
+  mpz_init(root);
+  mpz_init(rem);
+  mpz_sqrtrem(root, rem, BIGNUM_VAL(z));
+  return STk_n_values(2,
+                      bignum2number(root),
+                      bignum2number(rem));
+}
 
 /*
 <doc expt
@@ -4982,6 +5013,7 @@ int STk_init_number(void)
 
   ADD_PRIMITIVE(square);
   ADD_PRIMITIVE(sqrt);
+  ADD_PRIMITIVE(exact_int_sqrt);
   ADD_PRIMITIVE(expt);
 
 

--- a/tests/test-r7rs.stk
+++ b/tests/test-r7rs.stk
@@ -842,6 +842,32 @@
           (exact-integer-sqrt 99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999)
         (cons root rem)))
 
+(test "exact-integer-sqrt.5"
+      '(1234567 654321)
+      (receive (q r) (exact-integer-sqrt 1524156331810) (list q r)))
+
+(test "exact-integer-sqrt.6"
+      '(124 74)
+      (receive (q r) (exact-integer-sqrt 15450) (list q r)))
+
+(test "exact-integer-sqrt.7"
+      '(1073741823 2147483424)
+      (receive (q r) (exact-integer-sqrt 1152921504606846753) (list q r)))
+
+;; exact-integer-sqrt will internally call fxsqrt for fixnums:
+;; Why the loop? Well, it would be nice to test all cases near the edge so
+;; we will be sure no specific numeric strangeness happens. One point to
+;; keep in mind is that this is fairly portable: it will work for different
+;; architectures, with different bit lengths for fixnums (C 'sizeof(long)'
+;; may vary).
+(dotimes (k 1000)
+  (test "exact-integer-sqrt.8"
+        (- (greatest-fixnum) k)
+        (let ((res (receive (q r) (exact-integer-sqrt (- (greatest-fixnum) k)) (list q r))))
+          (let ((q (car res))
+                (r (cadr res)))
+            (+ (* q q) r)))))
+
 ;; -----------------------------------------------------------------
 (test-subsection "6.3 Booleans")
 


### PR DESCRIPTION
```scheme
stklos> (fxsqrt 1152921504606846753)
1073741824
-223
```
Oops...

This was happening because we were not being cautious with the result from libc `sqrt`. It's fixed.
    
While we're at it, why not make `exact-integer-sqrt` use `fxsqrt` when  the argument is a fixnum?

Now `exact-integer-sqrt` is also faster *and* allocates less then it did before, for fixnums:

```scheme
(let
  ((k (- (expt 2 60) 223)))
    (time
      (repeat 5_000_000
        (exact-integer-sqrt k))))
Old code: 2148.563 ms, Allocations: 720000000 bytes
New code: 1387.103 ms, Allocations: 560000000 bytes
```
Timings for bignums ~stayed the same~ (got much better).

Included some new tests.

Fixes #826 