### PR TITLE
[test performance issue] Add SRFI 194 - Random Data Generators

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -118,6 +118,7 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-190: Coroutines Generators
     - SRFI-192: Port Positioning
     - SRFI-193: Command line
+    - SRFI-194: Random data generators
     - SRFI-195: Multiple-value boxes
     - SRFI-196: Range Objects
     - SRFI-207: String-notated bytevectors

--- a/lib/srfi/194.stk
+++ b/lib/srfi/194.stk
@@ -1,0 +1,928 @@
+
+(define-library (srfi 194)
+  (import SCHEME
+          ;;(scheme case-lambda)
+          ;;(scheme inexact)
+          ;;(scheme complex)
+          ;;(scheme write)
+          (srfi 27)
+          (srfi 133)
+          (srfi 144)
+          (srfi 158))
+
+    (export
+
+    clamp-real-number
+
+    current-random-source
+    with-random-source
+
+    make-random-integer-generator
+    make-random-u1-generator
+    make-random-u8-generator make-random-s8-generator
+    make-random-u16-generator make-random-s16-generator
+    make-random-u32-generator make-random-s32-generator
+    make-random-u64-generator make-random-s64-generator
+    make-random-boolean-generator
+    make-random-char-generator
+    make-random-string-generator
+    make-random-real-generator
+    make-random-rectangular-generator
+    make-random-polar-generator
+
+    make-bernoulli-generator
+    make-binomial-generator
+    make-categorical-generator
+    make-normal-generator
+    make-exponential-generator
+    make-geometric-generator
+    make-poisson-generator
+    make-zipf-generator
+    make-sphere-generator
+    make-ellipsoid-generator
+    make-ball-generator
+
+    make-random-source-generator
+    gsampling)
+
+  (begin
+;;
+;; Parameters
+;;
+(define current-random-source (make-parameter default-random-source))
+
+(define (with-random-source random-source thunk)
+  (unless (random-source? random-source)
+    (error "expected random source"))
+  (parameterize ((current-random-source random-source))
+    (thunk)))
+
+;;
+;; Carefully return consecutive substreams of the s'th
+;; SRFI 27 stream of random numbers.  See Sections 1.2 and
+;; 1.3 of "An object-oriented random-number package with many
+;; long streams and substreams", by Pierre L'Ecuyer, Richard
+;; Simard, E. Jack Chen, and W. David Kelton, Operations Research,
+;; vol. 50 (2002), pages 1073-1075.
+;; https://doi.org/10.1287/opre.50.6.1073.358
+;;
+
+(define (make-random-source-generator s)
+  (if (not (and (exact? s)
+                (integer? s)
+                (not (negative? s))))
+      (error "make-random-source-generator: Expect nonnegative exact integer argument: " s)
+      (let ((substream 0))
+        (lambda ()
+          (let ((new-source (make-random-source))) ;; deterministic
+            (random-source-pseudo-randomize! new-source s substream)
+            (set! substream (+ substream 1))
+            new-source)))))
+
+;;
+;; Primitive randoms
+;;
+
+(define (make-random-integer-generator low-bound up-bound)
+  (unless (and (integer? low-bound)
+               (exact? low-bound))
+    (error "expected exact integer for lower bound"))
+  (unless (and (integer? up-bound)
+               (exact? up-bound))
+    (error "expected exact integer for upper bound"))
+  (unless (< low-bound up-bound)
+    (error "upper bound should be greater than lower bound"))
+  (let ((rand-int-proc (random-source-make-integers (current-random-source)))
+        (range (- up-bound low-bound)))
+    (lambda ()
+      (+ low-bound (rand-int-proc range)))))
+
+(define (make-random-u1-generator)
+  (make-random-integer-generator 0 2))
+(define (make-random-u8-generator)
+  (make-random-integer-generator 0 256))
+(define (make-random-s8-generator)
+  (make-random-integer-generator -128 128))
+(define (make-random-u16-generator)
+  (make-random-integer-generator 0 65536))
+(define (make-random-s16-generator)
+  (make-random-integer-generator -32768 32768))
+(define (make-random-u32-generator)
+  (make-random-integer-generator 0 (expt 2 32)))
+(define (make-random-s32-generator)
+  (make-random-integer-generator (- (expt 2 31)) (expt 2 31)))
+(define (make-random-u64-generator)
+  (make-random-integer-generator 0 (expt 2 64)))
+(define (make-random-s64-generator)
+  (make-random-integer-generator (- (expt 2 63)) (expt 2 63)))
+
+(define (clamp-real-number lower-bound upper-bound value)
+  (cond ((not (real? lower-bound))
+         (error "expected real number for lower bound"))
+        ((not (real? upper-bound))
+         (error "expected real number for upper bound"))
+        ((not (<= lower-bound upper-bound))
+         (error "lower bound must be <= upper bound"))
+        ((< value lower-bound) lower-bound)
+        ((> value upper-bound) upper-bound)
+        (else value)))
+
+(define (make-random-real-generator low-bound up-bound)
+  (unless (and (real? low-bound)
+               (finite? low-bound))
+    (error "expected finite real number for lower bound"))
+  (unless (and (real? up-bound)
+               (finite? up-bound))
+     (error "expected finite real number for upper bound"))
+  (unless (< low-bound up-bound)
+     (error "lower bound must be < upper bound"))
+  (let ((rand-real-proc (random-source-make-reals (current-random-source))))
+   (lambda ()
+     (define t (rand-real-proc))
+     ;; alternative way of doing lowbound + t * (up-bound - low-bound)
+     ;; is susceptible to rounding errors and would require clamping to be safe
+     ;; (which in turn requires 144 for adjacent float function)
+     (+ (* t low-bound)
+        (* (- 1.0 t) up-bound)))))
+
+(define (make-random-rectangular-generator
+          real-lower-bound real-upper-bound
+          imag-lower-bound imag-upper-bound)
+  (let ((real-gen (make-random-real-generator real-lower-bound real-upper-bound))
+        (imag-gen (make-random-real-generator imag-lower-bound imag-upper-bound)))
+    (lambda ()
+      (make-rectangular (real-gen) (imag-gen)))))
+
+(define make-random-polar-generator
+  (case-lambda
+    ((magnitude-lower-bound magnitude-upper-bound)
+     (make-random-polar-generator 0+0i magnitude-lower-bound magnitude-upper-bound 0 (* 2 PI)))
+    ((origin magnitude-lower-bound magnitude-upper-bound)
+     (make-random-polar-generator origin magnitude-lower-bound magnitude-upper-bound 0 (* 2 PI)))
+    ((magnitude-lower-bound magnitude-upper-bound angle-lower-bound angle-upper-bound)
+     (make-random-polar-generator 0+0i magnitude-lower-bound magnitude-upper-bound angle-lower-bound angle-upper-bound))
+    ((origin magnitude-lower-bound magnitude-upper-bound angle-lower-bound angle-upper-bound)
+     (unless (complex? origin)
+       (error "origin should be complex number"))
+     (unless (and (real? magnitude-lower-bound)
+                  (real? magnitude-upper-bound)
+                  (real? angle-lower-bound)
+                  (real? angle-upper-bound))
+       (error "magnitude and angle bounds should be real numbers"))
+     (unless (and (<= 0 magnitude-lower-bound)
+                  (<= 0 magnitude-upper-bound))
+       (error "magnitude bounds should be positive"))
+     (unless (< magnitude-lower-bound magnitude-upper-bound)
+       (error "magnitude lower bound should be less than upper bound"))
+     (when (= angle-lower-bound angle-upper-bound)
+       (error "angle bounds shouldn't be equal"))
+     (let* ((b (square magnitude-lower-bound))
+            (m (- (square magnitude-upper-bound) b))
+            (t-gen (make-random-real-generator 0. 1.))
+            (phi-gen (make-random-real-generator angle-lower-bound angle-upper-bound)))
+       (lambda ()
+         (let* ((t (t-gen))
+                (phi (phi-gen))
+                (r (sqrt (+ (* m t) b))))
+          (+ origin (make-polar r phi))))))))
+
+(define (make-random-boolean-generator)
+  (define u1 (make-random-u1-generator))
+  (lambda ()
+    (zero? (u1))))
+
+(define (make-random-char-generator str)
+  (when (not (string? str))
+    (error "expected string"))
+  (unless (> (string-length str) 0)
+    (error "given string is of length 0"))
+  (let* ((int-gen (make-random-integer-generator 0 (string-length str))))
+   (lambda ()
+     (string-ref str (int-gen)))))
+
+(define (make-random-string-generator k str)
+  (let ((char-gen (make-random-char-generator str))
+        (int-gen (make-random-integer-generator 0 k)))
+    (lambda ()
+      (generator->string char-gen (int-gen)))))
+
+;;
+;; Non-uniform distributions
+;;
+
+(define PI (* 4 (atan 1.0)))
+
+(define (make-bernoulli-generator p)
+  (unless (real? p)
+    (error "expected p to be real"))
+  (unless (<= 0 p 1)
+    (error "expected 0 <= p <= 1"))
+  (let ((rand-real-proc (random-source-make-reals (current-random-source))))
+   (lambda ()
+     (if (<= (rand-real-proc) p)
+         1
+         0))))
+
+(define (make-categorical-generator weights-vec)
+  (define weight-sum
+    (vector-fold
+      (lambda (sum p)
+        (unless (and (number? p)
+                     (> p 0))
+          (error "parameter must be a vector of positive numbers"))
+        (+ sum p))
+      0
+      weights-vec))
+  (define length (vector-length weights-vec))
+  (let ((real-gen (make-random-real-generator 0 weight-sum)))
+   (lambda ()
+     (define roll (real-gen))
+     (let it ((sum 0)
+              (i 0))
+       (define newsum (+ sum (vector-ref weights-vec i)))
+       (if (or (< roll newsum)
+               ;; in case of rounding errors and no matches, return last element
+               (= i (- length 1)))
+           i
+           (it newsum
+               (+ i 1)))))))
+
+;; Normal distribution (continuous - generates real numbers)
+;; Box-Muller algorithm
+;; NB: We tested Ziggurat method, too,
+;; only to find out Box-Muller is faster about 12% - presumably
+;; the overhead of each ops is larger in Gauche than C/C++, and
+;; so the difference of cost of log or sin from the primitive
+;; addition/multiplication are negligible.
+
+;; NOTE: this implementation is not thread safe
+(define make-normal-generator
+  (case-lambda
+    (()
+     (make-normal-generator 0.0 1.0))
+    ((mean)
+     (make-normal-generator mean 1.0))
+    ((mean deviation)
+     (let ((rand-real-proc (random-source-make-reals (current-random-source)))
+           (state #f))
+       (unless (and (real? mean)
+                    (finite? mean))
+         (error "expected mean to be finite real number"))
+       (unless (and (real? deviation)
+                    (finite? deviation)
+                    (> deviation 0))
+         (error "expected deviation to be positive finite real number"))
+       (lambda ()
+         (if state
+             (let ((result state))
+              (set! state #f)
+              result)
+             (let* ((r (sqrt (* -2 (log (rand-real-proc)))))
+                    (theta (* 2 PI (rand-real-proc))))
+               (set! state (+ mean (* deviation r (cos theta))))
+               (+ mean (* deviation r (sin theta))))))))))
+
+(define (make-exponential-generator mean)
+  (unless (and (real? mean)
+               (finite? mean)
+               (positive? mean))
+    (error "expected mean to be finite positive real number"))
+  (let ((rand-real-proc (random-source-make-reals (current-random-source))))
+   (lambda ()
+     (- (* mean (log (rand-real-proc)))))))
+
+(define (make-geometric-generator p)
+
+  (define log1p fllog1+) ;; usinf SRFI-144, faster
+  ;;(define (log1p x)
+    ;; Adapted from SRFI 144
+    ;; (let ((u (+ 1.0 x)))
+    ;;   (cond ((= u 1.0)
+    ;;          x) ;; gets sign of zero result correct
+    ;;         ((= u x)
+    ;;          (log u)) ;; large arguments and infinities
+    ;;         (else
+    ;;          (* (log u) (/ x (- u 1.0)))))))
+
+  (unless (and (real? p)
+               (> p 0)
+               (<= p 1))
+          (error "expected p to be real number, 0 < p <= 1"))
+  (if (zero? (- p 1.))
+      ;; p is indistinguishable from 1.
+      (lambda () 1)
+      (let ((c (/ (log1p (- p))))
+            (rand-real-proc (random-source-make-reals (current-random-source))))
+        (lambda ()
+          (exact (ceiling (* c (log (rand-real-proc)))))))))
+
+;; Draw from poisson distribution with mean L, variance L.
+;; For small L, we use Knuth's method.  For larger L, we use rejection
+;; method by Atkinson, The Computer Generation of Poisson Random Variables,
+;; J. of the Royal Statistical Society Series C (Applied Statistics), 28(1),
+;; pp29-35, 1979.  The code here is a port by John D Cook's C++ implementation
+;; (http://www.johndcook.com/stand_alone_code.html )
+
+;; NOTE: this implementation calculates and stores a table of log(n!) on first invocation of L >= 36
+;; and therefore is not entirely thread safe (should still produce correct result, but with performance hit if table
+;; is recalculated multiple times)
+(define (make-poisson-generator L)
+  (unless (and (real? L)
+               (finite? L)
+               (> L 0))
+    (error "expected L to be finite positive real number"))
+  (let ((rand-real-proc (random-source-make-reals (current-random-source))))
+   (if (< L 30)
+       (make-poisson/small rand-real-proc L)
+       (make-poisson/large rand-real-proc L))))
+
+;; private
+(define (make-poisson/small rand-real-proc L)
+  (lambda ()
+    (do ((exp-L (exp (- L)))
+         (k 0 (+ k 1))
+         (p 1.0 (* p (rand-real-proc))))
+        ((<= p exp-L) (- k 1)))))
+
+;; private
+(define (make-poisson/large rand-real-proc L)
+  (let* ((c (- 0.767 (/ 3.36 L)))
+         (beta (/ PI (sqrt (* 3 L))))
+         (alpha (* beta L))
+         (k (- (log c) L (log beta))))
+    (define (loop)
+      (let* ((u (rand-real-proc))
+             (x (/ (- alpha (log (/ (- 1.0 u) u))) beta))
+             (n (exact (floor (+ x 0.5)))))
+        (if (< n 0)
+            (loop)
+            (let* ((v (rand-real-proc))
+                   (y (- alpha (* beta x)))
+                   (t (+ 1.0 (exp y)))
+                   (lhs (+ y (log (/ v (* t t)))))
+                   (rhs (+ k (* n (log L)) (- (log-of-fact n)))))
+              (if (<= lhs rhs)
+                  n
+                  (loop))))))
+    loop))
+
+;; private
+;; log(n!) table for n 1 to 256. Vector, where nth index corresponds to log((n+1)!)
+;; Computed on first invocation of `log-of-fact`
+(define log-fact-table #f)
+
+;; private
+;; computes log-fact-table
+;; log(n!) = log((n-1)!) + log(n)
+(define (make-log-fact-table!)
+  (define table (make-vector 256))
+  (vector-set! table 0 0)
+  (do ((i 1 (+ i 1)))
+      ((> i 255) #t)
+      (vector-set! table i (+ (vector-ref table (- i 1))
+                              (log (+ i 1)))))
+  (set! log-fact-table table))
+
+;; private
+;; returns log(n!)
+;; adapted from https://www.johndcook.com/blog/2010/08/16/how-to-compute-log-factorial/
+(define (log-of-fact n)
+  (when (not log-fact-table)
+    (make-log-fact-table!))
+  (cond
+    ((<= n 1) 0)
+    ((<= n 256) (vector-ref log-fact-table (- n 1)))
+    (else (let ((x (+ n 1)))
+           (+ (* (- x 0.5)
+                 (log x))
+              (- x)
+              (* 0.5
+                 (log (* 2 PI)))
+              (/ 1.0 (* x 12.0)))))))
+
+
+
+(define (gsampling . generators-lst)
+  (let ((gen-vec (list->vector generators-lst))
+        (rand-int-proc (random-source-make-integers (current-random-source))))
+
+    ;remove exhausted generator at index
+    (define (remove-gen index)
+      (define new-vec (make-vector (- (vector-length gen-vec) 1)))
+      ;when removing anything but first, copy all elements before index
+      (when (> index 0)
+        (vector-copy! new-vec 0 gen-vec 0 index))
+      ;when removing anything but last, copy all elements after index
+      (when (< index (- (vector-length gen-vec) 1))
+        (vector-copy! new-vec index gen-vec (+ 1 index)))
+      (set! gen-vec new-vec))
+
+    ;randomly pick generator. If it's exhausted remove it, and pick again
+    ;returns value (or eof, if all generators are exhausted)
+    (define (pick)
+      (let* ((index (rand-int-proc (vector-length gen-vec)))
+             (gen (vector-ref gen-vec index))
+             (value (gen)))
+        (if (eof-object? value)
+            (begin
+              (remove-gen index)
+              (if (= (vector-length gen-vec) 0)
+                  (eof-object)
+                  (pick)))
+            value)))
+
+    (lambda ()
+      (if (= 0 (vector-length gen-vec))
+          (eof-object)
+          (pick)))))
+
+
+;;; Code for binomial random variable generation.
+;;; Written by Brad Lucier, lucier@math.purdue.edu
+
+;;; binomial-geometric is somewhat classical, the
+;;; "First waiting time algorithm" from page 525 of
+;;; Devroye, L. (1986), Non-Uniform Random Variate
+;;; Generation, Springer-Verlag, New York.
+
+;;; binomial-rejection is algorithm BTRS from
+;;; Hormann, W. (1993), The generation of binomial
+;;; random variates, Journal of Statistical Computation
+;;; and Simulation, 46:1-2, 101-110,
+;;; DOI: https://doi.org/10.1080/00949659308811496
+;;; stirling-tail and BTRD (mentioned in the comments)
+;;; are also from that paper.
+
+;;; Another implementation of the same algorithm is at
+;;; https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/random_binomial_op.cc
+;;; That implementation pointed out at least two bugs in the
+;;; BTRS paper.
+
+(define (stirling-tail k)
+  ;; Computes
+  ;;
+  ;; \log(k!)-[\log(\sqrt{2\pi})+(k+\frac12)\log(k+1)-(k+1)]
+  ;;
+  (let ((small-k-table
+         ;; Computed using computable reals package
+         ;; Matches values in paper, which are given
+         ;; for 0\leq k < 10
+         '#(.08106146679532726
+            .0413406959554093
+            .02767792568499834
+            .020790672103765093
+            .016644691189821193
+            .013876128823070748
+            .01189670994589177
+            .010411265261972096
+            .009255462182712733
+            .00833056343336287
+            .007573675487951841
+            .00694284010720953
+            .006408994188004207
+            .0059513701127588475
+            .005554733551962801
+            .0052076559196096404
+            .004901395948434738
+            .004629153749334028
+            .004385560249232324
+            .004166319691996922)))
+    (if (< k 20)
+        (vector-ref small-k-table k)
+        ;; the correction term (+ (/ (* 12 (+ k 1))) ...)
+        ;; in Stirling's approximation to log(k!)
+        (let* ((inexact-k+1 (inexact (+ k 1)))
+               (inexact-k+1^2 (square inexact-k+1)))
+          (/ (- #i1/12
+                (/ (- #i1/360
+                      (/ #i1/1260 inexact-k+1^2))
+                   inexact-k+1^2))
+             inexact-k+1)))))
+
+(define (make-binomial-generator n p)
+  (if (not (and (real? p)
+                (<= 0 p 1)
+                (exact-integer? n)
+                (positive? n)))
+       (error "make-binomial-generator: Bad parameters: " n p)
+       (cond ((< 1/2 p)
+              (let ((complement (make-binomial-generator n (- 1 p))))
+                (lambda ()
+                  (- n (complement)))))
+             ((zero? p)
+              (lambda () 0))
+             ((< (* n p) 10)
+              (binomial-geometric n p))
+             (else
+              (binomial-rejection n p)))))
+
+(define (binomial-geometric n p)
+  (let ((geom (make-geometric-generator p)))
+    (lambda ()
+      (let loop ((X -1)
+                 (sum 0))
+        (if (< n sum)
+            X
+            (loop (+ X 1)
+                  (+ sum (geom))))))))
+
+(define (binomial-rejection n p)
+  ;; call when p <= 1/2 and np >= 10
+  ;; Use notation from the paper
+  (let* ((spq
+          (inexact (sqrt (* n p (- 1 p)))))
+         (b
+          (+ 1.15 (* 2.53 spq)))
+         (a
+          (+ -0.0873
+             (* 0.0248 b)
+             (* 0.01 p)))
+         (c
+          (+ (* n p) 0.5))
+         (v_r
+          (- 0.92
+             (/ 4.2 b)))
+         (alpha
+          ;; The formula in BTRS has 1.5 instead of 5.1;
+          ;; The formula for alpha in algorithm BTRD and Table 1
+          ;; and the tensorflow code uses 5.1, so we use 5.1
+          (* (+ 2.83 (/ 5.1 b)) spq))
+         (lpq
+          (log (/ p (- 1 p))))
+         (m
+          (exact (floor (* (+ n 1) p))))
+         (rand-real-proc
+          (random-source-make-reals (current-random-source))))
+    (lambda ()
+      (let loop ()
+        (let* ((u (rand-real-proc))
+               (v (rand-real-proc))
+               (u
+                (- u 0.5))
+               (us
+                (- 0.5 (abs u)))
+               (k
+                (exact
+                 (floor
+                  (+ (* (+ (* 2. (/ a us)) b) u) c)))))
+          (cond ((or (< k 0)
+                     (< n k))
+                 (loop))
+                ((and (<= 0.07 us)
+                      (<= v v_r))
+                 k)
+                (else
+                 (let ((v
+                        ;; The tensorflow code notes that BTRS doesn't have
+                        ;; this logarithm; BTRS is incorrect (see BTRD, step 3.2)
+                        (log (* v (/ alpha
+                                     (+ (/ a (square us)) b))))))
+                   (if (<=  v
+                            (+ (* (+ m 0.5)
+                                  (log (* (/ (+ m 1.)
+                                             (- n m -1.)))))
+                               (* (+ n 1.)
+                                  (log (/ (- n m -1.)
+                                          (- n k -1.))))
+                               (* (+ k 0.5)
+                                  (log (* (/ (- n k -1.)
+                                             (+ k 1.)))))
+                               (* (- k m) lpq)
+                               (- (+ (stirling-tail m)
+                                     (stirling-tail (- n m)))
+                                  (+ (stirling-tail k)
+                                     (stirling-tail (- n k))))))
+                       k
+                       (loop))))))))))
+
+; SPDX-FileCopyrightText: 2020 Arvydas Silanskas
+; SPDX-License-Identifier: MIT
+;
+; zipf-zri.scm
+; Create a Zipf random distribution.
+;
+; Created by Linas Vepstas 10 July 2020
+; Nominated for inclusion in srfi-194
+;
+; Not optimized for speed!
+;
+; Implementation from ZRI algorithm presented in the paper:
+; "Rejection-inversion to generate variates from monotone discrete
+; distributions", Wolfgang Hörmann and Gerhard Derflinger
+; ACM TOMACS 6.3 (1996): 169-184
+;
+; Hörmann and Derflinger use "q" everywhere, when they really mean "s".
+; Thier "q" is not the standard q-series deformation. Its just "s".
+; The notation in the code below differs from the article to reflect
+; conventional usage.
+;
+;------------------------------------------------------------------
+;
+; The Hurwicz zeta distribution 1 / (k+q)^s for 1 <= k <= n integer
+; The Zipf distribution is recovered by setting q=0.
+;
+; The exponent `s` must be a real number not equal to 1.
+; Accuracy is diminished for |1-s|< 1e-6. The accuracy is roughly
+; equal to 1e-15 / |1-s| where 1e-15 == 64-bit double-precision ULP.
+;
+(define (make-zipf-generator/zri n s q)
+
+  ; The hat function h(x) = 1 / (x+q)^s
+  (define (hat x)
+    (expt (+ x q) (- s)))
+
+  (define _1-s (- 1 s))
+  (define oms (/ 1 _1-s))
+
+  ; The integral of hat(x)
+  ; H(x) = (x+q)^{1-s} / (1-s)
+  ; Note that H(x) is always negative.
+  (define (big-h x)
+    (/ (expt (+ q x) _1-s) _1-s))
+
+  ; The inverse function of H(x)
+  ; H^{-1}(y) = -q + (y(1-s))^{1/(1-s)}
+  (define (big-h-inv y)
+    (- (expt (* y _1-s) oms) q))
+
+  ; Lower and upper bounds for the uniform random generator.
+  (define big-h-half (- (big-h 1.5) (hat 1)))
+  (define big-h-n (big-h (+ n 0.5)))
+
+  ; Rejection cut
+  (define cut (- 1 (big-h-inv (- (big-h 1.5) (hat 1)))))
+
+  ; Uniform distribution
+  (define dist (make-random-real-generator big-h-half big-h-n))
+
+  ; Attempt to hit the dartboard. Return #f if we fail,
+  ; otherwise return an integer between 1 and n.
+  (define (try)
+    (define u (dist))
+    (define x (big-h-inv u))
+    (define kflt (floor (+ x 0.5)))
+    (define k (exact kflt))
+    (if (and (< 0 k)
+             (or
+               (<= (- k x) cut)
+               (>= u (- (big-h (+ k 0.5)) (hat k))))) k #f))
+
+  ; Did we hit the dartboard? If not, try again.
+  (define (loop-until)
+    (define k (try))
+    (if k k (loop-until)))
+
+  ; Return the generator.
+  loop-until)
+
+;------------------------------------------------------------------
+;
+; The Hurwicz zeta distribution 1 / (k+q)^s for 1 <= k <= n integer
+; The Zipf distribution is recovered by setting q=0.
+;
+; The exponent `s` must be a real number close to 1.
+; Accuracy is diminished for |1-s|> 2e-4. The accuracy is roughly
+; equal to 0.05 * |1-s|^4 due to exp(1-s) being expanded to 4 terms.
+;
+; This handles the special case of s==1 perfectly.
+(define (make-zipf-generator/one n s q)
+
+  (define _1-s (- 1 s))
+
+  ; The hat function h(x) = 1 / (x+q)^s
+  ; Written for s->1 i.e. 1/(x+q)(x+q)^{s-1}
+  (define (hat x)
+    (define xpq (+ x q))
+    (/ (expt xpq _1-s) xpq))
+
+  ; Expansion of exn(y) = [exp(y(1-s))-1]/(1-s) for s->1
+  ; Expanded to 4th order.
+  ; Should equal this:
+  ;;; (define (exn lg) (/ (- (exp (* _1-s lg)) 1) _1-s))
+  ; but more accurate for s near 1.0
+  (define (exn lg)
+    (define (trm n u lg) (* lg (+ 1 (/ (* _1-s u) n))))
+    (trm 2 (trm 3 (trm 4 1 lg) lg) lg))
+
+  ; Expansion of lg(y) = [log(1 + y(1-s))] / (1-s) for s->1
+  ; Expanded to 4th order.
+  ; Should equal this:
+  ;;; (define (lg y) (/ (log (+ 1 (* y _1-s))) _1-s))
+  ; but more accurate for s near 1.0
+  (define (lg y)
+    (define yms (* y _1-s))
+    (define (trm n u r) (- (/ 1 n) (* u r)))
+    (* y (trm 1 yms (trm 2 yms (trm 3 yms (trm 4 yms 0))))))
+
+  ; The integral of hat(x) defined at s==1
+  ; H(x) = [exp{(1-s) log(x+q)} - 1]/(1-s)
+  ; Should equal this:
+  ;;;  (define (big-h x) (/ (- (exp (* _1-s (log (+ q x)))) 1)  _1-s))
+  ; but expanded so that it's more accurate for s near 1.0
+  (define (big-h x)
+    (exn (log (+ q x))))
+
+  ; The inverse function of H(x)
+  ; H^{-1}(y) = -q + (1 + y(1-s))^{1/(1-s)}
+  ; Should equal this:
+  ;;; (define (big-h-inv y) (- (expt (+ 1 (* y _1-s)) (/ 1 _1-s)) q ))
+  ; but expanded so that it's more accurate for s near 1.0
+  (define (big-h-inv y)
+    (- (exp (lg y)) q))
+
+  ; Lower and upper bounds for the uniform random generator.
+  (define big-h-half (- (big-h 1.5) (hat 1)))
+
+  (define big-h-n (big-h (+ n 0.5)))
+
+  ; Rejection cut
+  (define cut (- 1 (big-h-inv (- (big-h 1.5) (/ 1 (+ 1 q))))))
+
+  ; Uniform distribution
+  (define dist (make-random-real-generator big-h-half big-h-n))
+
+  ; Attempt to hit the dartboard. Return #f if we fail,
+  ; otherwise return an integer between 1 and n.
+  (define (try)
+    (define u (dist))
+    (define x (big-h-inv u))
+    (define kflt (floor (+ x 0.5)))
+    (define k (exact kflt))
+    (if (and (< 0 k)
+             (or
+               (<= (- k x) cut)
+               (>= u (- (big-h (+ k 0.5)) (hat k))))) k #f))
+
+  ; Did we hit the dartboard? If not, try again.
+  (define (loop-until)
+    (define k (try))
+    (if k k (loop-until)))
+
+  ; Return the generator.
+  loop-until)
+
+;------------------------------------------------------------------
+;
+; (make-zipf-generator n [s [q]])
+;
+; The Hurwicz zeta distribution 1 / (k+q)^s for 1 <= k <= n integer
+; The Zipf distribution is recovered by setting q=0.
+; If `q` is not specified, 0 is assumed.
+; If `s` is not specified, 1 is assumed.
+;
+; Valid for real -10 < s < 100 (otherwise overflows likely)
+; Valid for real -0.5 < q < 2e8 (otherwise overflows likely)
+; Valid for integer 1 <= k < int-max
+;
+; Example usage:
+;    (define zgen (make-zipf-generator 50 1.01 0))
+;    (generator->list zgen 10)
+;
+(define make-zipf-generator
+  (case-lambda
+    ((n)
+     (make-zipf-generator n 1.0 0.0))
+    ((n s)
+     (make-zipf-generator n s 0.0))
+    ((n s q)
+     (if (< 1e-5 (abs (- 1 s)))
+         (make-zipf-generator/zri n s q)
+         (make-zipf-generator/one n s q)))))
+
+
+;;; SPDX-FileCopyrightText: 2020 Arvydas Silanskas
+;;; SPDX-FileCopyrightText: 2020 Linas Vepštas
+;;; SPDX-FileCopyrightText: 2024 Bradley J Lucier
+;;; SPDX-License-Identifier: MIT
+;;;
+;;; sphere.scm
+;;; Uniform distributions on a sphere, and a ball.
+;;; Submitted for inclusion in srfi-194
+;;;
+;;; Algorithm based on BoxMeuller as described in
+;;; http://extremelearning.com.au/how-to-generate-uniformly-random-points-on-n-spheres-and-n-balls/
+;;;
+;;; make-sphere-generator N - return a generator of points uniformly
+;;; distributed on an N-dimensional sphere.
+;;; This implements the BoxMeuller algorithm, that is, of normalizing
+;;; N+1 Gaussian random variables.
+
+(define (make-sphere-generator arg)
+  (cond
+   ((and (integer? arg)
+         (exact? arg)
+         (positive? arg))
+    (make-ellipsoid-generator* (make-vector (+ 1 arg) 1.0)))
+   (else
+    (error "make-sphere-generator: The argument must be a positive exact integer: " arg))))
+
+(define (make-ellipsoid-generator arg)
+
+  (define (return-error)
+    (error "make-ellipsoid-generator: The argument must be a vector of real numbers that are finite and positive when converted to inexact: " arg))
+
+  (if (and (vector? arg)
+           (vector-every real? arg))
+      (let ((inexact-arg (vector-map inexact arg)))
+        (if (vector-every (lambda (x)
+                            (and (positive? x) (finite? x)))
+                          inexact-arg)
+            (make-ellipsoid-generator* inexact-arg)
+            (return-error)))
+      (return-error)))
+
+;;; -----------------------------------------------
+;;; Generator of points uniformly distributed on an N-dimensional ellipsoid.
+;;;
+;;; The `axes` should be a vector of floats, specifying the axes of the
+;;; ellipsoid. The algorithm used is an accept/reject sampling algo,
+;;; wherein the acceptance rate is proportional to the measure of a
+;;; surface element on the ellipsoid. The measure is straight-forward to
+;;; arrive at, and the 3D case is described by `mercio` in detail at
+;;; https://math.stackexchange.com/questions/973101/how-to-generate-points-uniformly-distributed-on-the-surface-of-an-ellipsoid
+;;;
+;;; Note that sampling means that complexity goes as
+;;; O(B/A x C/A x D/A x ...) where `A` is the shorest axis,
+;;; and `B`, `C`, `D`, ... are the other axes. Maximum performance
+;;; is achieved on spheres, which is the case used in make-ball-generator
+
+(define (make-ellipsoid-generator* axes)
+  (let ((gauss (make-normal-generator))
+        (uniform (make-random-real-generator 0. 1.)) ;; should really be from a separate stream
+        (min-axis (vector-fold min +inf.0 axes)))
+
+    (define (sphere)
+      (let* ((point
+              (vector-map (lambda (_) (gauss)) axes))
+             (norm-inverse
+              (/ (sqrt (vector-fold (lambda (sum x)
+                                      (+ sum (square x)))
+                                    0.
+                                    point)))))
+        (vector-map (lambda (x) (* x norm-inverse)) point)))
+
+    (define (ellipsoid-distance ray)
+      (sqrt (vector-fold
+             (lambda (sum x a) (+ sum (square (/ x a))))
+             0. ray axes)))
+
+    (define (keep point)
+      (< (uniform)
+         (* min-axis (ellipsoid-distance point))))
+
+    (define (sample)
+      (let ((point (sphere)))
+        (if (keep point)
+            point
+            (sample))))
+
+    (lambda ()
+      (vector-map * (sample) axes))))
+
+
+
+;;;-----------------------------------------------
+;;; make-ball-generator N - return a generator of points
+;;; inside an N-dimensional ball.  It's based on the algorithm in
+;;;
+;;; An Efficient Method for Generating Points
+;;; Uniformly Distributed in Hyperellipsoids
+;;; Jean Dezert and Christian Musso
+;;; https://www.onera.fr/sites/default/files/297/C013_-_Dezert_-_YBSTributeMonterey2001.pdf
+;;;
+;;; which in turn is based on the Harman-Lacko-Voelker Dropped Coordinate method for
+;;; generating points uniformly inside the unit ball in N dimensions.
+
+(define (make-ball-generator arg)
+
+  (define (return-error)
+    (error "make-ball-generator: The argument must be either an exact, positive, integer or a vector of real numbers that are positive and finite when converted to inexact: " arg))
+
+  (if (and (integer? arg)
+           (exact? arg)
+           (positive? arg))
+      (make-ball-generator* (make-vector arg 1.0))
+      (if (and (vector? arg)
+               (vector-every real? arg))
+          (let ((inexact-arg (vector-map inexact arg)))
+            (if (vector-every (lambda (x)
+                                (and (positive? x)
+                                     (finite? x)))
+                              inexact-arg)
+                (make-ball-generator* inexact-arg)
+                (return-error)))
+          (return-error))))
+
+(define (make-ball-generator* axes)
+  (let* ((sphere-generator
+          ;; returns vectors with (vector-length axes) + 2 elements
+          (make-sphere-generator (+ (vector-length axes) 1))))
+    (lambda ()
+      ;; returns vectors with (vector-length axes) elements
+      (vector-map (lambda (el axis)
+                    (* el axis))
+                  (sphere-generator)
+                  axes))))
+))
+
+(provide "srfi/194")

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -124,6 +124,7 @@ SRC_STK   = 1.stk   \
             189.stk \
             190.stk \
             193.stk \
+            194.stk \
             195.stk \
             196.stk \
             207.stk \
@@ -244,6 +245,7 @@ SRC_OSTK =  1.ostk   \
             189.ostk \
             190.ostk \
             193.ostk \
+            194.ostk \
             195.ostk \
             196.ostk \
             207.ostk \
@@ -341,6 +343,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 171.ostk: 1.ostk 69.ostk
 189.ostk: 1.ostk
 190.ostk: 158.ostk
+194.ostk: 27.ostk 27.$(SO) 133.ostk 158.ostk ../scheme/flonum.$(SO)
 195.ostk: 35.ostk
 196.ostk: 1.ostk
 207.ostk: 1.ostk 13.ostk 151.ostk 158.ostk

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -232,7 +232,7 @@
     ;;191  ....... withdrawn
     (192 "Port Positioning")
     (193 "Command line")
-    ;; 194 Random data generators
+    (194 "Random data generators" () "srfi-194")
     (195 "Multiple-value boxes")
     (196 "Range Objects" () "srfi-196")
     ;; 197  Pipeline Operators

--- a/tests/srfis/194.stk
+++ b/tests/srfis/194.stk
@@ -1,0 +1,564 @@
+
+(import (srfi 158))
+
+(define-syntax test-approximate
+             (syntax-rules ()
+               ((_ target value max-delta)
+                (test "srfi-194" #t (and (<= value (+ target max-delta))
+                                         (>= value (- target max-delta)))))))
+
+;; ;;; syntax just we can plop it at top and still allow internal `define`s
+;; (define-syntax reset-source!
+;;   (syntax-rules ()
+;;     ((_)
+;;      (define _ (random-source-pseudo-randomize! (current-random-source) 0 0)))))
+
+(define (reset-source!)  (random-source-pseudo-randomize! (current-random-source) 0 0))
+
+(define (reset-source!*)
+  (random-source-pseudo-randomize! (current-random-source) 0 0))
+
+(define (assert-number-generator/all-in-range gen from to)
+  (test "srfi-194" #t
+    (generator-every
+      (lambda (num)
+        (and (>= num from)
+             (< num to)))
+      (gtake gen 1000))))
+
+(define (assert-number-generator gen from to)
+  (define range (- to from))
+  (define lower-quarter (+ from (* 0.25 range)))
+  (define upper-quarter (- to (* 0.25 range)))
+  (assert-number-generator/all-in-range gen from to)
+
+  (test "srfi-194" #t
+    (generator-any
+      (lambda (num)
+        (and (>= num from)
+             (< num lower-quarter)))
+      (gtake gen 1000)))
+
+  (test "srfi-194" #t
+    (generator-any
+      (lambda (num)
+        (and (>= num lower-quarter)
+             (< num upper-quarter)))
+      (gtake gen 1000)))
+
+  (test "srfi-194" #t
+    (generator-any
+      (lambda (num)
+        (and (>= num upper-quarter)
+             (< num to)))
+      (gtake gen 1000))))
+
+(define (assert-int-generator gen byte-size signed?)
+  (define from (if signed?
+                   (- (expt 2 (- byte-size 1)))
+                   0))
+  (define to (if signed?
+                 (expt 2 (- byte-size 1))
+                 (expt 2 byte-size)))
+  (assert-number-generator gen from to))
+
+(test-subsection "Test clamp real number")
+            (reset-source!)
+            (test "srfi-194" 10.0 (clamp-real-number 5.0 10.0 11))
+            (test "srfi-194" 5.0 (clamp-real-number 5.0 10.0 2.0))
+            (test "srfi-194" 7.5 (clamp-real-number 5.0 10.0 7.5))
+
+(test-subsection "Test with-random-source basic syntax")
+            (reset-source!)
+            (test "" #t (closure? (with-random-source default-random-source
+                                                      (lambda () (make-random-integer-generator 0 10)))))
+
+;;; testing random source, which is implementation specific
+;; (cond-expand
+;;   (gauche
+;;     (import
+;;       (gauche base)
+;;       (math mt-random))
+;;     (test-subsection "Test with-random-source")
+;;                 (reset-source!)
+;;                 ;; create and consume generators that are made with different source
+;;                 ;; with various order, and check that order doesn't change the outcome
+;;                 (define (test-multiple-sources gen1-maker gen1-expect
+;;                                                gen2-maker gen2-expect)
+
+;;                   ;;create gen1, consume gen1, create gen2, consume gen2
+;;                   (let ((gen1 (gen1-maker)))
+;;                    (test "srfi-194" (generator->list gen1) gen1-expect)
+;;                    (let ((gen2 (gen2-maker)))
+;;                     (test "srfi-194" (generator->list gen2) gen2-expect)))
+
+;;                   ;; create gen1, create gen2, consume gen1, consume gen2
+;;                   (let ((gen1 (gen1-maker))
+;;                         (gen2 (gen2-maker)))
+;;                     (test "srfi-194" (generator->list gen1) gen1-expect)
+;;                     (test "srfi-194" (generator->list gen2) gen2-expect)))
+
+;;                 (define multiple-sources-testcase
+;;                   (list (lambda ()
+;;                           (gtake (with-random-source
+;;                                    (make <mersenne-twister> :seed 0)
+;;                                    (lambda () (make-random-integer-generator 0 10)))
+;;                                  5))
+;;                         '(5 5 7 8 6)
+;;                         (lambda ()
+;;                           (gtake (with-random-source
+;;                                    (make <mersenne-twister> :seed 1)
+;;                                    (lambda () (make-random-integer-generator 0 10)))
+;;                                  5))
+;;                         '(4 9 7 9 0)))
+;;                 (apply test-multiple-sources multiple-sources-testcase)))
+;;   (else
+;;    #f))
+
+(test-subsection "Test make-random-source-generator")
+            (reset-source!)
+            (define (make-numbers src-gen)
+              (define gen1 (with-random-source (src-gen) (lambda () (make-random-integer-generator 0 100))))
+              (define gen2 (with-random-source (src-gen) (lambda () (make-random-real-generator 0. 100.))))
+              (generator->list
+               (gappend
+                (gtake gen1 10)
+                (gtake gen2 10))))
+
+            (test "srfi-194"
+                   (make-numbers (make-random-source-generator 0))
+                   (make-numbers (make-random-source-generator 0)))
+            (test "srfi-194" #t
+                  (not (equal? (make-numbers (make-random-source-generator 0))
+                               (make-numbers (make-random-source-generator 1)))))
+
+(test-subsection "Test random int")
+            (reset-source!)
+            (assert-number-generator
+              (make-random-integer-generator 1 100)
+              1 100)
+
+            (for-each
+              (lambda (testcase)
+                (define make-gen (car testcase))
+                (define byte-size (cadr testcase))
+                (define signed? (caddr testcase))
+                (assert-int-generator (make-gen) byte-size signed?))
+              (list
+                (list make-random-u8-generator 8 #f)
+                (list make-random-s8-generator 8 #t)
+                (list make-random-u16-generator 16 #f)
+                (list make-random-s16-generator 16 #t)
+                (list make-random-u32-generator 32 #f)
+                (list make-random-s32-generator 32 #t)
+                (list make-random-u64-generator 64 #f)
+                (list make-random-s64-generator 64 #t)))
+
+            ;;test u1 separately, since it will fail quarter checks due to small range
+            (assert-number-generator/all-in-range (make-random-u1-generator) 0 2)
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v) (= v 0))
+                (gtake (make-random-u1-generator) 100)))
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v) (= v 1))
+                (gtake (make-random-u1-generator) 100)))
+
+(test-subsection "Test random real")
+            (reset-source!)
+            (assert-number-generator
+              (make-random-real-generator 1.0 5.0)
+              1.0 5.0)
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v)
+                  (not (= v (floor v))))
+                (make-random-real-generator 1.0 5.0)))
+
+(test-subsection "Test complex rectangular")
+            (reset-source!)
+
+            (assert-number-generator
+              (gmap
+                real-part
+                (make-random-rectangular-generator -10.0 10.0 -100.0 100.0))
+              -10 10)
+
+            (assert-number-generator
+              (gmap
+                imag-part
+                (make-random-rectangular-generator -100.0 100.0 -10.0 10.0))
+              -10 10)
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (num)
+                  (and (not (= 0 (real-part num)))
+                       (not (= 0 (imag-part num)))))
+                (make-random-rectangular-generator -10.0 10.0 -10.0 10.0)))
+
+(test-subsection "Test complex polar")
+            (reset-source!)
+            (define PI (* 4 (atan 1.0)))
+
+            (define (test-polar g origin mag-from mag-to angle-from angle-to test-converge-origin)
+              (assert-number-generator
+                (gmap
+                  (lambda (num)
+                    (angle (- num origin)))
+                  g)
+                angle-from angle-to)
+
+              (assert-number-generator
+                (gmap
+                  (lambda (num)
+                    (magnitude (- num origin)))
+                  g)
+                mag-from mag-to)
+
+              ;; split generated area through circle at 0.5*(mag-from + mag-to)
+              ;; and validate generated points in them proportional to their area
+              (let* ((outter-count 0)
+                     (inner-count 0)
+                     (donut-area (lambda (r1 r2) (- (* r1 r1) (* r2 r2))))
+                     (mag-mid (/ (+ mag-from mag-to) 2.))
+                     (expected-fraction (/ (donut-area mag-to mag-mid)
+                                           (donut-area mag-mid mag-from))))
+                (generator-for-each
+                  (lambda (point)
+                    (if (< (magnitude (- point origin)) mag-mid)
+                        (set! inner-count (+ 1 inner-count))
+                        (set! outter-count (+ 1 outter-count))))
+                  (gtake g 10000))
+                (test-approximate expected-fraction (/ outter-count inner-count) 0.2))
+
+              ;; test points converge to center
+              (when test-converge-origin
+                (let ((sum 0+0i))
+                  (generator-for-each
+                    (lambda (point) (set! sum (+ point sum)))
+                    (gtake g 1000))
+                  (test-approximate (real-part origin) (real-part (/ sum 1000.)) 0.1)
+                  (test-approximate (imag-part origin) (imag-part (/ sum 1000.)) 0.1))))
+
+
+            (test-polar (make-random-polar-generator 0. 1.)
+                        0+0i 0. 1. (- PI) PI #t)
+
+            (test-polar (make-random-polar-generator 2+5i 1. 2.)
+                        2+5i 1. 2. (- PI) PI #t)
+
+            (test-polar (make-random-polar-generator 1. 2. -1. 1.)
+                        0+0i 1. 2. -1. 1. #f)
+
+            (test-polar (make-random-polar-generator -1+3i 0. 2. (- PI) PI)
+                        -1+3i 0. 2. (- PI) PI #t)
+
+(test-subsection "Test random bool")
+            (reset-source!)
+            (test "srfi-194" #t
+              (generator-every
+                (lambda (v)
+                  (or (eq? v #t)
+                      (eq? v #f)))
+                (gtake (make-random-boolean-generator) 10000)))
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v)
+                  (eq? #t v))
+                (make-random-boolean-generator)))
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v)
+                  (eq? #f v))
+                (make-random-boolean-generator)))
+
+(test-subsection "Test random char")
+            (reset-source!)
+            (test "srfi-194" #t
+              (generator-every
+                (lambda (v)
+                  (or (equal? v #\a)
+                      (equal? v #\b)))
+                (gtake (make-random-char-generator "ab")
+                       10000)))
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v)
+                  (equal? v #\a))
+                (make-random-char-generator "ab")))
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (v)
+                  (equal? v #\b))
+                (make-random-char-generator "ab")))
+
+(test-subsection "Test random string")
+            (reset-source!)
+            (test "srfi-194" #t
+              (generator-every
+                (lambda (str)
+                  (and (< (string-length str) 5)
+                       (every (lambda (c)
+                                (or (equal? c #\a)
+                                    (equal? c #\b)))
+                              (string->list str))))
+                (gtake (make-random-string-generator 5 "ab")
+                       10000)))
+
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (str)
+                  (equal? "abb" str))
+                (make-random-string-generator 4 "ab")))
+
+(test-subsection "Test Bernoulli")
+            (reset-source!)
+            (define g (make-bernoulli-generator 0.7))
+            (define expect 7000)
+            (define actual (generator-count
+                             (lambda (i) (= i 1))
+                             (gtake g 10000)))
+            (define ratio (inexact (/ actual expect)))
+            (test "srfi-194" #t (> ratio 0.9))
+            (test "srfi-194" #t (< ratio 1.1))
+
+(test-subsection "Test categorical")
+            (reset-source!)
+            (define result-vec (vector 0 0 0))
+            (define expect-vec (vector 2000 5000 3000))
+            (define wvec (vector 20 50 30))
+            (define g (make-categorical-generator wvec))
+            (generator-for-each
+              (lambda (i)
+                (vector-set! result-vec i (+ 1 (vector-ref result-vec i))))
+              (gtake g 10000))
+            (vector-for-each
+              (lambda (result expect)
+                (define ratio (inexact (/ result expect)))
+                (test-approximate 1.0 ratio 0.1))
+              result-vec
+              expect-vec)
+
+(test-subsection "Test poisson")
+            (reset-source!)
+            ;;TODO import from somewhere?
+            (define (fact k)
+              (cond
+                ((<= k 1) 1)
+                (else (* k (fact (- k 1))))))
+
+            (define (expected-fraction L k)
+              (/ (* (exact (expt L k)) (exact (exp (- L))))
+                 (fact k)))
+
+            (define (test-poisson L poisson-gen test-points)
+              (generator-every
+                (lambda (k)
+                  (define expect (expected-fraction L k))
+                  (define actual (/ (generator-count
+                                      (lambda (i) (= i k))
+                                      (gtake poisson-gen 10000))
+                                    10000))
+                  (define ratio (/ actual expect))
+                  (test "srfi-194" #t (> ratio 8/10))
+                  (test "srfi-194" #t (< ratio 12/10)))
+                (list->generator test-points)))
+
+            (test-poisson 2 (make-poisson-generator 2) '(1 2 3))
+            (test-poisson 40 (make-poisson-generator 40) '(30 40 50))
+            (test-poisson 280 (make-poisson-generator 280) '(260 280 300))
+
+(test-subsection "Test normal")
+            (reset-source!)
+            (define frac-at-1dev 0.34134)
+            (define frac-at-2dev 0.47725)
+            (define frac-at-3dev 0.49865)
+
+            (define (test-normal-at-point gen count-from count-to expected-fraction)
+              (define actual (/ (generator-count
+                                  (lambda (n)
+                                    (and (>= n count-from)
+                                         (< n count-to)))
+                                  (gtake gen 10000))
+                                10000.0))
+              (test "srfi-194" #t (and (> actual (* 0.9 expected-fraction))
+                                (< actual (* 1.1 expected-fraction)))))
+
+            (define (test-normal gen mean deviation)
+              (test-normal-at-point gen mean (+ mean deviation) frac-at-1dev)
+              (test-normal-at-point gen mean (+ mean (* 2 deviation)) frac-at-2dev)
+              (test-normal-at-point gen mean (+ mean (* 3 deviation)) frac-at-3dev))
+
+            (test-normal (make-normal-generator) 0.0 1.0)
+            (test-normal (make-normal-generator 1.0) 1.0 1.0)
+            (test-normal (make-normal-generator 1.0 2.0) 1.0 2.0)
+
+(test-subsection "Test exponential")
+            (reset-source!)
+            (define (expected-fraction mean x)
+              (- 1 (exp (* (- (/ 1.0 mean)) x))))
+
+            (define (test-exp-at-point gen count-to expected)
+              (define actual (/ (generator-count
+                                  (lambda (n)
+                                    (< n count-to))
+                                  (gtake gen 10000))
+                                10000.0))
+              (test "srfi-194" #t (> actual (* 0.9 expected)))
+              (test "srfi-194" #t (< actual (* 1.1 expected))))
+
+            (define (test-exp gen mean)
+              (test-exp-at-point gen 1 (expected-fraction mean 1))
+              (test-exp-at-point gen 2 (expected-fraction mean 2))
+              (test-exp-at-point gen 3 (expected-fraction mean 3)))
+
+            (test-exp (make-exponential-generator 1) 1)
+            (test-exp (make-exponential-generator 1.5) 1.5)
+
+(test-subsection "Test geometric")
+            (reset-source!)
+            (define (expected-fraction p x)
+              (* (expt (- 1 p) (- x 1)) p))
+
+            (define (test-geom-at-point gen p x)
+              (define expected (expected-fraction p x))
+              (define actual (/ (generator-count
+                                  (lambda (n)
+                                    (= n x))
+                                  (gtake gen 100000))
+                                100000))
+              (define ratio (/ actual expected))
+              (test "srfi-194" #t (> ratio 0.9))
+              (test "srfi-194" #t (< ratio 1.1)))
+
+            (define (test-geom gen p)
+              (test-geom-at-point gen p 1)
+              (test-geom-at-point gen p 3)
+              (test-geom-at-point gen p 5))
+
+            (test-geom (make-geometric-generator 0.5) 0.5)
+
+(test-subsection "Test uniform sampling")
+            (reset-source!)
+            (test "srfi-194"
+              '()
+              (generator->list (gsampling)))
+            (test "srfi-194"
+              '()
+              (generator->list (gsampling (generator) (generator))))
+            (test "srfi-194"
+              '(1 1 1)
+              (generator->list (gsampling (generator) (generator 1 1 1))))
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (el)
+                  (= el 1))
+                (gsampling (circular-generator 1) (circular-generator 2))))
+            (test "srfi-194" #t
+              (generator-any
+                (lambda (el)
+                  (= el 2))
+                (gsampling (circular-generator 1) (circular-generator 2))))
+
+(test-subsection "Test Zipf sampling")
+            (reset-source!)
+            (include "zipf-test.scm")
+            (zipf-test-group)
+
+(test-subsection "Test sphere")
+            (include "sphere-test.scm")
+            (reset-source!*)
+            ;; (cond-expand
+            ;;  (gambit
+            ;;   ;; Gambit fails this test, but I think the generator code is correct.
+            ;;   #t)
+            ;;  (else
+              (test-sphere (make-sphere-generator 1) (vector 1.0 1.0) 200 #t)
+            ;;))
+            (test-sphere (make-sphere-generator 2) (vector 1.0 1.0 1.0) 200 #t)
+            (test-sphere (make-sphere-generator 3) (vector 1.0 1.0 1.0 1.0) 200 #t)
+
+            (reset-source!*)
+            (cond-expand
+             (gambit
+              ;; Gambit fails this test, but I think the generator code is correct.
+              #t)
+             (else
+              (test-sphere (make-ellipsoid-generator (vector 1.0 1.0)) (vector 1.0 1.0) 200 #t)))
+            (test-sphere (make-ellipsoid-generator (vector 1.0 1.0 1.0)) (vector 1.0 1.0 1.0) 200 #t)
+            (test-sphere (make-ellipsoid-generator (vector 1.0 1.0 1.0 1.0)) (vector 1.0 1.0 1.0 1.0) 200 #t)
+
+            (reset-source!*)
+            (test-sphere (make-ellipsoid-generator (vector 1.0 3.0)) (vector 1.0 3.0) 200 #f)
+            (test-sphere (make-ellipsoid-generator (vector 1.0 3.0 5.0)) (vector 1.0 3.0 5.0) 200 #f)
+            (test-sphere (make-ellipsoid-generator (vector 1.0 3.0 5.0 7.0)) (vector 1.0 3.0 5.0 7.0) 200 #f)
+
+            (reset-source!*)
+            (test-ball (make-ball-generator 2) (vector 1.0 1.0))
+            (test-ball (make-ball-generator 3) (vector 1.0 1.0 1.0))
+            (test-ball (make-ball-generator (vector 1.0 3.0)) (vector 1.0 3.0))
+            (test-ball (make-ball-generator (vector 1.0 3.0 5.0)) (vector 1.0 3.0 5.0))
+
+            (reset-source!*)
+
+            (test-ellipsoid 1 1 10000)
+            (test-ellipsoid 5 5 10000)
+            (test-ellipsoid 10 2 10000)
+
+            ;; test the unit ball
+            (test-ellipse 1 1 10000)
+
+            ;; test the scaled unit ball
+            (test-ellipse 5 5 10000)
+
+            ;; test an eccentric ellipse
+            (test-ellipse 10 2 10000)
+
+(test-subsection "Test binomial")
+            (reset-source!)
+            (define (factorial n)
+              (if (<= n 1)
+                  1
+                  (* n (factorial (- n 1)))))
+            (define (C n k)
+              (/ (factorial n)
+                 (* (factorial k) (factorial (- n k)))))
+            (define (expected-frac n p k)
+              (* (C n k) (expt p k) (expt (- 1 p) (- n k))))
+
+            (define (test-binomial n p count)
+              (define g (make-binomial-generator n p))
+              (define counts (make-vector (+ n 1) 0))
+              (generator-for-each
+                (lambda (x)
+                  (vector-set! counts x (+ 1 (vector-ref counts x))))
+                (gtake g count))
+              (for-each
+                (lambda (k)
+                  (define expected (* count (expected-frac n p k) ))
+                  (define actual (vector-ref counts k))
+                  (cond
+                    ((= expected 0)
+                     (test "srfi-194" 0 actual))
+                    ;;hacky.. testing values with very low probability fails
+                    ((> expected (* 1/1000 count))
+                     (test-approximate 1.0 (/ actual expected) 0.2))))
+                (iota (+ n 1))))
+
+            (test-binomial 1 0 100)
+            (test-binomial 1 1 100)
+            (test-binomial 1 0. 100)
+            (test-binomial 1 1. 100)
+            (test-binomial 10 0 100)
+            (test-binomial 10 1 100)
+            (test-binomial 10 0. 100)
+            (test-binomial 10 1. 100)
+            ;;(test-binomial 10 0.25 100000)
+            ;;(test-binomial 40 0.375 1000000)

--- a/tests/srfis/sphere-test.scm
+++ b/tests/srfis/sphere-test.scm
@@ -1,0 +1,301 @@
+;;; SPDX-FileCopyrightText: 2020 Arvydas Silanskas
+;;; SPDX-FileCopyrightText: 2024 Bradley J Lucier
+;;; SPDX-License-Identifier: MIT
+;;;
+;;; Take REPS samples from unit sphere, verify random distribution.
+;;;
+;;; This test checks that:
+;;; * Every sample has unit length, within numerical tolerance.
+;;; * The REPS samples are uniformly distributed.
+;;; * Rotations of the REPS samples are uniformly distributed.
+(define (test-sphere sphereg dim-sizes REPS rotate?)
+  (define random-int (random-source-make-integers (current-random-source)))
+  (define random-real (random-source-make-reals (current-random-source)))
+  (define N (- (vector-length dim-sizes) 1))
+
+  ;; Fix list of samples
+  (define samples
+    (generator->list (gtake sphereg REPS)))
+
+  (define (l2-norm VEC)
+    (sqrt (vector-fold
+            (lambda (sum x l) (+ sum (/ (* x x)
+                                        (* l l))))
+            0
+            VEC
+            dim-sizes)))
+
+  ;; Rotate the j'th amnd k'th coordinates of a vector VEC
+  ;; by cosine co and sine si
+  (define (pair-rot VEC j k co si)
+    (define oj (vector-ref VEC j))
+    (define ok (vector-ref VEC k))
+    (define nj (+ (* co oj) (* si ok)))
+    (define nk (+ (* (- si) oj) (* co ok)))
+    (list->vector
+      (map (lambda (index)
+             (cond
+               ((= index j) nj)
+               ((= index k) nk)
+               (else (vector-ref VEC index))))
+           (iota (vector-length VEC)))))
+
+  ;; Apply a random rotation to a collection of vectors
+  (define how-many-rots
+    (if (< 10 N) 10 N))
+
+  (define (arb-rot VEC-LIST)
+    (define j (random-int N))
+    (define k (+ j 1 (random-int (- N j))))
+    (define theta (* 3.14 (random-real)))
+    (define co (cos theta))
+    (define si (sin theta))
+    (define rvl
+      (map (lambda (vec)
+             (pair-rot vec j k co si))
+           VEC-LIST))
+    (if (not (= 0 (random-int how-many-rots)))
+        (arb-rot rvl)
+        rvl))
+
+  ;; Expect a vector approaching zero. That is, each individual
+  ;; coordinate should be uniformly randomly distributed in the
+  ;; interval [-1,1]. The sum of REPS samples of these should
+  ;; converge to zero. The standard deviation of a uniform
+  ;; distribution is sqrt(REPS/12).
+  ;; https://en.wikipedia.org/wiki/Continuous_uniform_distribution
+  ;; So setting max bound of 9 stddev should allow it to usually
+  ;; pass.
+  (define (converge-to-zero samples)
+    (fold (lambda (acc sample) (vector-map + sample acc))
+          (make-vector REPS 0.0)
+          samples))
+
+  (define (should-be-zero samples)
+    (l2-norm (converge-to-zero samples)))
+
+  (define (norm-should-be-zero samples)
+    (/ (should-be-zero samples) (sqrt (/ REPS 12.0))))
+
+  (define (check-zero samples)
+    (define num-stddev 9.0)
+    (define zz (norm-should-be-zero samples))
+    (test "srfi-194-sphere" #t (< zz num-stddev)))
+
+  ;; maximum allowed tolerance for radius deviation
+  (define EPS (* 2e-15 (sqrt N)))
+
+  ;; Each individual sphere radius should be 1.0 to within float
+  ;; tolerance.
+  (for-each
+    (lambda (SAMP)
+      (test-approximate 1.0 (l2-norm SAMP) EPS))
+    samples)
+
+  ;; The distribution should be zero
+  (check-zero samples)
+
+  ;; Rotate wildly. Should still be uniform.
+  (when rotate?
+    (for-each
+      (lambda (junk) (check-zero (arb-rot samples)))
+      (make-list 12))))
+
+(define (test-ball ballg dim-sizes)
+  (define (l2-norm VEC)
+    (sqrt (vector-fold
+            (lambda (sum x l) (+ sum (/ (* x x)
+                                        (* l l))))
+            0
+            VEC
+            dim-sizes)))
+
+  (define (test-ball-generates-on-radius radius err)
+    (test "srfi-194-sphere" #t
+      (generator-any
+        (lambda (vec)
+          (define n (l2-norm vec))
+          (and (> n (- radius err))
+               (< n (+ radius err))))
+        (gtake ballg 10000))))
+
+  (define (test-ball-avg-zero N)
+    (define vec-sum
+      (generator-fold
+        (lambda (vec acc)
+          (vector-map + vec acc))
+        (make-vector (vector-length dim-sizes) 0.0)
+        (gtake ballg N)))
+    (define avg-vec
+      (vector-map
+        (lambda (e)
+          (/ e N))
+        vec-sum))
+    (define n (l2-norm avg-vec))
+    (test "srfi-194-sphere" #t (< n 1)))
+
+  (test-ball-generates-on-radius 0.0 0.1)
+  (test-ball-generates-on-radius 0.5 0.1)
+  (test-ball-generates-on-radius 1.0 0.1)
+
+  (test-ball-avg-zero 5000))
+
+  ;; Number of standard deviation difference from the expected value
+  ;; before we say a test failed.  If set to 2, then one out of
+  ;; 20 tests will fail even if the code is correct.  Setting it to
+  ;; 3 means that only one out of a 1000 tests will fail even if the
+  ;; code is correct.
+
+  (define STDs 3)
+
+  (define (test-ellipsoid a b N)
+
+    (define epsilon 1e-10)
+
+    (define pi (* 4 (atan 1)))
+
+    (define g (make-ellipsoid-generator (vector a b)))
+
+    (define points (generator->list (gtake g N)))
+
+    ;; The points on the "top" of the ellipse, with
+    ;; x between -a/2 and a/2
+
+    (define top
+      (filter (lambda (v)
+                (and (<  (- (/ a 2)) (vector-ref v 0) (/ a 2))
+                     (<  0 (vector-ref v 1))))
+              points))
+
+    ;; The points on the "right" of the ellipse, with
+    ;; y between -b/2 and b/2
+
+    (define right
+      (filter (lambda (v)
+                (and (< (- (/ b 2)) (vector-ref v 1) (/ b 2))
+                     (< 0 (vector-ref v 0))))
+              points))
+
+    (define (arc-length a b)
+      ;; parametrization: (a\cos t, b\sin t)
+      ;; this is the norm of the derivative
+      (lambda (t)
+        (sqrt (+ (square (* a (sin t)))
+                 (square (* b (cos t)))))))
+
+    (define (simpsons-rule f t0 t1 N)
+      ;; O(Delta^4) numerical integration
+      ;; integrate f between t0 and t1 with N intervals
+      (let* ((Delta (/ (- t1 t0) N))
+             (sum1 (do ((i 0 (+ i 1))
+                        (sum 0. (+ sum
+                                   (f (+ t0 (* i Delta)))
+                                   (f (+ t0 (* (+ i 1) Delta))))))
+                       ((= i N) sum)))
+             (sum2 (do ((i 0 (+ i 1))
+                        (sum 0. (+ sum (f (+ t0 (* (+ i 0.5) Delta))))))
+                       ((= i N) sum))))
+        (* Delta (/ (+ (* 4 sum2) sum1) 6))))
+
+    (define p-right
+      (/ (simpsons-rule (arc-length a b) (- (* pi 1/6)) (* pi 1/6) 100)
+         (simpsons-rule (arc-length a b) 0 (* pi 2) 100)))
+
+    (define p-top
+      (/ (simpsons-rule (arc-length a b) (* pi 1/3) (* pi 2/3) 100)
+         (simpsons-rule (arc-length a b) 0 (* pi 2) 100)))
+
+    ;; test that they're all more-or-less on the ellipse
+
+    (test "srfi-194-sphere" #t (every (lambda (p)
+                          (< (abs (- (sqrt (+ (square (/ (vector-ref p 0) a))
+                                              (square (/ (vector-ref p 1) b))))
+                                     1))
+                             epsilon))
+                        points))
+
+    (for-each (lambda (p m)
+                ;; p = probability of landing in arc, m = measured number
+                (test "srfi-194-sphere" #t (< (abs (- (* p N) m))
+                                (* STDs (sqrt (* N p (- 1 p)))))))
+              (list p-right p-top)
+              (map length (list right top)))
+    )
+
+  (define (test-ellipse a b N)
+
+    ;; This test with two-dimensional ellipses stands in for all
+    ;; dimensions, as the code to generate points is independent
+    ;; of dimension
+
+    (define pi (* 4 (atan 1)))
+
+    (define interior-points
+      (generator->list (gtake (make-ball-generator (vector a b)) N)))
+
+    (define (in-ellipse? point)
+      (< (+ (square (/ (vector-ref point 0) a))
+            (square (/ (vector-ref point 1) b)))
+         1))
+
+    ;; Find points inside rectangles inside various parts
+    ;; of the ellipse
+
+    (define center
+      (filter (lambda (v)
+                (and (< (- (/ a 4))
+                        (vector-ref v 0)
+                        (/ a 4))
+                     (< (- (/ b 4))
+                        (vector-ref v 1)
+                        (/ b 4))))
+              interior-points))
+
+    (define right-x
+      ;; (right-x b/4) is on the ellipse
+      (* a (sqrt 15/16)))
+
+    (define right
+      (filter (lambda (v)
+                (and (< (- right-x (/ a 2))
+                        (vector-ref v 0)
+                        right-x)
+                     (< (- (/ b 4))
+                        (vector-ref v 1)
+                        (/ b 4))))
+              interior-points))
+
+    (define top-y
+      ;; (a/4 top-y) is on the ellipse
+      (* b (sqrt 15/16)))
+
+    (define top
+      (filter (lambda (v)
+                (and (< (- (/ a 4))
+                        (vector-ref v 0)
+                        (/ a 4))
+                     (< (- top-y (/ b 2))
+                        (vector-ref v 1)
+                        top-y)))
+              interior-points))
+
+    ;; p is he fraction of the area in the ellipse
+    ;; contained in the rectangles (it's all the same).
+
+    #;(define p
+    (/ (* (/ a 2) (/ b 2))
+    (* pi a b)))
+
+    (define p (/ (* 4 pi)))
+
+    ;; check that all the points are truly inside the ellipse.
+
+    (test "srfi-194-sphere" #t (every in-ellipse? interior-points))
+
+    (for-each (lambda (p m)
+                ;; p = probability of landing in rectangle,
+                ;; m = measured number of events
+                (test "srfi-194-sphere" #t (< (abs (- (* p N) m))
+                                              (* STDs (sqrt (* N p (- 1 p)))))))
+              (list p p p)
+              (map length (list center right top))))

--- a/tests/srfis/zipf-test.scm
+++ b/tests/srfis/zipf-test.scm
@@ -1,0 +1,342 @@
+; SPDX-FileCopyrightText: 2020 Arvydas Silanskas
+; SPDX-FileCopyrightText: 2020 Linas Vepštas
+; SPDX-License-Identifier: MIT
+;
+; zipf-test.scm
+; Unit tests for the Zipf (zeta) distribution.
+;
+; Created by Linas Vepstas 10 July 2020
+; Part of srfi-194
+
+; srfi-133 compatible API
+(define zvector-map vector-map)
+(define z2vector-map vector-map)
+(define zvector-fold vector-fold)
+
+; srfi-43 compatible API
+;(define (zvector-map f vec)
+;  (vector-map (lambda (i x) (f x)) vec))
+;(define (z2vector-map f veca vecb)
+;  (vector-map (lambda (i x y) (f x y)) veca vecb))
+;(define (zvector-fold f knil vec)
+;  (vector-fold (lambda (i x elt) (f x elt)) knil vec))
+
+; ------------------------------------------------------------------
+; Debug utility for gnuplot graphing.
+; You can use this to dump a vector to a tab-delimited file.
+(define (vector-to-file vec filename)
+  (define (write-vec)
+    (for-each
+      (lambda (i)
+        (define index (+ i 1))
+        (define val (vector-ref vec i))
+        (display index)
+        (display "  ")
+        (display val)
+        (newline))
+      (iota (vector-length vec))))
+  (with-output-to-file filename write-vec))
+
+; ------------------------------------------------------------------
+; Test harness for exploring the Zipf (Riemann/Hurwicz zeta) distribution
+; parameter space.
+;
+;     (test-zipf TEST-ID NVOCAB ESS QUE REPS TOL)
+;
+; * TEST-ID -- String ID, for debugging.
+; * The next three parameters are presented to the generator as
+;     (make-zipf-generator NVOCAB ESS QUE)
+;   ++  NVOCAB -- Size of vocabulary to select from.
+;   ++  ESS -- The Riemann zeta "s" exponent.
+;   ++  QUE -- The Hurwicz zeta "q" offset.
+; * REPS -- The number of samples to draw from the distribution.
+; * TOL -- The test tolerance, governing the expected failure rate.
+;
+; The algorithm is roughly:
+;   Take REPS samples (make-zipf-generator NVOCAB ESS QUE)
+;   Accumulate them into NVOCAB histogram bins.
+;   Normalize counts to unit probability (i.e. divide by NVOCAB)
+;
+; The resulting distribution should uniformly converge to C/(k+q)^s
+; for 1 <= k <= NVOCAB where C is a normalization constant.
+;
+; This compares the actual distribution to the expected convergent
+; and reports an error if it is not within TOL of the convergent.
+; i.e. it computes the Banach l_0 norm of (distribution-convergent)
+; TOL is to be given in units of standard deviations. So, for example,
+; setting TOL to 6 gives a six-sigma bandpass, allowing the tests to
+; usually pass.
+;
+; The keyword here is "usually". The tail of the Zipf distribution is
+; generally quite thin, and experiences a lot of statistical variation.
+; There does not seem to be any published theory of exactly how the
+; central limit theorm can be applied to estimate the distribution of
+; the tail. The code below assumes an approximate gaussian distribution,
+; computes it and tests it; however certain parameter ranges violate
+; this assumption. Thus, this test will fail from time to time,
+; depending on the luck of the draw. If it fails, it should be repeated
+; once or twice, ubtil it passes.
+;
+(define (test-zipf-once TEST-ID NVOCAB ESS QUE REPS TOL)
+
+  ; Default random number generator
+  (define ZGEN make-zipf-generator)
+
+  ; Bin-counter containing accumulated histogram.
+  (define bin-counts
+    (let ((bin-counts (make-vector NVOCAB 0)))
+     ; Accumulate samples into the histogram.
+     (generator-for-each
+       (lambda (SAMP)
+         (define offset (- SAMP 1))
+         (vector-set! bin-counts offset (+ 1 (vector-ref bin-counts offset))))
+       (gtake (ZGEN NVOCAB ESS QUE) REPS))
+     bin-counts))
+
+  ; Verify the distribution is within tolerance.
+  ; This is written out long-hand for easier debuggability.
+
+  ; Frequency is normalized to be 0.0 to 1.0
+  (define frequency (zvector-map (lambda (n) (/ n REPS)) bin-counts))
+  (define probility (zvector-map (lambda (n) (inexact n)) frequency))
+
+  ; Sequence 1..NVOCAB
+  (define seq (list->vector (iota NVOCAB 1)))
+
+  ; Sequence  1/(k+QUE)^ESS
+  (define inv-pow
+    (zvector-map (lambda (k) (expt (+ k QUE) (- (inexact ESS)))) seq))
+
+  ; Hurwicz harmonic number sum_1..NVOCAB 1/(k+QUE)^ESS
+  (define hnorm
+    (zvector-fold
+      (lambda (sum cnt) (+ sum cnt)) 0 inv-pow))
+
+  ; The expected distribution.
+  (define expect
+    (zvector-map (lambda (x) (/ x hnorm)) inv-pow))
+
+  ; Convert to floating point.
+  (define prexpect (zvector-map (lambda (x) (inexact x)) expect))
+
+  ; The difference.
+  (define diff (z2vector-map (lambda (x y) (- x y)) probility prexpect))
+
+  ; Re-weight the tail by k^{s/2}. This seems give a normal error
+  ; distribution. ... at least, for small q. Problems for large q
+  ; and with undersampling; so we hack around that.
+  (define err-dist
+    (if (< 10 QUE) diff
+        (z2vector-map (lambda (i x) (* x (expt (+ i 1) (* 0.5 ESS))))
+                    (list->vector (iota (vector-length diff)))
+                    diff)))
+
+  ; Normalize to unit root-mean-square.
+  (define rms (/ 1 (sqrt (* 2 3.141592653 REPS))))
+  (define norm-dist (zvector-map (lambda (x) (/ x rms)) err-dist))
+
+  ; Maximum deviation from expected distribution (l_0 norm)
+  (define l0-norm
+    (zvector-fold
+      (lambda (sum x) (if (< sum (abs x)) (abs x) sum)) 0 norm-dist))
+
+  ; The mean.
+  (define mean
+    (/ (zvector-fold (lambda (sum x) (+ sum x)) 0 norm-dist)
+       NVOCAB))
+
+  (define root-mean-square
+    (sqrt (/ (zvector-fold (lambda (sum x) (+ sum (* x x))) 0 norm-dist)
+             NVOCAB)))
+
+  ; Test for uniform convergence.
+  ; (test-assert TEST-ID (<= l0-norm TOL))
+  (define tol-result (<= l0-norm TOL))
+
+  ; Should not random walk too far away.
+  ; Could tighten this with a proper theory of the error distribution.
+  ; (test-assert TEST-ID (< (abs mean) 3))
+  (define mean-result (< (abs mean) 3))
+  ; I don't understand the error distribution ....
+  ; (test-assert (and (< 0.4 root-mean-square) (< root-mean-square 1.5)))
+
+  ; Sanity check. The total counts in the bins should be equal to REPS.
+  ; If this fails, the test harness itself is broken.
+  (test TEST-ID
+        #t
+        (equal? REPS
+                (zvector-fold
+                 (lambda (sum cnt) (+ sum cnt)) 0 bin-counts)))
+
+  ; Utility debug printing
+  ;(vector-to-file probility "probility.dat")
+  ;(vector-to-file prexpect "prexpect.dat")
+  ;(vector-to-file diff "diff.dat")
+
+  (list tol-result mean-result))
+
+; ------------------------------------------------------------------
+; Sometimes the Zip test fails, due to random variation. It should
+; pass, if attempted a second time. This gives it three chances.
+; If it fails three times, then something bad is happening.
+(define (test-zipf TEST-ID NVOCAB ESS QUE REPS TOL)
+
+  ;; Three strikes, you're out.
+  (define RETRY 3)
+
+  (define num-failures
+    (list-index
+     (lambda (n)
+       (define rc (test-zipf-once TEST-ID NVOCAB ESS QUE REPS TOL))
+       (and (first rc) (second rc)))
+     (iota RETRY)))
+
+  ; `num-failures` will be #f if it failed each and every time.
+  ;(if (number? num-failures)
+  ;  (if (< 0 num-failures)
+  ;    (format #t "Test '~A' out of bounds ~A times.\n" TEST-ID num-failures))
+  ;  (format #t "Error: Test '~A' failed every time!\n" TEST-ID))
+
+  ; Announce excessive repeated failures.
+  ;(format #t "" TEST-ID num-failures)
+  (test TEST-ID #t (number? num-failures))
+)
+
+; ------------------------------------------------------------------
+; Explore the parameter space.
+(define (zipf-test-group)
+  ; (test-begin "srfi-194-zipf")
+
+  ; The unit test computes something that is "almost" a standard
+  ; deviation for the error distribution. Except, maybe not quite,
+  ; I don't fully understand the theory. So most tests seem to come
+  ; in fine in well-under a six-sigma deviation, but some of the wilder
+  ; parameter choices misbehave, so six-sigma doesn't always work.
+  ; Also, when the number of bins is large, its easy to under-sample;
+  ; some bins end up empty and the std-dev is thrown off as a result.
+  ; Thus, the tolerance bounds below are hand-adjusted.
+  (define six-sigma 6.0)
+
+  (define hack-que 3.0)
+
+  ; Zoom into s->1
+  (test-zipf "zoom-1"   30 1.1     0 1000 six-sigma)
+  (test-zipf "zoom-2"   30 1.01    0 1000 six-sigma)
+  (test-zipf "zoom-3"   30 1.001   0 1000 six-sigma)
+  (test-zipf "zoom-4"   30 1.0001  0 1000 six-sigma)
+  (test-zipf "zoom-5"   30 1.00001 0 1000 six-sigma)
+
+  (test-zipf "zoom-6"   30 (+ 1 1e-6)  0 1000 six-sigma)
+  (test-zipf "zoom-8"   30 (+ 1 1e-8)  0 1000 six-sigma)
+  (test-zipf "zoom-10"  30 (+ 1 1e-10) 0 1000 six-sigma)
+  (test-zipf "zoom-12"  30 (+ 1 1e-12) 0 1000 six-sigma)
+  (test-zipf "zoom-14"  30 (+ 1 1e-14) 0 1000 six-sigma)
+  (test-zipf "zoom-inf" 30 1           0 1000 six-sigma)
+
+  ; Verify improving uniform convergence
+  (test-zipf "uniform-1" 30 1  0 10000   six-sigma)
+  (test-zipf "uniform-2" 30 1  0 100000  six-sigma)
+
+  ; Larger vocabulary
+  (test-zipf "mid-voc-1" 300 1.1     0 10000 six-sigma)
+  (test-zipf "mid-voc-2" 300 1.01    0 10000 six-sigma)
+  (test-zipf "mid-voc-3" 300 1.001   0 10000 six-sigma)
+  (test-zipf "mid-voc-4" 300 1.0001  0 10000 six-sigma)
+  (test-zipf "mid-voc-5" 300 1.00001 0 10000 six-sigma)
+
+  ; Larger vocabulary. Take more samples....
+  (test-zipf "large-voc-1" 3701 1.1     0 40000 six-sigma)
+  (test-zipf "large-voc-2" 3701 1.01    0 40000 six-sigma)
+  (test-zipf "large-voc-3" 3701 1.001   0 40000 six-sigma)
+  (test-zipf "large-voc-4" 3701 1.0001  0 40000 six-sigma)
+  (test-zipf "large-voc-5" 3701 1.00001 0 40000 six-sigma)
+
+  ; Huge vocabulary; few samples. Many bins will be empty,
+  ; causing the std-dev to get large.
+  (test-zipf "huge-voc-1" 43701 (+ 1 1e-6)  0 60000 9.5)
+  (test-zipf "huge-voc-2" 43701 (+ 1 1e-7)  0 60000 9.5)
+  (test-zipf "huge-voc-3" 43701 (+ 1 1e-9)  0 60000 9.5)
+  (test-zipf "huge-voc-4" 43701 (+ 1 1e-12) 0 60000 9.5)
+  (test-zipf "huge-voc-5" 43701 1           0 60000 9.5)
+
+  ; Large s, small range
+  (test-zipf "big-s-lo-1" 5 1.1     0 1000 six-sigma)
+  (test-zipf "big-s-lo-2" 5 2.01    0 1000 six-sigma)
+  (test-zipf "big-s-lo-3" 5 4.731   0 1000 six-sigma)
+  (test-zipf "big-s-lo-4" 5 9.09001 0 1000 six-sigma)
+  (test-zipf "big-s-lo-5" 5 13.45   0 1000 8.0)
+
+  ; Large s, larger range. Most histogram bins will be empty
+  ; so allow much larger error margins. There are excessively
+  ; frequent large failures in this bunch.
+  (test-zipf "bis-mid-1" 130 1.5     0 30000 six-sigma)
+  (test-zipf "bis-mid-2" 130 2.03    0 30000 9.0)
+  (test-zipf "bis-mid-3" 130 4.5     0 30000 36.0) ; This one is problematic
+  (test-zipf "bis-mid-4" 130 6.66    0 30000 24.0)
+
+  ; Verify that accuracy improves with more samples.
+  (test-zipf "samp-bi-1" 129 1.1     0 10000 six-sigma)
+  (test-zipf "samp-bi-2" 129 1.01    0 10000 six-sigma)
+  (test-zipf "samp-bi-3" 129 1.001   0 10000 six-sigma)
+  (test-zipf "samp-bi-4" 129 1.0001  0 10000 six-sigma)
+  (test-zipf "samp-bi-5" 129 1.00001 0 10000 six-sigma)
+
+  ; Non-zero Hurwicz parameter
+  (test-zipf "hurw-1" 131 1.1     0.3    10000 six-sigma)
+  (test-zipf "hurw-2" 131 1.1     1.3    10000 six-sigma)
+  (test-zipf "hurw-3" 131 1.1     6.3    10000 six-sigma)
+  (test-zipf "hurw-4" 131 1.1     20.23  10000 six-sigma)
+
+  ; Negative Hurwicz parameter. Must be greater than branch point at -0.5.
+  (test-zipf "hneg-1" 81 1.1     -0.1   1000 six-sigma)
+  (test-zipf "hneg-2" 81 1.1     -0.3   1000 six-sigma)
+  (test-zipf "hneg-3" 81 1.1     -0.4   1000 six-sigma)
+  (test-zipf "hneg-4" 81 1.1     -0.499 1000 six-sigma)
+
+  ; A walk into a stranger corner of the parameter space.
+  (test-zipf "big-h-1" 131 1.1     41.483 10000 hack-que)
+  (test-zipf "big-h-2" 131 2.1     41.483 10000 hack-que)
+  (test-zipf "big-h-3" 131 6.1     41.483 10000 hack-que)
+  (test-zipf "big-h-4" 131 16.1    41.483 10000 hack-que)
+  (test-zipf "big-h-5" 131 46.1    41.483 10000 hack-que)
+  (test-zipf "big-h-6" 131 96.1    41.483 10000 hack-que)
+
+  ; A still wilder corner of the parameter space.
+  (test-zipf "huhu-1" 131 1.1     1841.4 10000 hack-que)
+  (test-zipf "huhu-2" 131 1.1     1.75e6 10000 hack-que)
+  (test-zipf "huhu-3" 131 2.1     1.75e6 10000 hack-que)
+  (test-zipf "huhu-4" 131 12.1    1.75e6 10000 hack-que)
+  (test-zipf "huhu-5" 131 42.1    1.75e6 10000 hack-que)
+
+  ; Lets try s less than 1
+  (test-zipf "small-s-1" 35 0.9     0 1000 six-sigma)
+  (test-zipf "small-s-2" 35 0.99    0 1000 six-sigma)
+  (test-zipf "small-s-3" 35 0.999   0 1000 six-sigma)
+  (test-zipf "small-s-4" 35 0.9999  0 1000 six-sigma)
+  (test-zipf "small-s-5" 35 0.99999 0 1000 six-sigma)
+
+  ; Attempt to force an overflow
+  (test-zipf "ovfl-1" 437 (- 1 1e-6)  0 1000 six-sigma)
+  (test-zipf "ovfl-2" 437 (- 1 1e-7)  0 1000 six-sigma)
+  (test-zipf "ovfl-3" 437 (- 1 1e-9)  0 1000 six-sigma)
+  (test-zipf "ovfl-4" 437 (- 1 1e-12) 0 1000 six-sigma)
+
+  ; Almost flat distribution
+  (test-zipf "flat-1" 36 0.8     0 1000 six-sigma)
+  (test-zipf "flat-2" 36 0.5     0 1000 six-sigma)
+  (test-zipf "flat-3" 36 0.1     0 1000 six-sigma)
+
+  ; A visit to crazy-town -- increasing, not decreasing exponent
+  (test-zipf "neg-s-1" 36 0.0     0 1000 six-sigma)
+  (test-zipf "neg-s-2" 36 -0.1    0 1000 six-sigma)
+  (test-zipf "neg-s-3" 36 -1.0    0 1000 six-sigma)
+  (test-zipf "neg-s-4" 36 -3.0    0 1000 six-sigma)
+
+  ; More crazy with some Hurwicz on top.
+  (test-zipf "neg-shu-1" 16 0.0     0.5 1000 six-sigma)
+  (test-zipf "neg-shu-2" 16 -0.2    2.5 1000 six-sigma)
+  (test-zipf "neg-shu-3" 16 -1.3    10  1000 six-sigma)
+  (test-zipf "neg-shu-4" 16 -2.9    100 1000 six-sigma)
+
+  ; (test-end "srfi-194-zipf")
+  )


### PR DESCRIPTION
@egallesio I have prepared SRFI 194, but there are some issues:

1. in `tests/srfis` there are two files which are included from the main test file. Is that OK?
2. This SRFI makes heavy use of closure-generating procedures. Hence, they cannot be written in C, so it's numeric code that is fully written in Scheme, *and* producing closures... So it's somewhat inefficient. I think I have before proposed something like "C closures", and the motivation was this.
3. Tests are very slow. The version here has two tests (the binomial tests, at the end of the test file) commented out, and even then, it takes more than 10x the run time of current tests.

I'm not sure how to proceed.  I have tried to optimize the SRFI and the tests, but didn't come up with very good enhancements.