### PR TITLE
Fix SRFI 253 lambda-checked to check returns even in simple cases

### DIFF
--- a/lib/srfi/253.stk
+++ b/lib/srfi/253.stk
@@ -153,11 +153,21 @@
       (args ... . last) (checks ...)))))
 
 (define-syntax lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ;; Empty args with return type checking
+    ((_ () => (returns ...) body ...)
+     (lambda ()
+       (values-checked (returns ...) (begin body ...))))
+    ;; No need to parse as there are no args
     ((_ () body ...)
      (lambda () body ...))
+    ;; Regular (positional ... [. rest]) arglist
     ((_ (arg . args) body ...)
      (%lambda-checked lambda-checked (body ...) () () arg . args))
+    ;; arg->list lambda, but with return checking
+    ((_ arg => (returns ...) body ...)
+     (lambda arg
+       (values-checked (returns ...) (begin body ...))))
     ;; Case of arg->list lambda, no-op.
     ((_ arg body ...)
      (lambda arg body ...))))


### PR DESCRIPTION
Where the mere lambda was generated previously