### PR TITLE
[simple] `(expt x bignum)` is zero if -1.0 < `x` < 1.0 and `x` is inexact

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -4218,8 +4218,23 @@ static SCM my_expt(SCM x, SCM y)
 {
   /* y is >= 0 */
   switch (TYPEOF(y)) {
-    case tc_integer:
     case tc_bignum:
+      if (REALP(x)) {
+        double val = REAL_VAL(x);
+        if (val > -1.0 && val < 1.0)               /* (-1, 1) */
+          return double2real(0.0);
+        if (val == 1.0)                            /* 1 */
+          return x;
+        int odd_exp = (number_parity(y) == -1);
+        if (val == -1.0)                           /* -1 */
+          return odd_exp? x : double2real(1.0);
+        if (val < -1.0 && odd_exp)                 /* negative, odd exponent */
+          return double2real(minus_inf);
+        /* negative with even exponent, or positive. */
+        return double2real(plus_inf);
+      }
+      /* FALLTHROUGH */
+    case tc_integer:
 
       if (y == MAKE_INT(0))  /* Treat special case where y = 0 => 1 */
         return MAKE_INT(1);

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1386,6 +1386,49 @@
       -1.0
       (expt -1.0 132897461238946918327469812213123215555532132133763))
 
+(test "expt big exponent.8"
+      -1.0
+      (expt -1.0 132897461238946918327469812213123215555532132133763))
+
+(test "expt big exponent small base.1"
+      0.0
+      (expt 0.99 (expt 2 100)))
+
+(test "expt big exponent small base.2"
+      0.0
+      (expt -0.99 (expt 2 100)))
+
+(test "expt big exponent small base.3"
+      0.0
+      (expt 0.1 (expt 2 100)))
+
+(test "expt big exponent small base.4"
+      0.0
+      (expt -0.1 (expt 2 100)))
+
+(test "expt big exponent small base.5"
+      +inf.0
+      (expt 2.5 (expt 2 100)))
+
+(test "expt big exponent small base.6"
+      +inf.0
+      (expt -2.5 (expt 2 100)))
+
+(test "expt big exponent small base.7"
+      -inf.0
+      (expt -2.5 (1+ (expt 2 100))))
+
+(test "expt big exponent small base.8"
+      +inf.0
+      (expt 2.5 (expt 2 100)))
+
+(test "expt big exponent small base.9"
+      -inf.0
+      (expt -inf.0 (1+ (expt 2 100))))
+
+(test "expt big exponent small base.10"
+      +inf.0
+      (expt +inf.0 (expt 2 100)))
 
 
 ;;------------------------------------------------------------------


### PR DESCRIPTION
(This is a one-liner actually)

STklos previously complained ("exponent too big") when the exponent was a bignum. 

```scheme
stklos> (expt 0.1 (expt 2 70))
**** Error:
expt: exponent too big: '1180591620717411303424'
```
But an inexact number within the range $(-1.0, 1.0)$ would result in something so small that we can consider it to be zero:

```scheme
stklos> (expt 0.1 (expt 2 70))
0.0
```

Similar behavior can be seen in Gauche, Gambit, Chez, Guile, Chibi (they all return positive zero when x is inexact and the exponent is a bignum).



Some tests included.
