### PR TITLE
Support return type checking in SRFI 253

### DIFF
--- a/lib/srfi/253.stk
+++ b/lib/srfi/253.stk
@@ -129,7 +129,13 @@
 
 ;; ----------------------------------------------------------------------
 (define-syntax %lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ((_ name (=> (returns ...) body ...) args (checks ...))
+     (lambda args
+       checks ...
+       (values-checked
+        (returns ...)
+        (begin body ...))))
     ((_ name (body ...) args (checks ...))
      (lambda args
        checks ...
@@ -159,7 +165,8 @@
 
 ;; ----------------------------------------------------------------------
 (define-syntax %case-lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ;; Terminal case, generate the actual lambda
     ((_ (clauses-so-far ...)
         ()
         args-so-far (checks-so-far ...) (body ...))
@@ -168,6 +175,15 @@
        (args-so-far
         checks-so-far ...
         body ...)))
+    ;; Empty args with returns
+    ((_ (clauses-so-far ...)
+        ((() => (returns ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
+     (%case-lambda-checked
+      (clauses-so-far ... (args-so-far checks-so-far ... body ...))
+      (clauses-to-process ...)
+      () () ((values-checked (returns ...) (begin body-to-process ...)))))
+    ;; Empty args without returns
     ((_ (clauses-so-far ...)
         ((() body-to-process ...) clauses-to-process ...)
         args-so-far (checks-so-far ...) (body ...))
@@ -175,6 +191,15 @@
       (clauses-so-far ... (args-so-far checks-so-far ... body ...))
       (clauses-to-process ...)
       () () (body-to-process ...)))
+    ;; Regular args with returns
+    ((_ (clauses-so-far ...)
+        (((arg . args-to-process) => (returns ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
+     (%case-lambda-checked
+      (clauses-so-far ... (args-so-far checks-so-far ... body ...))
+      (clauses-to-process ...)
+      () () ((values-checked (returns ...) (begin body-to-process ...))) arg . args-to-process))
+    ;; Regular args without returns
     ((_ (clauses-so-far ...)
         (((arg . args-to-process) body-to-process ...) clauses-to-process ...)
         args-so-far (checks-so-far ...) (body ...))
@@ -182,6 +207,15 @@
       (clauses-so-far ... (args-so-far checks-so-far ... body ...))
       (clauses-to-process ...)
       () () (body-to-process ...) arg . args-to-process))
+    ;; Rest arg with returns
+    ((_ (clauses-so-far ...)
+        ((arg-to-process => (returns ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
+     (%case-lambda-checked
+      (clauses-so-far ... (args-so-far checks-so-far ... body ...))
+      (clauses-to-process ...)
+      arg-to-process () ((values-checked (returns ...) (begin body-to-process ...)))))
+    ;; Rest arg without returns
     ((_ (clauses-so-far ...)
         ((arg-to-process body-to-process ...) clauses-to-process ...)
         args-so-far (checks-so-far ...) (body ...))
@@ -189,6 +223,7 @@
       (clauses-so-far ... (args-so-far checks-so-far ... body ...))
       (clauses-to-process ...)
       arg-to-process () (body-to-process ...)))
+    ;; Consume arg with predicate / check
     ((_ (clauses-so-far ...) (clauses-to-process ...)
         (args-so-far ...) (checks-so-far ...) (body ...) (arg pred) . args)
      (%case-lambda-checked
@@ -196,11 +231,13 @@
       (args-so-far ... arg)
       (checks-so-far ... (check-arg pred arg 'case-lambda-checked))
       (body ...) . args))
+    ;; Consume regular arg
     ((_ (clauses-so-far ...) (clauses-to-process ...)
         (args-so-far ...) (checks-so-far ...) (body ...) arg . args)
      (%case-lambda-checked
       (clauses-so-far ...) (clauses-to-process ...)
       (args-so-far ... arg) (checks-so-far ...) (body ...) . args))
+    ;; Consume rest arg
     ((_ (clauses-so-far ...) (clauses-to-process ...)
         (args-so-far ...) (checks-so-far ...) (body ...) . arg)
      (%case-lambda-checked
@@ -208,12 +245,22 @@
       (args-so-far ... . arg) (checks-so-far ...) (body ...)))))
 
 (define-syntax case-lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ((_ (() => (returns ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked () (rest-clauses ...) () ()
+                           ((values-checked (returns ...) (begin first-body ...)))))
     ((_ (() first-body ...) rest-clauses ...)
      (%case-lambda-checked () (rest-clauses ...) () () (first-body ...)))
+    ((_ ((first-arg . first-args) => (returns ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked () (rest-clauses ...) () ()
+                           ((values-checked (returns ...) (begin first-body ...)))
+                           first-arg . first-args))
     ((_ ((first-arg . first-args) first-body ...) rest-clauses ...)
      (%case-lambda-checked () (rest-clauses ...) () () (first-body ...)
                            first-arg . first-args))
+    ((_ (args-var => (returns ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked () (rest-clauses ...) args-var ()
+                           ((values-checked (returns ...) (begin first-body ...)))))
     ((_ (args-var first-body ...) rest-clauses ...)
      (%case-lambda-checked () (rest-clauses ...) args-var () (first-body ...)))))
 

--- a/tests/srfis/253.stk
+++ b/tests/srfis/253.stk
@@ -154,8 +154,8 @@
 (test/error "lambda-check.14" ((lambda-checked ((a integer?)) #t) "hello"))
 (test/error "lambda-check.15" ((lambda-checked (a (b integer?)) #t) "hello" "hi"))
 ;; SRFI 273 return value checks
-(test "lambda-check.16" ((lambda-checked (a (b integer?)) => (integer?) 2) 1))
-(test/error "lambda-check.17" ((lambda-checked (a (b integer?)) => (integer?) #t) 1))
+(test "lambda-check.16" ((lambda-checked ((b integer?)) => (integer?) 2) 1))
+(test/error "lambda-check.17" ((lambda-checked ((b integer?)) => (integer?) #t) 1))
 ;; Rest args. Sample implementation doesn't reliably pass this.
 ;; (test-assert (lambda-checked (a . c) #t))
 ;; (test-assert (lambda-checked ((a integer?) . c) #t))

--- a/tests/srfis/253.stk
+++ b/tests/srfis/253.stk
@@ -153,14 +153,17 @@
 
 (test/error "lambda-check.14" ((lambda-checked ((a integer?)) #t) "hello"))
 (test/error "lambda-check.15" ((lambda-checked (a (b integer?)) #t) "hello" "hi"))
+;; SRFI 273 return value checks
+(test "lambda-check.16" ((lambda-checked (a (b integer?)) => (integer?) 2) 1))
+(test/error "lambda-check.17" ((lambda-checked (a (b integer?)) => (integer?) #t) 1))
 ;; Rest args. Sample implementation doesn't reliably pass this.
 ;; (test-assert (lambda-checked (a . c) #t))
 ;; (test-assert (lambda-checked ((a integer?) . c) #t))
 ;; (test-assert (lambda-checked (a b . c) #t))
 ;; (test-assert (lambda-checked (a (b integer?) . c) #t))
 ;; Syntax checks
- (test/compile-error "lambda-check.16" (lambda-checked))
- (test/compile-error "lambda-checked.17" (lambda-checked ()))
+(test/compile-error "lambda-check.18" (lambda-checked))
+(test/compile-error "lambda-checked.19" (lambda-checked ()))
 
 ;;;
 ;;; case-lambda-checked
@@ -215,6 +218,23 @@
 (test "case-lambda-checked.13" #t (checked-case-lambda 3 "hello"))
 (test "case-lambda-checked.14" #t (checked-case-lambda "hi" "hello"))
 (test/error "case-lambda-checked.15" (checked-case-lambda 3 3 3))
+;; SRFI 273 return value checks
+(define good-return-checked-case-lambda
+  (case-lambda-checked
+   (() => (integer?) 1)
+   (((a integer?)) => (integer?) 1)
+   (args => (integer?) 1)))
+(test "case-lambda-checked.16" (good-return-checked-case-lambda 1))
+(test "case-lambda-checked.17" (good-return-checked-case-lambda))
+(test "case-lambda-checked.18" (good-return-checked-case-lambda 1 2 3))
+(define bad-return-checked-case-lambda
+  (case-lambda-checked
+   (() => (integer?) #t)
+   (((a integer?)) => (integer?) #t)
+   (args => (integer?) #t)))
+(test/error "case-lambda-checked.19" (bad-return-checked-case-lambda 1))
+(test/error "case-lambda-checked.20" (bad-return-checked-case-lambda))
+(test/error "case-lambda-checked.21" (bad-return-checked-case-lambda 1 2 3))
 
 ;;;
 ;;; define-checked 


### PR DESCRIPTION
This extension is described in [SRFI 273](https://srfi.schemers.org/srfi-273/srfi-273.html#spec--return-value), along with others (to be contributed separately.)