### PR TITLE
[trivial] Don't call `sub2` when not needed

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -695,7 +695,7 @@ static SCM double2rational(double d)
   int_part = double2integer(i);
 
   if (!fraction) {
-    res = negative ? sub2(MAKE_INT(0), int_part) : int_part;
+      res = negative ? double2integer((- i)) : int_part;
   } else {
 
 #ifdef __MINI_GMP_H__


### PR DESCRIPTION
Instead of `sub2(MAKE_INT(0), int_part)`, we can do `double2integer((- i))`.

The code is a tiny bit clearer, and also quite faster:

```scheme
(time
  (repeat 5_000_000
    (exact 12345.678910)
    (exact 99911000.1212121212121212)))
```
Old code: 2171.353 ms
New code: 2042.934 ms