### PR TITLE
case-lambda: Parse args smarter to enable more useful arity inspection

### DIFF
--- a/lib/bonus.stk
+++ b/lib/bonus.stk
@@ -2352,17 +2352,34 @@ doc>
 doc>
 |#
 (define-macro (case-lambda . clauses)
-  (let ((len           (gensym))
-        (args          (gensym))
-        (len-prim      (gensym 'length))
-        (apply-prim    (gensym 'apply))
-        (err-prim      (gensym 'error))
-        (compute-arity (in-module STKLOS-COMPILER compute-arity)))
+  (let* ((len           (gensym))
+         (args          (gensym "args"))
+         (clause-args   (map car clauses))
+         (longest-common-args (if (let lp ((args clause-args))
+                                    (if (null? args)
+                                        #t
+                                        (and (list? (car args))
+                                             (lp (cdr args)))))
+                                  (let lp ((args clause-args))
+                                    (if (member '() args)
+                                        '()
+                                        (cons (caar args)
+                                              (lp (map cdr args)))))
+                                  '()))
+         (arglist (if (null? longest-common-args)
+                      args
+                      `(,@longest-common-args . ,args)))
+         (len-prim      (gensym 'length))
+         (apply-prim    (gensym 'apply))
+         (err-prim      (gensym 'error))
+         (compute-arity (in-module STKLOS-COMPILER compute-arity)))
     `(#%let ((,len-prim   (in-module SCHEME length))
              (,apply-prim (in-module SCHEME apply))
              (,err-prim   (in-module SCHEME error)))
-       (lambda ,args
-         (let ((,len (,len-prim ,args)))
+       (lambda ,arglist
+         (let ((,len (,len-prim ,(if (null? longest-common-args)
+                                     args
+                                     `(apply list ,@longest-common-args ,args)))))
            (#%cond
             ,@(map (lambda (x)
                      (unless (>= (length x) 2)
@@ -2373,16 +2390,16 @@ doc>
                        (cond
                         ((positive? arity)
                          `((= ,len ,arity)
-                           (,apply-prim (#%lambda ,formals ,@body) ,args)))
+                           (,apply-prim (#%lambda ,formals ,@body) ,@longest-common-args ,args)))
                         ((zero? arity)
                          `((= ,len ,arity)
                            ,@body))
                         (else
                          `((>= ,len ,(- (- arity) 1))
-                           (,apply-prim (#%lambda ,formals ,@body) ,args))))))
+                           (,apply-prim (#%lambda ,formals ,@body) ,@longest-common-args ,args))))))
                    clauses)
             (else (,err-prim "no matching clause in case-lambda with ~S for ~S"
-                             ',(map car clauses) ,args))))))))
+                             ',(map car clauses) (apply list ,@longest-common-args ,args)))))))))
 
 
 ;;;


### PR DESCRIPTION
This makes `case-lambda` to generate more inspectable and useful arglists, in the traces of [similar Chibi pull request](https://github.com/ashinn/chibi-scheme/pull/1189), for example:

``` scheme
(case-lambda ((a b c) 1) ((a b) 1))
;; #[closure 7efcf8226f80 (a b . args13)]
```

@egallesio how does it look?