### PR TITLE
[trivial] `max`/`min`: do not compare complexes

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2010,10 +2010,13 @@ DEFINE_PRIMITIVE("max", max, vsubr, (int argc, SCM *argv))
   int exactp;
 
   if (argc == 0) error_at_least_1();
-  if (argc == 1) {
-    if (STk_realp(*argv) == STk_true) return *argv;
+
+  /* At least one argument; it must be REAL: */
+  if (STk_realp(*argv) == STk_false)
     error_not_a_real_number(*argv);
-  }
+
+  /* Exactly one argument; return it: */
+  if (argc == 1) return *argv;
 
   exactp = isexactp(*argv);
   if (STk_isnan(*argv)) return *argv;
@@ -2041,10 +2044,13 @@ DEFINE_PRIMITIVE("min", min, vsubr, (int argc, SCM *argv))
   int exactp;
 
   if (argc == 0) error_at_least_1();
-  if (argc == 1) {
-    if (STk_realp(*argv) == STk_true) return *argv;
+
+  /* At least one argument; it must be REAL: */
+  if (STk_realp(*argv) == STk_false)
     error_not_a_real_number(*argv);
-  }
+
+  /* Exactly one argument; return it: */
+  if (argc == 1) return *argv;
 
   exactp = isexactp(*argv);
   if (STk_isnan(*argv)) return *argv;

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -2573,6 +2573,10 @@
 (test "nan and min.1" +nan.0 (min 1 2 3.0 4/5 +nan.0))
 (test "nan and min.2" +nan.0 (min +nan.0 1 2 3.0 4/5))
 
+(test/error "max and non-real.1" (max 1.2+0.1i 200))
+(test/error "max and non-real.2" (max 10 1.2+0.1i 200))
+(test/error "min and non-real.1" (min 1.2+0.1i 200))
+(test/error "min and non-real.2" (min 10 1.2+0.1i 200))
 
 (test "abs complex"
       5


### PR DESCRIPTION
The first element was not being checked.

`(max 1+2i 200)`

was being considered "ok". It's fixed now.

Fixes #845 