### PR TITLE
Add an SRFI 273 check-impl? syntax to SRFI 253

### DIFF
--- a/lib/srfi/253.stk
+++ b/lib/srfi/253.stk
@@ -48,6 +48,8 @@
                  pair? number? null?
                  procedure? rational? string? symbol? keyword? vector? fixnum?
 
+                 check-impl?
+
                  <boolean> <char> <complex> <real> <pair> <number> <null>
                  <procedure> <rational> <string> <symbol> <keyword> <vector>
                  <fixnum>)
@@ -85,6 +87,8 @@
      (assume (is-a? val <vector>) "type mismatch" caller))
     ((_ fixnum? val caller)
      (assume (is-a? val <fixnum>) "type mismatch" caller))
+    ((_ (check-impl? type) val)
+     (assume (is-a? val type) "type mismatch" caller))
     ((_ pred val)
      (check-arg pred val 'check-arg))
     ((_ pred val caller)
@@ -102,7 +106,7 @@
 
 ;; ----------------------------------------------------------------------
 (define-syntax %check-case
-  (syntax-rules (else)
+  (syntax-rules (check-impl? else)
     ((_ val (clause ...) (else body ...))
      (cond
       clause ...
@@ -114,6 +118,11 @@
       (else (assume (or clause-check ...)
                     "at least one branch of check-case should be true"
                     'clause-check ...))))
+    ((_ val (clause ...) ((check-impl? type) body ...) rest ...)
+     (%check-case
+      val
+      (clause ... ((is-a? val type) body ...))
+      rest ...))
     ((_ val (clause ...) (pred body ...) rest ...)
      (%check-case
       val

--- a/tests/srfis/253.stk
+++ b/tests/srfis/253.stk
@@ -86,10 +86,17 @@
 ;; It is an error when predicate doesn't pass, but it doesn't have to
 ;; throw errors. Disable depending on implementation.
 (test/error "check-arg.35" (check-arg-true (lambda (a) (> a 3)) 0))
-
+;; check-impl? syntax from SRFI 273
+(test "check-arg.36" #t (check-arg-true (check-impl? <number>) 3.8))
+(test "check-arg.37" #t (check-arg-true (check-impl? <pair>) '(1 2 3)))
+(test "check-arg.38" #t (check-arg-true (check-impl? <string>) "hello"))
+(test "check-arg.39" #t (check-arg-true (check-impl? <symbol>) 'hello))
+(test "check-arg.40" #t (check-arg-true (check-impl? <number>) 3+2i))
+(test "check-arg.41" #t (check-arg-true (check-impl? <number>) 3))
+(test/error "check-arg.42" (check-arg-true (check-impl? <number>) "string"))
 
 ;; Syntax checks
-; [eg] following test seems OK to me => commented
+                                        ; [eg] following test seems OK to me => commented
 ;;(test/error "check-arg.36" (begin (check-arg integer? 3 'testing-caller-arg) #t))
 (test/compile-error "check-arg.37" (check-arg))
 


### PR DESCRIPTION
This auxiliary syntax, while introduced in SRFI 273, belongs to SRFI 253 APIs. Does that look alright @egallesio?