### PR TITLE
Do not use absolute path for `rm`

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -73,11 +73,11 @@ $(DOCDB): $(OTHERDB)
 # Documentation
 #
 clean:
-	/bin/rm -f $(ALLDB)  stklos*.1 *~
+	rm -f $(ALLDB)  stklos*.1 *~
 
 distclean: clean
-	for d in $(SUBDOCS); do (/bin/rm -f $$d/Makefile); done
-	/bin/rm -f Makefile
+	for d in $(SUBDOCS); do (rm -f $$d/Makefile); done
+	rm -f Makefile
 
 uninstall-hook:
 	rmdir $(docpdfdir) $(docimgdir) $(dochtmldir) $(doclocation) || true

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -725,11 +725,11 @@ $(DOCDB): $(OTHERDB)
 # Documentation
 #
 clean:
-	/bin/rm -f $(ALLDB)  stklos*.1 *~
+	rm -f $(ALLDB)  stklos*.1 *~
 
 distclean: clean
-	for d in $(SUBDOCS); do (/bin/rm -f $$d/Makefile); done
-	/bin/rm -f Makefile
+	for d in $(SUBDOCS); do (rm -f $$d/Makefile); done
+	rm -f Makefile
 
 uninstall-hook:
 	rmdir $(docpdfdir) $(docimgdir) $(dochtmldir) $(doclocation) || true

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -46,9 +46,9 @@ all:
 
 clean:
 	(cd C-module; make clean)
-	/bin/rm -f $(schemedemo_SCRIPTS) *~
+	rm -f $(schemedemo_SCRIPTS) *~
 
 distclean: clean
 	(cd C-module; make distclean)
-	/bin/rm -f Makefile
-	/bin/rm -rf .deps
+	rm -f Makefile
+	rm -rf .deps

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -609,12 +609,12 @@ all:
 
 clean:
 	(cd C-module; make clean)
-	/bin/rm -f $(schemedemo_SCRIPTS) *~
+	rm -f $(schemedemo_SCRIPTS) *~
 
 distclean: clean
 	(cd C-module; make distclean)
-	/bin/rm -f Makefile
-	/bin/rm -rf .deps
+	rm -f Makefile
+	rm -rf .deps
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/extensions/curl/demos/Makefile.am
+++ b/extensions/curl/demos/Makefile.am
@@ -19,8 +19,8 @@ install:
 	@echo "Demos are not installed"
 
 clean:
-	/bin/rm -f $(EXE) *~ 
+	rm -f $(EXE) *~ 
 
 distclean-am: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 

--- a/extensions/curl/demos/Makefile.in
+++ b/extensions/curl/demos/Makefile.in
@@ -487,10 +487,10 @@ install:
 	@echo "Demos are not installed"
 
 clean:
-	/bin/rm -f $(EXE) *~ 
+	rm -f $(EXE) *~ 
 
 distclean-am: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/extensions/curl/lib/stklos/Makefile.am
+++ b/extensions/curl/lib/stklos/Makefile.am
@@ -52,7 +52,7 @@ SUFFIXES = .stk -incl.c .@SH_SUFFIX@ .c
          -I$(BASEDIR)/src @GCINC@ @GMPINC@ \
          -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@ -lcurl
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 $(EXTENSION)-incl.c: $(EXTENSION).stk $(SCM_SRCS)
 

--- a/extensions/curl/lib/stklos/Makefile.in
+++ b/extensions/curl/lib/stklos/Makefile.in
@@ -580,7 +580,7 @@ STKLOS_BINARY ?= $(BASEDIR)/src/stklos
          -I$(BASEDIR)/src @GCINC@ @GMPINC@ \
          -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@ -lcurl
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 $(EXTENSION)-incl.c: $(EXTENSION).stk $(SCM_SRCS)
 

--- a/extensions/fuse/demos/Makefile.am
+++ b/extensions/fuse/demos/Makefile.am
@@ -19,9 +19,9 @@ install:
 	@echo "Demos are not installed"
 
 clean:
-	/bin/rm -f $(EXE) *~ 
+	rm -f $(EXE) *~ 
 
 distclean-am: clean
-	/bin/rm -f stklos-fuse.so
-	/bin/rm -f Makefile
+	rm -f stklos-fuse.so
+	rm -f Makefile
 

--- a/extensions/fuse/demos/Makefile.in
+++ b/extensions/fuse/demos/Makefile.in
@@ -487,11 +487,11 @@ install:
 	@echo "Demos are not installed"
 
 clean:
-	/bin/rm -f $(EXE) *~ 
+	rm -f $(EXE) *~ 
 
 distclean-am: clean
-	/bin/rm -f stklos-fuse.so
-	/bin/rm -f Makefile
+	rm -f stklos-fuse.so
+	rm -f Makefile
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/extensions/fuse/lib/stklos/Makefile.am
+++ b/extensions/fuse/lib/stklos/Makefile.am
@@ -47,7 +47,7 @@ SUFFIXES = .stk -incl.c .@SH_SUFFIX@ .c
          -I$(BASEDIR)/src @GCINC@ @GMPINC@ \
          -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@ -lfuse
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 $(EXTENSION)-incl.c: $(EXTENSION).stk $(SCM_SRCS)
 

--- a/extensions/fuse/lib/stklos/Makefile.in
+++ b/extensions/fuse/lib/stklos/Makefile.in
@@ -578,7 +578,7 @@ STKLOS_BINARY ?= $(BASEDIR)/src/stklos
          -I$(BASEDIR)/src @GCINC@ @GMPINC@ \
          -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@ -lfuse
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 $(EXTENSION)-incl.c: $(EXTENSION).stk $(SCM_SRCS)
 

--- a/extensions/gtklos/demos/Makefile.am
+++ b/extensions/gtklos/demos/Makefile.am
@@ -32,11 +32,11 @@ install:
 	@echo "Demos are not installed"
 
 clean:
-	/bin/rm -f $(EXE) *~ all-demos
+	rm -f $(EXE) *~ all-demos
 
 distclean-am:
-	/bin/rm -f stklos-gtklos.so
-	/bin/rm -f Makefile
+	rm -f stklos-gtklos.so
+	rm -f Makefile
 
 demo: all
 	./demos

--- a/extensions/gtklos/demos/Makefile.in
+++ b/extensions/gtklos/demos/Makefile.in
@@ -499,11 +499,11 @@ install:
 	@echo "Demos are not installed"
 
 clean:
-	/bin/rm -f $(EXE) *~ all-demos
+	rm -f $(EXE) *~ all-demos
 
 distclean-am:
-	/bin/rm -f stklos-gtklos.so
-	/bin/rm -f Makefile
+	rm -f stklos-gtklos.so
+	rm -f Makefile
 
 demo: all
 	./demos

--- a/extensions/gtklos/lib/stklos/Makefile.am
+++ b/extensions/gtklos/lib/stklos/Makefile.am
@@ -66,7 +66,7 @@ SUFFIXES = .stk -incl.c .@SH_SUFFIX@ .c
          -I$(BASEDIR)/src @GCINC@ @GMPINC@ \
          -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@  -o $*.@SH_SUFFIX@ $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 $(EXTENSION)-incl.c: $(EXTENSION).stk $(SCM_SRCS)
 

--- a/extensions/gtklos/lib/stklos/Makefile.in
+++ b/extensions/gtklos/lib/stklos/Makefile.in
@@ -602,7 +602,7 @@ STKLOS_BINARY ?= $(BASEDIR)/src/stklos
          -I$(BASEDIR)/src @GCINC@ @GMPINC@ \
          -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@  -o $*.@SH_SUFFIX@ $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 $(EXTENSION)-incl.c: $(EXTENSION).stk $(SCM_SRCS)
 

--- a/lib/Lalr.d/Makefile.am
+++ b/lib/Lalr.d/Makefile.am
@@ -45,6 +45,6 @@ calc: calc.stk
 	chmod a+x calc
 
 clean: 
-	/bin/rm -f *.ostk calc *~
+	rm -f *.ostk calc *~
 
 doc:

--- a/lib/Lalr.d/Makefile.in
+++ b/lib/Lalr.d/Makefile.in
@@ -573,7 +573,7 @@ calc: calc.stk
 	chmod a+x calc
 
 clean: 
-	/bin/rm -f *.ostk calc *~
+	rm -f *.ostk calc *~
 
 doc:
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -113,7 +113,7 @@ SUFFIXES = .stk .ostk .scm  -incl.c  .$(SH_SUFFIX) .c
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../src @GCINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 #======================================================================
 
@@ -152,7 +152,7 @@ generate-git-info:
 	   echo "*** Recompile STklos";                            \
 	   (cd ../src && $(MAKE) stklos);                            \
 	   echo "*** Cleaning useless images";                     \
-	   /bin/rm boot.img[0-3] instr[0-3];                       \
+	   rm boot.img[0-3] instr[0-3];                       \
 	else                                                       \
 	   echo "*** Boot file creation failed";                   \
 	   exit 1;                                                 \
@@ -207,13 +207,13 @@ $(DOCDB): $(scheme_sources)
 	$(STKLOS_BINARY) -q -c -f ../doc/extract-doc $(scheme_sources) > $(DOCDB)
 
 clean:
-	/bin/rm -f $(scheme_OBJS) $(scheme_SOLIBS) ./srfis-data.scm
+	rm -f $(scheme_OBJS) $(scheme_SOLIBS) ./srfis-data.scm
 	@for i in $(SUBDIRS) ;do \
 	   (cd $$i && $(MAKE) clean)\
 	done
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 	touch boot.stk
 	@for i in $(SUBDIRS) ;do \
 	   (cd $$i && $(MAKE) distclean)\

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -832,7 +832,7 @@ STKLOS_BINARY ?= ../src/stklos
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../src @GCINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.@SH_SUFFIX@ $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 
 #======================================================================
 
@@ -871,7 +871,7 @@ generate-git-info:
 	   echo "*** Recompile STklos";                            \
 	   (cd ../src && $(MAKE) stklos);                            \
 	   echo "*** Cleaning useless images";                     \
-	   /bin/rm boot.img[0-3] instr[0-3];                       \
+	   rm boot.img[0-3] instr[0-3];                       \
 	else                                                       \
 	   echo "*** Boot file creation failed";                   \
 	   exit 1;                                                 \
@@ -923,13 +923,13 @@ $(DOCDB): $(scheme_sources)
 	$(STKLOS_BINARY) -q -c -f ../doc/extract-doc $(scheme_sources) > $(DOCDB)
 
 clean:
-	/bin/rm -f $(scheme_OBJS) $(scheme_SOLIBS) ./srfis-data.scm
+	rm -f $(scheme_OBJS) $(scheme_SOLIBS) ./srfis-data.scm
 	@for i in $(SUBDIRS) ;do \
 	   (cd $$i && $(MAKE) clean)\
 	done
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 	touch boot.stk
 	@for i in $(SUBDIRS) ;do \
 	   (cd $$i && $(MAKE) distclean)\

--- a/lib/scheme/Makefile.am
+++ b/lib/scheme/Makefile.am
@@ -136,7 +136,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@ @LDFLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	@/bin/rm -f $*.o
+	@rm -f $*.o
 
 
 #======================================================================
@@ -242,7 +242,7 @@ clean:
 distclean: clean
 	(cd vector && $(MAKE) distclean)
 	(cd regex && $(MAKE) distclean)
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd vector && $(MAKE) uninstall)

--- a/lib/scheme/Makefile.in
+++ b/lib/scheme/Makefile.in
@@ -863,7 +863,7 @@ STKLOS_BINARY ?= ../../src/stklos
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@ @LDFLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	@/bin/rm -f $*.o
+	@rm -f $*.o
 
 #======================================================================
 # Dependencies
@@ -961,7 +961,7 @@ clean:
 distclean: clean
 	(cd vector && $(MAKE) distclean)
 	(cd regex && $(MAKE) distclean)
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd vector && $(MAKE) uninstall)

--- a/lib/scheme/vector/Makefile.am
+++ b/lib/scheme/vector/Makefile.am
@@ -111,7 +111,7 @@ f32.stk f64.stk c64.stk c128.stk: tagvector-template.stk base.$(SO)
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 			-I../../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@ @LDFLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	@/bin/rm -f $*.o
+	@rm -f $*.o
 
 #======================================================================
 # Dependencies
@@ -139,7 +139,7 @@ clean:
 	rm -f $(srfi_OBJS) *-incl.c *~
 
 distclean: clean
-	/bin/rm -f Makefile $(srfi_interm)
+	rm -f Makefile $(srfi_interm)
 
 uninstall-hook:
 	(cd $(srfidir) && rm -f $(srfi_sources) $(srfi_interm)) || true

--- a/lib/scheme/vector/Makefile.in
+++ b/lib/scheme/vector/Makefile.in
@@ -711,7 +711,7 @@ f32.stk f64.stk c64.stk c128.stk: tagvector-template.stk base.$(SO)
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 			-I../../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@ @LDFLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	@/bin/rm -f $*.o
+	@rm -f $*.o
 
 #======================================================================
 # Dependencies
@@ -738,7 +738,7 @@ clean:
 	rm -f $(srfi_OBJS) *-incl.c *~
 
 distclean: clean
-	/bin/rm -f Makefile $(srfi_interm)
+	rm -f Makefile $(srfi_interm)
 
 uninstall-hook:
 	(cd $(srfidir) && rm -f $(srfi_sources) $(srfi_interm)) || true

--- a/lib/srfi/160/Makefile.am
+++ b/lib/srfi/160/Makefile.am
@@ -147,7 +147,7 @@ clean:
 	rm -f $(srfi_OBJS) *-incl.c *~
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd $(PREFIX)$(srfidir) && rm -f $(srfi_sources) ) || true

--- a/lib/srfi/160/Makefile.in
+++ b/lib/srfi/160/Makefile.in
@@ -749,7 +749,7 @@ clean:
 	rm -f $(srfi_OBJS) *-incl.c *~
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd $(PREFIX)$(srfidir) && rm -f $(srfi_sources) ) || true

--- a/lib/srfi/Makefile.am
+++ b/lib/srfi/Makefile.am
@@ -310,7 +310,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	@/bin/rm -f $*.o
+	@rm -f $*.o
 
 #======================================================================
 # Dependencies
@@ -430,7 +430,7 @@ clean:
 	(cd 160 && $(MAKE) clean)
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 	(cd 160 && $(MAKE) distclean)
 
 uninstall-hook:

--- a/lib/srfi/Makefile.in
+++ b/lib/srfi/Makefile.in
@@ -1033,7 +1033,7 @@ STKLOS_BINARY ?= ../../src/stklos
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	@/bin/rm -f $*.o
+	@rm -f $*.o
 
 #======================================================================
 # Dependencies
@@ -1151,7 +1151,7 @@ clean:
 	(cd 160 && $(MAKE) clean)
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 	(cd 160 && $(MAKE) distclean)
 
 uninstall-hook:

--- a/lib/stklos/Makefile.am
+++ b/lib/stklos/Makefile.am
@@ -79,7 +79,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@ @LDFLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 #======================================================================
 # Dependencies
 
@@ -96,7 +96,7 @@ clean:
 	rm -f $(ALL_OBJS) *-incl.c  *~
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd $(schemedir) && rm -f $(scheme_sources)) || true

--- a/lib/stklos/Makefile.in
+++ b/lib/stklos/Makefile.in
@@ -688,7 +688,7 @@ STKLOS_BINARY ?= ../../src/stklos
 	@CC@ @CFLAGS@ @CPPFLAGS@ @STKCFLAGS@ @SH_COMP_FLAGS@ \
 		-I../../src @GCINC@ @GMPINC@ -c -o $*.o $*.c
 	@SH_LOADER@ @SH_LOAD_FLAGS@ @LDFLAGS@ -o $*.$(SO) $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 #======================================================================
 # Dependencies
 
@@ -705,7 +705,7 @@ clean:
 	rm -f $(ALL_OBJS) *-incl.c  *~
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd $(schemedir) && rm -f $(scheme_sources)) || true

--- a/lib/streams/Makefile.am
+++ b/lib/streams/Makefile.am
@@ -66,7 +66,7 @@ SUFFIXES = .stk .ostk .stk -incl.c .$(SO) .c
 		-I../../src @GCINC@ @GMPINC@ \
 	-c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@  $*.$(SO) $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 #======================================================================
 # Dependencies
 derived.ostk: primitive.ostk ../scheme/list.$(SO)
@@ -81,7 +81,7 @@ clean:
 	rm -f $(ALL_OBJS) *-incl.c  *~
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd $(schemedir) && rm -f $(scheme_sources)) || true

--- a/lib/streams/Makefile.in
+++ b/lib/streams/Makefile.in
@@ -673,7 +673,7 @@ STKLOS_BINARY ?= ../../src/stklos
 		-I../../src @GCINC@ @GMPINC@ \
 	-c -o $*.o $*.c
 	@SH_LOADER@ @LDFLAGS@ @SH_LOAD_FLAGS@  $*.$(SO) $*.o @DLLIBS@
-	/bin/rm -f $*.o
+	rm -f $*.o
 #======================================================================
 # Dependencies
 derived.ostk: primitive.ostk ../scheme/list.$(SO)
@@ -688,7 +688,7 @@ clean:
 	rm -f $(ALL_OBJS) *-incl.c  *~
 
 distclean: clean
-	/bin/rm -f Makefile
+	rm -f Makefile
 
 uninstall-hook:
 	(cd $(schemedir) && rm -f $(scheme_sources)) || true

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,10 +118,10 @@ $(DOCDB): $(stklos_SOURCES)
 	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b boot.img -f ../doc/extract-doc $(stklos_SOURCES) > $(DOCDB)
 
 clean-am:
-	/bin/rm -f *.o $(DOCDB) git-info.h boot.ok stklos
+	rm -f *.o $(DOCDB) git-info.h boot.ok stklos
 
 distclean: clean
-	/bin/rm -f boot.img Makefile extraconf.h stklos stamp-h1 stklosconf.h
+	rm -f boot.img Makefile extraconf.h stklos stamp-h1 stklosconf.h
 
 
 uninstall-hook:

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -976,10 +976,10 @@ $(DOCDB): $(stklos_SOURCES)
 	$(STKLOS_BINARY) $(STKLOS_FLAGS) -b boot.img -f ../doc/extract-doc $(stklos_SOURCES) > $(DOCDB)
 
 clean-am:
-	/bin/rm -f *.o $(DOCDB) git-info.h boot.ok stklos
+	rm -f *.o $(DOCDB) git-info.h boot.ok stklos
 
 distclean: clean
-	/bin/rm -f boot.img Makefile extraconf.h stklos stamp-h1 stklosconf.h
+	rm -f boot.img Makefile extraconf.h stklos stamp-h1 stklosconf.h
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(bindir)/stklos-@VERSION@


### PR DESCRIPTION
This is a possible fix to #885 although this PR does not change `gmp/Makefile.{in,am}`...