### PR TITLE
Preserve complex exactness when mixing reals and exact complexes.

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -2627,7 +2627,18 @@ SCM STk_div2(SCM o1, SCM o2)
           return make_complex(div2(add2(mul2(r1, r2), mul2(i1, i2)), tmp),
                               div2(sub2(mul2(i1, r2), mul2(r1, i2)), tmp));
         }
-        case tc_real:     // fallthrough
+            /* Below: when we do (/ +6i 2.0)  we should get +3.0i.
+                      However, if we fall through and use mul2(r1,o2)
+                      we will have real part "0 / 2.0" which does
+                      NOT result in 0, but in 0.0 (inexactness contaminates).
+                      But in this case it makes no sense. Schemes do vary
+                      with respect to this, but since STklos uses mixed
+                      exactness in complexes, it makes sense to return
+                      +3.0i. So we test for r1 == 0. */
+        case tc_real:     if (r1 == MAKE_INT(0))
+                            return make_complex(MAKE_INT(0),
+                                                div2(i1, o2));
+                          // fallthrough
         case tc_rational: // fallthrough
         case tc_bignum:   // fallthrough
         case tc_integer: return make_complex(div2(r1, o2),
@@ -2697,8 +2708,19 @@ SCM STk_div2(SCM o1, SCM o2)
  div_x_by_a_complex: {
   SCM a   = COMPLEX_REAL(o2);
   SCM b   = COMPLEX_IMAG(o2);
+              /* Below: when we do (/ 6.0 +2i)  we should get +3.0i.
+                      However, if we fall through and use mul2(r1,o2)
+                      we will have real part "0 / 2.0" which does
+                      NOT result in 0, but in 0.0 (inexactness contaminates).
+                      But in this case it makes no sense. Schemes do vary
+                      with respect to this, but since STklos uses mixed
+                      exactness in complexes, it makes sense to return
+                      +3.0i. So we test for a == 0. */
   SCM tmp = add2(mul2(a, a), mul2(b, b));
 
+  if (a == MAKE_INT(0))
+    return make_complex(MAKE_INT(0),
+                        sub2(MAKE_INT(0), div2(mul2(b, o1), tmp)));
   return make_complex(div2(mul2(a, o1), tmp),
                       sub2(MAKE_INT(0), div2(mul2(b, o1), tmp)));
   }

--- a/src/number.c
+++ b/src/number.c
@@ -2284,7 +2284,17 @@ SCM STk_mul2(SCM o1, SCM o2)
                             return make_complex(sub2(mul2(r1,r2), mul2(i1, i2)),
                                               add2(mul2(r1,i2), mul2(r2, i1)));
                           }
-        case tc_real:     // fallthrough
+            /* Below: when we do (* +3i 2.0)  we should get +6.0i.
+                      However, if we fall through and use mul2(r1,o2)
+                      we will have real part "0 times 2.0" which does
+                      NOT result in 0, but in 0.0 (inexactness contaminates).
+                      But in this case it makes no sense. Schemes do vary
+                      with respect to this, but since STklos uses mixed
+                      exactness in complexes, it makes sense to return
+                      +6.0i. So we test for r1 == 0. */
+        case tc_real:     if (r1 == MAKE_INT(0))
+                            return make_complex(MAKE_INT(0), mul2(i1, o2));
+                          // fallthrough
         case tc_rational: // fallthrough
         case tc_bignum:   // fallthrough
         case tc_integer:  return make_complex(mul2(r1, o2), mul2(i1, o2));
@@ -2394,8 +2404,19 @@ SCM STk_mul2(SCM o1, SCM o2)
   error_cannot_operate("multiplication", o1, o2);
 
  mult_x_and_complex:    // x here can be a real, a rational, a bignum or a fixnum
+  /* Below: when we do (* 2.0 +3i)  we should get +6.0i.
+            However, if we fall through and use mul2(r1,o2)
+            we will have real part "0 times 2.0" which does
+            NOT result in 0, but in 0.0 (inexactness contaminates).
+            But in this case it makes no sense. Schemes do vary
+            with respect to this, but since STklos uses mixed
+            exactness in complexes, it makes sense to return
+            +6.0i. So we test for real part == 0. */
+  if (COMPLEX_REAL(o2) == MAKE_INT(0))
+      return make_complex(MAKE_INT(0),
+                          mul2(o1,COMPLEX_IMAG(o2)));
   return make_complex(mul2(o1,COMPLEX_REAL(o2)),
-                       mul2(o1,COMPLEX_IMAG(o2)));
+                      mul2(o1,COMPLEX_IMAG(o2)));
 }
 
 DEFINE_PRIMITIVE("*", multiplication, vsubr, (int argc, SCM *argv))

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -2446,6 +2446,13 @@
       0+6.0i
       (* 2.0 +3i))
 
+(test "real / complex, exact 0 imag-part"
+      0-2.0i
+      (/ 6.0 +3i))
+(test "complex / real, exact 0 imag-part"
+      0+2.0i
+      (/ +6i +3.0))
+
 (test "cosh +inf"
       #t
       (and (infinite? (cosh +inf.0))

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -470,8 +470,8 @@
 (test-subsection "complex writer syntax")
 
 (test "complex printing"
-      '("+inf.0+inf.0i" "+nan.0+inf.0i" "+inf.0+inf.0i"
-       "-inf.0-inf.0i"  "+nan.0+nan.0i" "+nan.0+nan.0i"
+      '("+inf.0+inf.0i" "0+inf.0i" "+inf.0+inf.0i"
+       "-inf.0-inf.0i"  "0+nan.0i" "0+nan.0i"
        "1+1i"           "0+1i"          "1+0.0i"
        "1-0.0i"         "1+1/2i"        "2-1/3i")
       (map number->string
@@ -2442,6 +2442,9 @@
       +inf.0+3/2i
       (* 1/2 +inf.0+3i))
 
+(test "complex times real, exact 0 imag-part"
+      0+6.0i
+      (* 2.0 +3i))
 
 (test "cosh +inf"
       #t


### PR DESCRIPTION
When we do `(* +3i 2.0)` we should get `+6.0i` because STklos has mixed exactness for complexes.

 However, the current code does `mul2(r1,o2)` and  we will have real part "0 times 2.0" which  does NOT result in 0, but in 0.0 (inexactness contaminates).  But in  this case it makes no sense. Since STklos uses mixed exactness in complexes, it makes sense to return `+6.0i`. So we test for `real part == 0`, and when it is, we just use plain `MAKE_INT(0)` when calling `make_compelx`. 

The same for division.

Almost all Scheme implementations seem to do this: when mixed exactness is supported, then the above results in `+6.0i`. The same is true for Common Lisp:


| system      | mixed complexes?  | (* 2.0 +3i) | note                  |
|-------------|------------------|-------------|-----------------------|
| bigloo      | no complexes     |             |                       |
| chez        | N                | 0.0+6.0i    |                       |
| chibi       | Y                | 0+6.0i      |                       |
| chicken     | N                | 0.0+6.0i    |                       |
| cyclone     | N (inexact only) | 6.0i        | 0.0+2i == +2i         |
| gambit      | Y                | +6.i        |                       |
| gauche      | N                | 0.0+6.0i    |                       |
| guile       | N                | 0.0+6.0i    |                       |
| kawa        | Y                | +6.0i       |                       |
| loko        | N                | 0.0+6.i     |                       |
| mit         | Y                | +6.i        |                       |
| sagittarius | N                | 0.0+6.0i    |                       |
| wile        | N                | 0.0+6.0i    |                       |
| ypsilon     | N                | 0+6.0i      | not sure what happens |
|-------------|------------------|-------------|-----------------------|
| ABCL        | N                | #C(0.0 6.0) |                       |
| Clisp       | Y                | #C(0 6.0)   |                       |
| ECL         | N                | #C(0.0 6.0) |                       |
| GCL         | N                | #C(0.0 6.0) |                       |
| SBCL        | N                | #C(0.0 6.0) |                       |
