### PR TITLE
Shorten the assume in SRFI 253 check-arg—was redundant

### DIFF
--- a/lib/srfi/253.stk
+++ b/lib/srfi/253.stk
@@ -88,8 +88,7 @@
     ((_ pred val)
      (check-arg pred val 'check-arg))
     ((_ pred val caller)
-     (assume (pred val) "argument should match the specification"  '(pred val)
-             caller))))
+     (assume (pred val) "argument should match the specification" caller))))
 
 ;; ----------------------------------------------------------------------
 (define-syntax values-checked


### PR DESCRIPTION
Just a minor improvement—no more duplication of `assert` expression in SRFI 253.