### PR TITLE
More precise and faster expt with rational exponents

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -4268,6 +4268,49 @@ static SCM my_expt(SCM x, SCM y)
       return fixnum_exponent_expt(x, INT_VAL(y));
 
     case tc_rational:
+      /* If we have 1/2k in the exponent, we can repeatedly take square roots
+         of x, until the denominator is odd, then we call my_expt again to
+         finish the computation.
+         1. The result will be more precise
+         2. Oh, it's faster! ;)                                              */
+
+      if (RATIONAL_NUM(y) == MAKE_INT(1)) {
+        SCM z = x;
+        /* Denominator is FIXNUM: */
+        if (INTP(RATIONAL_DEN(y)) && power_of_2_p(INT_VAL(RATIONAL_DEN(y)))) {
+          long den = INT_VAL(RATIONAL_DEN(y));
+          while (den % 2 == 0) {
+            z = STk_sqrt(z);
+            den = den / 2;
+          }
+          if (den == 1) return z;
+          else          return my_expt(z, Cmake_rational(MAKE_INT(1), MAKE_INT(den)));
+
+          /* Denominator is a BIGNUM: */
+        } else if (BIGNUMP(RATIONAL_DEN(y)) && mpz_even_p(BIGNUM_VAL(RATIONAL_DEN(y)))) {
+          mpz_t bden;
+          mpz_init(bden);
+          mpz_set(bden, BIGNUM_VAL(RATIONAL_DEN(y)));
+          while (mpz_even_p(bden)) {
+            mpz_sqrt(z, z);
+            mpz_divexact_ui(bden, bden, 2);
+          }
+          if (mpz_cmp_si(bden,1) == 0) return z;
+          else                         return my_expt(z, Cmake_rational(MAKE_INT(1),
+                                                                        bignum2number(bden)));
+        }
+
+        /* x^(a/b), with a < b:
+           First do x^a, then x^(1/b).
+           In some cases, this is more precise than doing the whole thing at
+           once... */
+      } else if (RATIONAL_DEN(y) > RATIONAL_NUM(y))
+        return my_expt(my_expt(x,RATIONAL_NUM(y)),
+                       Cmake_rational(MAKE_INT(1),RATIONAL_DEN(y)));
+
+      /* None of the cases above apply, we treat the number as a real: */
+
+      /* FALLTHROUGH */
     case tc_real:
       if (zerop(y)) /* Treat  special case where y = 0.0 (or -0.0) */
         return double2real(1.0);


### PR DESCRIPTION
@egallesio -- I didn't mark this as "simple", and also didn't ask for inclusion in the next release, because I think it may be a little more complex. But it seems nice (optimizes speed, and gives more precise results)

1. $x^{(a/b)}$, with $a < b$: First do $x^a$, then $x^{(1/b)}$. In some cases, this is more precise than doing the whole thing at once, since we do not lose precision dividing $a/b$ and using `expt` with an inexact exponent.
2. If we have $1/2k$ in the exponent, we can repeatedly take square roots of $x$, until the denominator is odd, then we call `my_expt` again to finish the computation. Becase:
   i)  The result will be more precise
   ii) Oh, it's faster! ;)

```scheme
(time
  (repeat 100_000_000
    (expt 10000000000000000000 3/4)))
Old code: 1083.245 ms
New code:  697.020 ms
```

Also,

```
10000000000000000000^(3/4) is:

177827941003892.28012254211951926848447 (Pari/GP)
177827941003892.28125                   (New code for STklos)
177827941003892.09375                   (Old code for STklos)
```