### PR TITLE
[simple] Fix `tanh` for large numbers

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3683,7 +3683,10 @@ static SCM my_tanh(SCM z)
     case tc_integer:  if (INT_VAL(z) == 0) return MAKE_INT(0);
                       return double2real(tanh(INT_VAL(z)));
     case tc_complex:
-    case tc_bignum:
+    case tc_bignum:   if (BIGNUM_FITS_DOUBLE(z))
+                          return double2real(tanh(REAL_VAL(z)));
+                      else
+                          return double2real(1.0); /* Cannot be exact! */
     case tc_rational: {
                         SCM ez = my_exp(z);
                         SCM inv_ez = div2 (MAKE_INT(1), ez);

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -2104,6 +2104,14 @@
          (tanh 2)
          0.9640275801000000))
 
+(test "tanh bignum"
+      1.0
+      (tanh (expt 10 1000)))
+
+(test "tanh inf"
+      1.0
+      (tanh +inf.0))
+
 
 (test "sinh asinh 2"
       #t


### PR DESCRIPTION
Should be infinite for anything larger than the largest flonum...
But:
```scheme
(tanh (expt 10 100000)) => +nan.0
```
Now this is fixed:
```scheme
(tanh (expt 10 100000)) => 1.0
```

This PR depends on #851 