### PR TITLE
Don't use K&R C

### DIFF
--- a/src/gnu-getopt.c
+++ b/src/gnu-getopt.c
@@ -272,9 +272,7 @@ static char *posixly_correct;
 // STklos: #endif
 
 static char *
-my_index (str, chr)
-     const char *str;
-     int chr;
+my_index (const char *str, int chr)
 {
   while (*str)
     {


### PR DESCRIPTION
I think I found some pre-ANSI-C artifact in STklos... :grin: 

In `gnu-getopt.c`, one function was still using old style function definition, with argument types inside the function!

In Android/termux, this fails because of stricter behavior of clang. This will likely also break in other systems too in the near future.