### PR TITLE
Treat exact zeros in make-polar

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -4614,12 +4614,12 @@ DEFINE_PRIMITIVE("make-rectangular", make_rectangular, subr2, (SCM r, SCM i))
 }
 
 
-DEFINE_PRIMITIVE("make-polar", make_polar, subr2, (SCM a, SCM m))
+DEFINE_PRIMITIVE("make-polar", make_polar, subr2, (SCM m, SCM a))
 {
-  if (STk_realp(a) == STk_false) error_not_a_real_number(a);
   if (STk_realp(m) == STk_false) error_not_a_real_number(m);
+  if (STk_realp(a) == STk_false) error_not_a_real_number(a);
 
-  return make_polar(a, m);
+  return make_polar(m, a);
 }
 
 

--- a/src/number.c
+++ b/src/number.c
@@ -401,9 +401,11 @@ static inline SCM make_complex(SCM r, SCM i)
   return (isexactp(i) && zerop(i)) ? r : Cmake_complex(r, i);
 }
 
-static inline SCM make_polar(SCM a, SCM m)
+static inline SCM make_polar(SCM m, SCM a)
 {
-  return make_complex(mul2(a, my_cos(m)), mul2(a, my_sin(m)));
+  if (m == MAKE_INT(0)) return MAKE_INT(0);
+  if (a == MAKE_INT(0)) return m;
+  return make_complex(mul2(m, my_cos(a)), mul2(m, my_sin(a)));
 }
 
 

--- a/tests/test-number.stk
+++ b/tests/test-number.stk
@@ -2382,6 +2382,30 @@
 ;;------------------------------------------------------------------
 (test-subsection "Complexes")
 
+(test "make-polar zero magnitude.1"
+      0
+      (make-polar 0 1.2))
+
+(test "make-polar zero magnitude.2"
+      0
+      (make-polar 0 +inf.0))
+
+(test "make-polar zero magnitude.3"
+      0
+      (make-polar 0 +nan.0))
+
+(test "make-polar zero angle.1"
+      2/3
+      (make-polar 2/3 0))
+
+(test "make-polar zero angle.2"
+      +inf.0
+      (make-polar +inf.0 0))
+
+(test "make-polar zero angle.3"
+      +nan.0
+      (make-polar +nan.0 0))
+
 (test "complex sum"
       7+3i
       (+ 2-3i 5+6i))


### PR DESCRIPTION
```scheme
(make-polar 0 x) => 0
(make-polar x 0) => x
```

(Exact zero magnitude means exact zero; exact zero  angle means exact zero imaginary part)
```
stklos> make-polar 
#[primitive (make-polar a m)]
```
Oops. The first argument is magnitude, and the second is the angle!