### PR TITLE
Trigs

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -1314,7 +1314,7 @@ static SCM read_integer_or_real(char *str, long base, char exact_flag, char **en
   char saved_char = '\0', *original_str = str;
   char *p, *p1, *p2, *p3, *p4;
   SCM res;
-  
+
   if ((*str == '-' || *str == '+') && isalpha(str[1])) {
     SCM n = STk_false;
     /* Treat special inf "+inf.0" -inf.0 , "+nan.0", "-nan.0"
@@ -2733,7 +2733,41 @@ DEFINE_PRIMITIVE("abs", abs, subr1, (SCM x))
     case tc_complex:  {
                         SCM r = COMPLEX_REAL(x);
                         SCM i = COMPLEX_IMAG(x);
-                        return STk_sqrt(add2(mul2(r, r), mul2(i, i)));
+                        int inexact = 0;
+                        /* Compute the sum of squares that would be
+                           inside the square root, but before
+                           answering check if it's infinite, because
+                           we could have an overflow: r and i could be
+                           large doubles, that won't fit a double
+                           after squaring and summing.
+                        */
+                        SCM x = add2(mul2(r, r), mul2(i, i));
+                        if (REALP(x) && isinf(REAL_VAL(x))) { /* got inf! */
+                            /* Now, if either r or i are real & inf,
+                               we're fine, the result should actually
+                               be infinite.
+
+                               If not, then we have an overflow, so we
+                               redo the computation changing doubles
+                               to bignums. */
+                            if (! ( (REALP(r) && isinf(REAL_VAL(r))) ||
+                                    (REALP(i) && isinf(REAL_VAL(i))))) {
+                              /* One of them could be a bignum or rational... */
+                              if (REALP(r)) {
+                                r = double2integer(REAL_VAL(r));
+                                inexact = 1;
+                              }
+                              if (REALP(i)) {
+                                i = double2integer(REAL_VAL(i));
+                                inexact = 1;
+                              }
+                              x = add2(mul2(r, r), mul2(i, i));
+                            }
+                        }
+                        x = STk_sqrt(x);
+                        if (inexact && isexactp(x))
+                          x = exact2inexact(x);
+                        return x;
                       }
     default:          error_not_a_real_number(x);
   }
@@ -3494,9 +3528,14 @@ static SCM asin_complex(SCM z)
 
 static SCM asin_real(double d)
 {
+  if (isinf(d)) {
+    int s = signbit(d) ? -1 : +1;
+    return Cmake_complex(double2real(s * (MY_PI / 2.0L)), double2real(s * minus_inf));
+  }
   if (d < -1)
     return sub2(MAKE_INT(0), asin_real(-d));
   if (d > 1)
+    /* - i  log ( d i + SQRT(1 - d^2) )  */
     return mul2(Cmake_complex(MAKE_INT(0), MAKE_INT(-1UL)),
                 my_log(add2(mul2(Cmake_complex(MAKE_INT(0), MAKE_INT(1UL)),
                                  double2real(d)),
@@ -3543,6 +3582,12 @@ static inline SCM acos_complex(SCM z)
 
 static SCM acos_real(double d)
 {
+  if (isinf(d)) {
+    if(signbit(d)) {
+      return Cmake_complex(double2real(MY_PI), double2real(minus_inf));
+    } else
+      return Cmake_complex(MAKE_INT(0), double2real(plus_inf));
+  }
   return (-1 <= d && d <= 1) ? double2real(acos(d)) : acos_complex(double2real(d));
 }
 

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -2131,6 +2131,35 @@
 
 
 ;; sin, asin; cos, acos
+(test "asin +inf"
+      #t
+      (let ((x (asin +inf.0)))
+        (and (< 1.57079632670 (real-part x) 1.57079632680)
+             (negative? (imag-part x))
+             (infinite? (imag-part x)))))
+
+(test "asin -inf"
+      #t
+      (let ((x (asin -inf.0)))
+        (and (> -1.57079632670 (real-part x) -1.57079632680)
+             (positive? (imag-part x))
+             (infinite? (imag-part x)))))
+
+
+(test "acos +inf"
+      #t
+      (let ((x (acos +inf.0)))
+        (and (zero? (real-part x))
+             (positive? (imag-part x))
+             (infinite? (imag-part x)))))
+
+(test "acos -inf"
+      #t
+      (let ((x (acos -inf.0)))
+        (and (< 3.1415926535 (real-part x) 3.1415926536)
+             (negative? (imag-part x))
+             (infinite? (imag-part x)))))
+
 (test "sin-asin 1"
       1.0
       (sin (asin 1)))


### PR DESCRIPTION
```scheme
Before: (abs 0+1e300i) => +inf.0
Now:    (abs 0+1e300i) => 1e+300
```

(`abs` for complexes would first do $x^2+y^2$ then extract `sqrt`, which would overflow. Now we check if  the sum of squares is infinite first.)

Side effects:

```scheme
Before: (asin  (expt 2 511)) => +nan.0-inf.0i
Now:    (asin  (expt 2 511)) => 1.5707963267949-354.891356446692i
```

(The second is correct)

Also, one more change in this patch:

```scheme
Before: (asin +inf.0) => +nan.0+nan.0i
Now:    (asin +inf.0) => 1.5707963267949-inf.0i

Before: (acos +inf.0) => +nan.0+inf.0i
Now:    (acos +inf.0) => 0+inf.0i

Before: (acos -inf.0) => +nan.0+nan.0i
Now:    (acos -inf.0) => 3.14159265358979-inf.0i
```

There are still some imprecisions with the trig functions, but that's already some good improvement, I guess...