### PR TITLE
Name cut-generated procedures with %cut% and %cute%

### DIFF
--- a/lib/srfi/26.stk
+++ b/lib/srfi/26.stk
@@ -40,11 +40,13 @@
                  (fct  (car tmp))
                  (body (cdr tmp)))
             `(lambda ,(reverse slot-names)
+               :%cut
                ((begin ,fct) ,@body))))
       ((eq? (car lst) '<...>)
           (let* ((rest (gensym))
                  (body (reverse pos)))
             `(lambda (,@(reverse slot-names) . ,rest)
+               :%cut+
                (apply ,@body ,rest))))
       ((eq? (car lst) '<>)
           (let ((x (gensym)))
@@ -72,12 +74,14 @@
           (let* ((body (reverse pos)))
             `(let ,(reverse bindings)
                (lambda ,(reverse slot-names)
+                 :%cute
                  ,body))))
       ((eq? (car lst) '<...>)
           (let* ((rest (gensym))
                  (body (reverse pos)))
             `(let ,(reverse bindings)
                  (lambda (,@(reverse slot-names) . ,rest)
+                   :%cute+
                    (apply ,@body ,rest)))))
       ((eq? (car lst) '<>)
           (let ((x (gensym)))


### PR DESCRIPTION
This is useful in debugging. Throwaway lambdas made with cut/cute might be erroneous, and being able to see at a glance that they are cut-generated might narrow the bug search area tremendously.