### PR TITLE
[simple] Fix `acos` for numbers outside [-1, +1]

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3487,11 +3487,15 @@ static SCM my_asin(SCM z)
 
 static inline SCM acos_complex(SCM z)
 {
-  return mul2(Cmake_complex(MAKE_INT(0), MAKE_INT(-1UL)),
-              my_log(add2(z,
-                          mul2(Cmake_complex(MAKE_INT(0), MAKE_INT(1UL)),
-                               STk_sqrt(sub2(MAKE_INT(1UL),
-                                             mul2(z, z)))))));
+  /* acos(z) = -i ln(z + SQRT(z^2-1)).
+     HOWEVER, we may end up with a negative imaginary part, due to the
+     way the computation is done, but it's enough to take the absolute
+     value of the imag part (it will be correct).   */
+  SCM res = mul2(Cmake_complex(MAKE_INT(0), MAKE_INT(-1UL)), /* -i */
+                 my_log(add2(z,
+                             STk_sqrt(add2(mul2(z, z), MAKE_INT(-1UL))))));
+  COMPLEX_IMAG(res) = absolute(COMPLEX_IMAG(res));
+  return res;
 }
 
 static SCM acos_real(double d)


### PR DESCRIPTION
The formula was wrong!

For example, we have as a fact that

$acos(100000000) = 19.113827924512310756561163758933089291i$

And
```scheme
(acos 100000000) => +nan.0+inf.0i          ; before this patch
(acos 100000000) => 0.0+19.1138279245123i  ; with this patch
```