### PR TITLE
Print procedure / closure with arity whenever possible

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -75,6 +75,20 @@ static void print_lambda(SCM closure, SCM port, int mode)
   if (formals != STk_false) {
     STk_nputs(port, " ", 1);
     STk_print(formals, port, mode);
+  } else {
+    switch (CLOSURE_ARITY(closure)) {
+      case 0:  STk_fprintf(port, ""); break;
+      case 1:  STk_fprintf(port, " _"); break;
+      case 2:  STk_fprintf(port, " _ _"); break;
+      case 3:  STk_fprintf(port, " _ _ _"); break;
+      case 4:  STk_fprintf(port, " _ _ _ _"); break;
+      case 5:  STk_fprintf(port, " _ _ _ _ _"); break;
+      case -1: STk_fprintf(port, " . _"); break;
+      case -2: STk_fprintf(port, " _ . _"); break;
+      case -3: STk_fprintf(port, " _ _ . _"); break;
+      case -4: STk_fprintf(port, " _ _ _ . _"); break;
+      default: break;
+    }
   }
   STk_nputs(port,"]", 1);
 }

--- a/src/proc.c
+++ b/src/proc.c
@@ -77,16 +77,16 @@ static void print_lambda(SCM closure, SCM port, int mode)
     STk_print(formals, port, mode);
   } else {
     switch (CLOSURE_ARITY(closure)) {
-      case 0:  STk_fprintf(port, ""); break;
-      case 1:  STk_fprintf(port, " _"); break;
-      case 2:  STk_fprintf(port, " _ _"); break;
-      case 3:  STk_fprintf(port, " _ _ _"); break;
-      case 4:  STk_fprintf(port, " _ _ _ _"); break;
-      case 5:  STk_fprintf(port, " _ _ _ _ _"); break;
-      case -1: STk_fprintf(port, " . _"); break;
-      case -2: STk_fprintf(port, " _ . _"); break;
-      case -3: STk_fprintf(port, " _ _ . _"); break;
-      case -4: STk_fprintf(port, " _ _ _ . _"); break;
+      case 0:  STk_fprintf(port, " ()"); break;
+      case 1:  STk_fprintf(port, " (_)"); break;
+      case 2:  STk_fprintf(port, " (_ _)"); break;
+      case 3:  STk_fprintf(port, " (_ _ _)"); break;
+      case 4:  STk_fprintf(port, " (_ _ _ _)"); break;
+      case 5:  STk_fprintf(port, " (_ _ _ _ _)"); break;
+      case -1: STk_fprintf(port, " _"); break;
+      case -2: STk_fprintf(port, " (_ . _)"); break;
+      case -3: STk_fprintf(port, " (_ _ . _)"); break;
+      case -4: STk_fprintf(port, " (_ _ _ . _)"); break;
       default: break;
     }
   }


### PR DESCRIPTION
This small change improves REPL experience somewhat, helping people to remember the shape of procedure arguments even when named formals are not available. I personally missed it direly, coming from Chibi and Chicken.

There should be no trade-offs as it’s essentially constant string printing based on an integer constant dispatching.

@egallesio how does it look?