### PR TITLE
Make SRFI 273’ define-values-checked stricter

### DIFF
--- a/lib/srfi/273.stk
+++ b/lib/srfi/273.stk
@@ -42,9 +42,9 @@
   (define-syntax define-values-checked
     (syntax-rules ()
       ((_ (var ...) (check ...) form)
-       (begin
-         (define-values (var ...) form)
-         (assume (check var)) ...))))
+       (define-values (var ...)
+         (let-values (((var ...) form))
+           (values-checked (check ...) var ...))))))
   (define-syntax declare-checked
     (syntax-rules ()
       ((_ name predicate)


### PR DESCRIPTION
Sorry, noticed this bug only now. Thus a follow up :sweat_smile: 