### PR TITLE
[simple] Optimize `repeat`

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -1133,19 +1133,25 @@ doc>
     (if (fixnum? count)
         ;; We can compute the number of loops at compile time and produce
         ;; simpler code. We can also use fx functions.
-        (if (and (= it 1) (positive? count))
-            ;; No loop unrolling
-            `(let ((,c ,count)) ,(%repeat c body #t))
-            ;; Unroll the loop.
-            (let ((valq (quotient count it))
-                  (valr (remainder count it)))
-               `(begin
-                  ,(if (positive? valq) ;; We have a "big" loop
-                      `(let ((,q ,valq)) ,(%repeat q inside #t))
-                      `(void))
-                  ,(if (positive? valr);; we have a "small" loop
-                       `(let ((,r ,valr)) ,(%repeat r body #t))
-                       `(void)))))
+        (cond ((not (positive? count))
+               '(begin (void)))
+              ((= it 1)
+               ;; No loop unrolling
+               `(let ((,c ,count)) ,(%repeat c body #t)))
+              ((<= count it)
+               ;; No iteration structure needed; just repeat the call
+               `(begin ,@(%multiply-list body count) (void)))
+              (else
+               ;; Unroll the loop.
+               (let ((valq (quotient count it))
+                     (valr (remainder count it)))
+                 `(begin
+                    ,(if (positive? valq) ;; We have a "big" loop
+                         `(let ((,q ,valq)) ,(%repeat q inside #t))
+                         `(void))
+                    ,(if (positive? valr);; we have a "small" loop
+                         `(let ((,r ,valr)) ,(%repeat r body #t))
+                         `(void))))))
         ;; count is not a fixnum.  Compute modulo and reminder at runtime
         (if (= it 1)
             ;; No loop unrolling.


### PR DESCRIPTION
Before:
```scheme
(pp (macro-expand '(repeat 3 do-something)))
=> (begin
     (void)
     (let ((G4 3))
       (tagbody
         #:top
         (when (fx> G4 0)
           (set! G4 (fx- G4 1))
           do-something
           (-> #:top)))))
```

Now:
```scheme
(pp (macro-expand '(repeat 3 do-something)))
=> (begin
     do-something
     do-something
     do-something
     (void))
```

The speedup is quite interesting:

```
(time (repeat 100_000_000 (repeat 3 -1)))
Old code: 8415.120 ms
New code:  600.858 ms
```

:smile: 