### PR TITLE
[simple] Optimize away `(not (not` inside `if`...

### DIFF
--- a/lib/comprewrite.stk
+++ b/lib/comprewrite.stk
@@ -99,18 +99,28 @@
  ;; ===> then-expr  (if CONST is #f)
  ;; ===> else-expr  (otherwise)
  (lambda (expr len env)
+   (define (rewrite-cond c)
+     (if (and (pair? c)             ; (
+              (eq? (car c)  'not)   ; (not
+              (pair? (cdr c))       ; (not (...
+              (pair? (cadr c))      ; (not ( OBJ      (cdr not nil)
+              (eq? (caadr c) 'not)) ; (not (not ...
+         (cadadr c)
+         c))
    (if (<= 3 len 4)
-       (let ((Cond (rewrite-expression (cadr expr) env))
-             (Then (caddr expr))
-             (Else (if (null? (cdddr expr))
-                       #void
-                       (cadddr expr))))
-         (if (const-expr? Cond)
-             (if (const-value Cond)
-                 (rewrite-expression Then env)
-                 (rewrite-expression Else env))
-             expr))
-       expr)))
+       (let ((Cond (rewrite-cond (rewrite-expression (cadr expr) env))))
+         (let ((expr (cons (car expr)
+                          (cons Cond (cddr expr)))))
+           (let ((Then (caddr expr))
+                 (Else (if (null? (cdddr expr))
+                           #void
+                           (cadddr expr))))
+             (if (const-expr? Cond)
+                 (if (const-value Cond)
+                     (rewrite-expression Then env)
+                     (rewrite-expression Else env))
+                 expr))
+           expr)))))
 
 
 (compiler:add-rewriter!            ;; 'NOT' rewriter


### PR DESCRIPTION
Before:
```
stklos> (disassemble-expr  '(if (not (not x)) 1 2))

000:  GLOBAL-REF           0
002:  IN-NOT
003:  JUMP-TRUE            3	;; ==> 008
005:  IM-ONE
006:  GOTO                 2	;; ==> 010
008:  SMALL-INT            2
010:
```
Now:
```
stklos> (disassemble-expr  '(if (not (not x)) 1 2))

000:  GLOBAL-REF           0
002:  JUMP-FALSE           3	;; ==> 007
004:  IM-ONE
005:  GOTO                 2	;; ==> 009
007:  SMALL-INT            2
009:
```
Before:
```
stklos> (disassemble-expr '(until (not x) y))

000:  GLOBAL-REF           0
002:  IN-NOT
003:  JUMP-TRUE-V          2	;; ==> 007
005:  GOTO                 -7	;; ==> 000
007:
```
Now:
```
stklos> (disassemble-expr '(until (not x) y))

000:  GLOBAL-REF           0
002:  JUMP-FALSE-V         2	;; ==> 006
004:  GOTO                 -6	;; ==> 000
006:
```

Does this make a difference? YES!

```scheme
(let ((i 0))
  (time
    (until (> i 30_000_000)
      (inc! i))))
Old code: 1809.308 ms
New code:  755.170 ms
```

Passes all tests! :-)

Fixes #849 