### PR TITLE
Support SRFI-261: Portable SRFI Library Reference

### DIFF
--- a/SUPPORTED-SRFIS
+++ b/SUPPORTED-SRFIS
@@ -148,4 +148,5 @@ implemented in latest version is available at https://stklos.net/srfi.html):
     - SRFI-253: Data (Type-)Checking
     - SRFI-258: Uninterned symbols
     - SRFI-260: Generated symbols
+    - SRFI-261: Portable SRFI Library Reference
     - SRFI-264: String Syntax for Scheme Regular Expressions

--- a/lib/srfis.stk
+++ b/lib/srfis.stk
@@ -299,7 +299,7 @@
     (258 "Uninterned symbols" () "srfi-258")
     ;; 259 Tagged procedures with type safety (draft)
     (260 "Generated symbols" () "srfi-260")
-    ;; 261 Portable SRFI Library Reference
+    (261 "Portable SRFI Library Reference" () "srfi-261")
     ;; 262 Extensible pattern matcher
     ;; 263 Prototype Object System
     (264 "String Syntax for Scheme Regular Expressions" () "srfi-264")

--- a/src/env.c
+++ b/src/env.c
@@ -28,7 +28,7 @@
 #include "hash.h"
 #include "vm.h"
 #include "thread-common.h"
-
+#include <ctype.h>
 
 /*===========================================================================* \
  *
@@ -215,6 +215,49 @@ static SCM make_export_list(SCM symbols)
 }
 
 
+static int check_srfi_261(SCM tmp) {
+  SCM first = CAR(tmp);
+  SCM second = CAR(CDR(tmp));
+
+  /* Second must be a symbol: */
+  if (!SYMBOLP(second)) return 0;
+
+  /* First must be "srfi": */
+  if(strcmp(SYMBOL_PNAME(first), "srfi")) return 0;
+
+  const char *str = SYMBOL_PNAME(second);
+  int len = strlen(str);
+
+  /* Check if 2nd symbol has name "srfi-N".
+     This is a symbol name, so we only need  to
+     check if the prefix is 'srfi-' and if everything
+     after that is digits. */
+
+  if (len < 6 ||                    // At least "srfi-N"
+      strncmp(str,"srfi-", 5) != 0) // "srfi-" prefix
+    return 0;
+
+  for (int i=5; i<len; i++)             // and all digits after that!
+    if (!isdigit(str[i]))
+      return 0;
+
+  return 1;
+}
+
+static int remove_srfi_prefix(SCM s) {
+  /* From "(srfi srfi-N)" extract N, so as to implement library
+     names as per SRFI-261.
+
+     Input: (srfi srfi-1234)
+     Output: "srfi/1234"
+     This is to comply with SRFI-261   */
+  const char *name = SYMBOL_PNAME(s);
+  int len = strlen(name) ;
+  int i = len - 1;
+  while (i >= 0 && isdigit(name[i])) i--;
+  return atoi(&name[i + 1]);
+}
+
 static SCM normalize_library_name(SCM obj) /* return a library name as a symbol */
 {
   if (SYMBOLP(obj))
@@ -222,21 +265,33 @@ static SCM normalize_library_name(SCM obj) /* return a library name as a symbol 
   else if (CONSP(obj) && STk_int_length(obj) > 0) { /* (list? obj) is true */
     SCM res = STk_open_output_string();
 
-    for (SCM tmp = obj; !NULLP(tmp); tmp = CDR(tmp)) {
-      SCM head = CAR(tmp);
+    SCM second = STk_nil;
+    if (STk_int_length(obj) == 2)  // exactly 2, we want "(srfi srfi-N)"  only!
+      second = CDR(obj);
 
-      if (SYMBOLP(head))
-        STk_print(head, res, DSP_MODE);
-      else {
-        long val = STk_integer_value(head);
+    if (CONSP(second)             &&
+        SYMBOLP(CAR(second))      &&  // second must be a symbol!
+        check_srfi_261(obj)) {
+      STk_fprintf(res, "srfi/");
+      int srfi_number = remove_srfi_prefix(CAR(CDR(obj)));
+      STk_fprintf(res, "%d", srfi_number);
+    } else {
+      for (SCM tmp = obj; !NULLP(tmp); tmp = CDR(tmp)) {
+        SCM head = CAR(tmp);
 
-        if (val >= 0)
+        if (SYMBOLP(head))
           STk_print(head, res, DSP_MODE);
-        else
-          STk_error("bad library name component ~S", head);
+        else {
+          long val = STk_integer_value(head);
+
+          if (val >= 0)
+            STk_print(head, res, DSP_MODE);
+          else
+            STk_error("bad library name component ~S", head);
+        }
+        if (!NULLP(CDR(tmp))) /* not the last component */
+          STk_putc('/', res);
       }
-      if (!NULLP(CDR(tmp))) /* not the last component */
-        STk_putc('/', res);
     }
     return STk_intern(STRING_CHARS(STk_get_output_string(res)));   // FIXME: avoid allocation
   }

--- a/tests/test-misc.stk
+++ b/tests/test-misc.stk
@@ -927,6 +927,27 @@ b|)
       '(#t #t #t)
       (list (keyword? ':a) (keyword? 'a:) (keyword? '#:a)))
 
+;;------------------------------------------------------------------
+
+(test "%normalize-library-name.1"
+      'a/b/c
+      (%normalize-library-name '(a b c)))
+
+(test "%normalize-library-name.2"
+      'a
+      (%normalize-library-name 'a))
+
+(test "%normalize-library-name.3"
+      'srfi/1
+      (%normalize-library-name '(srfi 1)))
+
+(test "%normalize-library-name.4"
+      'srfi/1
+      (%normalize-library-name '(srfi srfi-1)))
+
+(test "%normalize-library-name.5"
+      'srfi/1
+      (%normalize-library-name 'srfi/1))
 
 ;;------------------------------------------------------------------
 (test-section-end)


### PR DESCRIPTION
The SRFI is natively supported, and the modifications are:

1. `(srfi srfi-NNN)` is normalizes to `srfi/NNN` for library names
2. Some standard SRFI aliases would be added

However, I am not sure about implementation of (2).

Do we add `(%make-copy-module srfi/NAME srfi/N)` to all relevant SRFI implementations, in their `.stk` files under `lib/srfi`? I believe adding the names as aliases in `lib/srfi.stk` doesn't work.