### PR TITLE
Fix hash of circular lists

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -120,10 +120,21 @@ static unsigned long sxhash(SCM obj)
   if (!BOXED_OBJP(obj)) return (AS_LONG(obj) >> 2);
 
   switch (BOXED_TYPE(obj)) {
-    case tc_cons:       h = sxhash(CAR(obj));
-                        for(tmp=CDR(obj); CONSP(tmp); tmp=CDR(tmp))
-                          h = HASH_WORD(h, sxhash(CAR(tmp)));
-                        h = HASH_WORD(h, sxhash(tmp));
+    case tc_cons:       int len;
+                        tmp = STk_list_type_and_length(obj, &len);
+                        /* If tmp is a cons, the list is circular! */
+                        if (CONSP(tmp)) {
+                          /* Sum len to h just to make the hash very different from
+                             the hash of the similar non-circular list: */
+                          h = sxhash(CAR(obj)) + (unsigned long) len;
+                          for(tmp=CDR(obj), i=1; i<len; tmp=CDR(tmp), i++)
+                            h = HASH_WORD(h, sxhash(CAR(tmp)));
+                        } else { /* non-circular list: */
+                          h = sxhash(CAR(obj));
+                          for(tmp=CDR(obj); CONSP(tmp); tmp=CDR(tmp))
+                            h = HASH_WORD(h, sxhash(CAR(tmp)));
+                          h = HASH_WORD(h, sxhash(tmp));
+                        }
                         return h;
     case tc_bignum:     return sxhash(STk_number2string(obj, MAKE_INT(16)));
     case tc_real:       return (unsigned long) REAL_VAL(obj);

--- a/tests/test-hash.stk
+++ b/tests/test-hash.stk
@@ -162,6 +162,20 @@
           (void)
           ret)))
 
-    
+;; hash-table-hash
+
+(test "hash int" #t (integer? (hash-table-hash 2)))
+(test "hash bignum" #t (integer? (hash-table-hash (expt 2 1000))))
+(test "hash real" #t (integer? (hash-table-hash 2.0)))
+(test "hash rational" #t (integer? (hash-table-hash 2/3)))
+(test "hash complex" #t (integer? (hash-table-hash 2-1i)))
+(test "hash nil" #t (integer? (hash-table-hash '())))
+(test "hash list" #t (integer? (hash-table-hash '(1 2))))
+(test "hash vector" #t (integer? (hash-table-hash #(1 2))))
+(test "hash lambda" #t (integer? (hash-table-hash (lambda (x) 2))))
+(let ((L (list 1 2 3 4 5)))
+  (set-cdr! (cddddr L) (cdr L))
+  (test "hash circular list" #t (integer? (hash-table-hash L))))
+
 
 (test-section-end)


### PR DESCRIPTION
This may fix #889.

We will only know if a list is circular after calling `STk_list_type_and_length`, so we do it when we get a cons to hash. If it is circular, the hash is length + the hash of the list if it were not circular. Other cases are unaffected.

Does it look OK?