### PR TITLE
[trivial] Optimize `lseq=?`

### DIFF
--- a/lib/scheme/lseq.stk
+++ b/lib/scheme/lseq.stk
@@ -48,7 +48,7 @@
 ;;;;    Creation date: 13-Nov-2020 05:21 (jpellegrini)
 ;;;;
 (define-module scheme/lseq
-  
+
   (export generator->lseq lseq? lseq=?)
   (export lseq-car lseq-first lseq-cdr lseq-rest lseq-ref lseq-take lseq-drop)
   (export lseq-realize lseq->generator lseq-length lseq-append lseq-zip)
@@ -130,10 +130,8 @@
 ;;; Compare lseqs for equality
 (define (lseq=? = lseq1 lseq2)
   (cond
-    ((and (null? lseq1) (null? lseq2))
+    ((eq? lseq1 lseq2)
      #t)
-    ((or (null? lseq1) (null? lseq2))
-     #f)
     ((= (lseq-car lseq1) (lseq-car lseq2))
      (lseq=? = (lseq-cdr lseq1) (lseq-cdr lseq2)))
     (else #f)))


### PR DESCRIPTION
Instead of testing if both sequences are NIL, use eq?

```scheme
(import (scheme lseq))
(import (scheme generator))
(define g (generator->lseq (make-iota-generator 10_000 1)))
(define f (generator->lseq (make-iota-generator 10_000 1)))
(define h f)
(lseq-ref h 20)

(time
  (repeat 1000
    (lseq=? equal? f h)))

Old code: 1899.850 ms
New code:    0.181 ms
```

Realized this after seeing a similar commit in Gauche.

The change is logically equivalent, but results in much faster code. And it's actually suggested by the SRFI text:

> The elt=? procedure must be consistent with eq?. This implies that
> two lseqs which are eq? are always lseq=?, as well; implementations
> may exploit this fact to "short-cut" the element-by-element equality
> tests.