### PR TITLE
Tell describe about parameters

### DIFF
--- a/lib/stklos/describe.stk
+++ b/lib/stklos/describe.stk
@@ -156,6 +156,11 @@ doc>
             (format port "~a ~svector of length ~s" a-an tag
                     (%uvector-length x)))))
 
+     ((parameter? x)
+      (format port "a parameter")
+      (when (%parameter-name x)
+        (format port " whose name is ~a" (%parameter-name x))))
+
      ((closure? x)
       (format port "a closure")
       ;; We don't need to show the formals, because they're already


### PR DESCRIPTION
Now parameters are properly described!

```scheme
stklos> (define x (make-parameter 1))
;; x
stklos> (describe keyword-colon-position)
#[parameter keyword-colon-position] is a parameter whose name is keyword-colon-position.
stklos> (describe x)
#[parameter 7f9ff466c720] is a parameter.
```