### PR TITLE
Fix (expt negative rational)

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -4397,7 +4397,9 @@ static SCM my_expt(SCM x, SCM y)
         if (INT_VAL(x) == 0) return MAKE_INT(0);        //  0
         if (INT_VAL(x) == 1) return MAKE_INT(1);        // +1
       }
-      if (INTP(x) || BIGNUMP(x)) {
+      /* If x < 0 then we go into the complex world, and this code
+         won't help, so we skip to the tc_real case */
+      if (!negativep(x) && (INTP(x) || BIGNUMP(x))) {
         /* y = m/n */
         SCM m = RATIONAL_NUM(y);
         SCM n = RATIONAL_DEN(y);

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -1549,6 +1549,15 @@
       (expt +inf.0 (expt 2 100)))
 
 
+;
+
+(test "+1 to a fraction -> 1" 1 (expt  1 2/3))
+(test "-1 to a fraction -> complex result, NOT equal to (((-1)^2)^1/3)"
+      #t
+      (let ((x (expt -1 2/3)))
+        (< -0.5001 (real-part x) -0.4999)
+        (< +0.8660 (imag-part x) +0.8661)))
+
 ;;------------------------------------------------------------------
 (test-subsection "sqrt")
 


### PR DESCRIPTION
The result will be complex.

Before: `(expt -1 2/3) => 1`
Now:    `(expt -1 2/3) => -0.5+0.866025403784439i`